### PR TITLE
Create output parent directory if not exists

### DIFF
--- a/client/config/dfget.go
+++ b/client/config/dfget.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
+	logger "d7y.io/dragonfly/v2/pkg/dflog"
 	"github.com/pkg/errors"
 
 	"d7y.io/dragonfly/v2/pkg/basic"
@@ -151,6 +153,11 @@ func (cfg *ClientOption) checkOutput() error {
 		cfg.Output = absPath
 	}
 
+	dir, _ := path.Split(cfg.Output)
+	if err := MkdirAll(dir, 0777, basic.UserId, basic.UserGroup); err != nil {
+		return err
+	}
+
 	if f, err := os.Stat(cfg.Output); err == nil && f.IsDir() {
 		return fmt.Errorf("path[%s] is directory but requires file path", cfg.Output)
 	}
@@ -162,6 +169,31 @@ func (cfg *ClientOption) checkOutput() error {
 		} else if os.IsPermission(err) || dir == "/" {
 			return fmt.Errorf("user[%s] path[%s] %v", basic.Username, cfg.Output, err)
 		}
+	}
+	return nil
+}
+
+// MkdirAll make directories recursive, and change uid, gid to latest directory.
+// For example: the path /data/x exists, uid=1, gid=1
+// when call MkdirAll("/data/x/y/z", 0755, 2, 2)
+// MkdirAll creates /data/x/y and change owner to 2:2, creates /data/x/y/z and change owner to 2:2
+func MkdirAll(dir string, perm os.FileMode, uid, gid int) error {
+	if _, err := os.Stat(strings.TrimRight(dir, "/")); os.IsNotExist(err) {
+		parent, _ := path.Split(dir)
+		err = MkdirAll(strings.TrimRight(parent, "/"), perm, uid, gid)
+		if err != nil && !os.IsExist(err) {
+			logger.Errorf("mkdirall error: %s", err)
+			return err
+		}
+		err = os.Mkdir(dir, perm)
+		if err != nil && !os.IsExist(err) {
+			logger.Errorf("mkdirall error: %s", err)
+			return err
+		}
+		return os.Chown(dir, uid, gid)
+	} else if err != nil {
+		logger.Errorf("mkdirall error: %s", err)
+		return err
 	}
 	return nil
 }

--- a/client/daemon/service/manager.go
+++ b/client/daemon/service/manager.go
@@ -192,6 +192,7 @@ func (m *manager) Download(ctx context.Context,
 				p.DoneCallback()
 				logger.Infof("task %s done", p.TaskId)
 				if req.Uid != 0 && req.Gid != 0 {
+					logger.Infof("change own to uid %d gid %d", req.Uid, req.Gid)
 					if err = os.Chown(req.Output, int(req.Uid), int(req.Gid)); err != nil {
 						logger.Errorf("change own failed: %s", err)
 						return err

--- a/cmd/dfget/cmd/root.go
+++ b/cmd/dfget/cmd/root.go
@@ -387,6 +387,12 @@ func downloadFromSource(hdr map[string]string, dferr error) (err error) {
 		logger.Infof("copied %d bytes to %s", written, dfgetConfig.Output)
 		end = time.Now()
 		fmt.Printf("Download from source success, time cost: %dms\n", end.Sub(start).Milliseconds())
+		// change permission
+		logger.Infof("change own to uid %d gid %d", basic.UserId, basic.UserGroup)
+		if err = os.Chown(dfgetConfig.Output, basic.UserId, basic.UserGroup); err != nil {
+			logger.Errorf("change own failed: %s", err)
+			return err
+		}
 		return nil
 	}
 	logger.Errorf("copied %d bytes to %s, with error: %s",


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

When output parent directory is not exist, dfget should create the directory.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#187 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
