### PR TITLE
Correct CDN UUID in scheduler

### DIFF
--- a/scheduler/manager/cdn_manager.go
+++ b/scheduler/manager/cdn_manager.go
@@ -316,7 +316,7 @@ func (cm *CDNManager) processPieceSeed(task *types.Task, ps *cdnsystem.PieceSeed
 }
 
 func (cm *CDNManager) getHostUUID(ps *cdnsystem.PieceSeed) string {
-	return fmt.Sprintf("cdn:%s", ps.PeerId)
+	return fmt.Sprintf("cdn:%s", ps.SeederName)
 }
 
 func (cm *CDNManager) createPiece(task *types.Task, ps *cdnsystem.PieceSeed, pt *types.PeerTask) *types.Piece {


### PR DESCRIPTION
Signed-off-by: santong <weipeng.swp@alibaba-inc.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to the incorrect identification of the CDN by Schuler, the same CDN corresponds to multiple hosts in the scheduler

<!--- Describe your changes in detail -->

## Related Issue
fix #354 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
