### PR TITLE
fix: check health too long when dfdaemon is unavailable

### DIFF
--- a/client/dfget/dfget.go
+++ b/client/dfget/dfget.go
@@ -126,24 +126,15 @@ func downloadFromSource(cfg *config.DfgetConfig, hdr map[string]string) (err err
 		logger.Warnf("%s", err)
 		return err
 	}
-
-	var (
-		start = time.Now()
-		end   time.Time
-	)
-
 	fmt.Println("dfget download error, try to download from source")
+
 	var (
+		start    = time.Now()
+		end      time.Time
 		target   *os.File
 		response io.ReadCloser
-		_        map[string]string
 		written  int64
 	)
-
-	if err != nil {
-		logger.Errorf("init source client error: %s", err)
-		return err
-	}
 
 	response, err = source.Download(context.Background(), cfg.URL, hdr)
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
1. Use for loop with buffered channel and time.After to control timeout
2. refactor some redundant log and variable

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/Dragonfly2/issues/343
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
1. When dfdaemon is unavailable, dfget will stuck in health checking for a long time. This will slow downloading task. 
## Screenshots (if appropriate):
Now timeout works.
![image](https://user-images.githubusercontent.com/17826874/122155435-8f094680-ce99-11eb-818f-aab6108fa040.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
