### PR TITLE
Fix: when load config from cdn directory in dynconfig, skip sub directories

### DIFF
--- a/internal/dynconfig/dynconfig.go
+++ b/internal/dynconfig/dynconfig.go
@@ -101,7 +101,7 @@ func WithExpireTime(e time.Duration) Option {
 	}
 }
 
-// NewDynconfig returns a new dynconfig instence
+// New returns a new dynconfig instance
 func New(sourceType SourceType, options ...Option) (*Dynconfig, error) {
 	d, err := NewDynconfigWithOptions(sourceType, options...)
 	if err != nil {
@@ -176,7 +176,7 @@ func (d *Dynconfig) Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) e
 // mapstructure.DecoderConfig options
 type DecoderConfigOption func(*mapstructure.DecoderConfig)
 
-// defaultDecoderConfig returns default mapsstructure.DecoderConfig with suppot
+// defaultDecoderConfig returns default mapstructure.DecoderConfig with support
 // of time.Duration values & string slices
 func defaultDecoderConfig(output interface{}, opts ...DecoderConfigOption) *mapstructure.DecoderConfig {
 	c := &mapstructure.DecoderConfig{


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

When there is some directories in `cdnDir`, `ioutil.ReadFile(filepath.Join(d.cdnDirPath, file.Name()))` will always fail.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
