### PR TITLE
fix: use string slice for header

### DIFF
--- a/cmd/dfget/cmd/root.go
+++ b/cmd/dfget/cmd/root.go
@@ -140,7 +140,7 @@ func init() {
 		"Filter the query parameters of the url, P2P overlay is the same one if the filtered url is same, "+
 			"in format of key&sign, which will filter 'key' and 'sign' query parameters")
 
-	flagSet.StringArrayP("header", "H", dfgetConfig.Header, "url header, eg: --header='Accept: *' --header='Host: abc'")
+	flagSet.StringSliceP("header", "H", dfgetConfig.Header, "url header, eg: --header='Accept: *' --header='Host: abc'")
 
 	flagSet.Bool("disable-back-source", dfgetConfig.DisableBackSource,
 		"Disable downloading directly from source when the daemon fails to download file")


### PR DESCRIPTION
When I added two or more headers in dfget, it will meet error like `net/http: invalid header field name "[Accept"` with an unexpected "[", I find that it is because of viper.
We can notice that the type StringArray is treat as String(default) in the following codes in viper, and the ValueString method of StringArray will add the "[" and "]".
<img width="496" alt="截屏2021-09-03 下午4 06 13" src="https://user-images.githubusercontent.com/67889264/131972431-b8b05848-cf65-464d-8944-f37cb3376ffa.png">
So I suppose that we should use StringSlice instead of StringArray.

