### PR TITLE
new 3 schedulers -- dynamic/exchangeMax/exchangeMin

### DIFF
--- a/scheduler/core/evaluator/dynamic/dynamic_evaluator.go
+++ b/scheduler/core/evaluator/dynamic/dynamic_evaluator.go
@@ -1,0 +1,154 @@
+/*
+ *     Copyright 2020 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynamic
+
+import (
+	logger "d7y.io/dragonfly/v2/internal/dflog"
+	"d7y.io/dragonfly/v2/scheduler/config"
+	"d7y.io/dragonfly/v2/scheduler/core/evaluator"
+	"d7y.io/dragonfly/v2/scheduler/supervisor"
+)
+
+type dynamicEvaluator struct {
+	cfg *config.SchedulerConfig
+}
+
+var args map[string]float64
+
+func init() {
+	args = make(map[string]float64)
+	args["load"] = 0.5
+	args["dist"] = 0.5
+}
+
+func NewEvaluator(cfg *config.SchedulerConfig) evaluator.Evaluator {
+	eval := &dynamicEvaluator{cfg: cfg}
+	logger.Debugf("create dynamic evaluator successfully")
+	return eval
+}
+
+func (eval *dynamicEvaluator) NeedAdjustParent(peer *supervisor.Peer) bool {
+	if peer.Host.CDN {
+		return false
+	}
+
+	if peer.GetParent() == nil && !peer.IsDone() {
+		logger.Debugf("peer %s need adjust parent because it has not parent and status is %s", peer.PeerID, peer.GetStatus())
+		return true
+	}
+	// TODO Check whether the parent node is in the blacklist
+	if peer.GetParent() != nil && eval.IsBadNode(peer.GetParent()) {
+		logger.Debugf("peer %s need adjust parent because it current parent is bad", peer.PeerID)
+		return true
+	}
+
+	if peer.GetParent() != nil && peer.GetParent().IsLeave() {
+		logger.Debugf("peer %s need adjust parent because it current parent is status is leave", peer.PeerID)
+		return true
+	}
+
+	costHistory := peer.GetCostHistory()
+	if len(costHistory) < 4 {
+		return false
+	}
+
+	avgCost, lastCost := getAvgAndLastCost(costHistory, 4)
+	// TODO adjust policy
+	if (avgCost * 20) < lastCost {
+		logger.Debugf("peer %s need adjust parent because it latest download cost is too time consuming", peer.PeerID)
+		return true
+	}
+	return false
+}
+
+func (eval *dynamicEvaluator) IsBadNode(peer *supervisor.Peer) bool {
+	if peer.IsBad() {
+		logger.Debugf("peer %s is bad because status is %s", peer.PeerID, peer.GetStatus())
+		return true
+	}
+	costHistory := peer.GetCostHistory()
+	if len(costHistory) < 4 {
+		return false
+	}
+
+	avgCost, lastCost := getAvgAndLastCost(costHistory, 4)
+
+	if avgCost*40 < lastCost && !peer.Host.CDN {
+		logger.Debugf("peer %s is bad because recent pieces have taken too long to download avg[%d] last[%d]", peer.PeerID, avgCost, lastCost)
+		return true
+	}
+
+	return false
+}
+
+// Evaluate The bigger, the better
+func (eval *dynamicEvaluator) Evaluate(dst *supervisor.Peer, src *supervisor.Peer) float64 {
+	profits := getProfits(dst, src)
+
+	load := getHostLoad(dst.Host)
+
+	dist := getDistance(dst, src)
+
+	score := profits + load*args["load"] + dist*args["dist"]
+	return score
+}
+
+func getAvgAndLastCost(list []int, splitPos int) (avgCost, lastCost int) {
+	length := len(list)
+	totalCost := 0
+	for i, cost := range list {
+		totalCost += cost
+		if length-i <= splitPos {
+			lastCost += cost
+		}
+	}
+	avgCost = totalCost / length
+	lastCost = lastCost / splitPos
+	return
+}
+
+// getProfits 0.0~unlimited larger and better
+func getProfits(dst *supervisor.Peer, src *supervisor.Peer) float64 {
+	diff := supervisor.GetDiffPieceNum(dst, src)
+	if diff > 0 {
+		return float64(dst.Task.PieceTotal + 1 - diff)
+	} else {
+		return float64(diff)
+	}
+}
+
+// getHostLoad 0.0~1.0 larger and better
+func getHostLoad(host *supervisor.PeerHost) float64 {
+	return 1.0 - host.GetUploadLoadPercent()
+}
+
+// getDistance 0.0~1.0 larger and better
+func getDistance(dst *supervisor.Peer, src *supervisor.Peer) float64 {
+	hostDist := 40.0
+	if dst.Host == src.Host {
+		hostDist = 0.0
+	} else {
+		if src.Host.NetTopology != "" && dst.Host.NetTopology == src.Host.NetTopology {
+			hostDist = 10.0
+		} else if src.Host.IDC != "" && dst.Host.IDC == src.Host.IDC {
+			hostDist = 20.0
+		} else if dst.Host.SecurityDomain != src.Host.SecurityDomain {
+			hostDist = 80.0
+		}
+	}
+	return 1.0 - hostDist/80.0
+}

--- a/scheduler/core/scheduler/dynamic/dynamic_scheduler.go
+++ b/scheduler/core/scheduler/dynamic/dynamic_scheduler.go
@@ -1,0 +1,273 @@
+/*
+ *     Copyright 2020 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynamic
+
+import (
+	"sort"
+
+	logger "d7y.io/dragonfly/v2/internal/dflog"
+	"d7y.io/dragonfly/v2/scheduler/config"
+	"d7y.io/dragonfly/v2/scheduler/core/evaluator"
+	"d7y.io/dragonfly/v2/scheduler/core/evaluator/dynamic"
+	"d7y.io/dragonfly/v2/scheduler/core/scheduler"
+	"d7y.io/dragonfly/v2/scheduler/supervisor"
+)
+
+const name = "dynamic"
+
+func init() {
+	scheduler.Register(newDynamicSchedulerBuilder())
+}
+
+type dynamicSchedulerBuilder struct {
+	name string
+}
+
+func newDynamicSchedulerBuilder() scheduler.Builder {
+	return &dynamicSchedulerBuilder{
+		name: name,
+	}
+}
+
+var _ scheduler.Builder = (*dynamicSchedulerBuilder)(nil)
+
+func (builder *dynamicSchedulerBuilder) Build(cfg *config.SchedulerConfig, opts *scheduler.BuildOptions) (scheduler.Scheduler, error) {
+	logger.Debugf("start create dynamic scheduler...")
+	evalFactory := evaluator.NewEvaluatorFactory(cfg)
+	evalFactory.Register("default", dynamic.NewEvaluator(cfg))
+	evalFactory.RegisterGetEvaluatorFunc(0, func(taskID string) (string, bool) { return "default", true })
+	sched := &Scheduler{
+		evaluator:   evalFactory,
+		peerManager: opts.PeerManager,
+		cfg:         cfg,
+	}
+	logger.Debugf("create dynamic scheduler successfully")
+	return sched, nil
+}
+
+func (builder *dynamicSchedulerBuilder) Name() string {
+	return builder.name
+}
+
+type Scheduler struct {
+	evaluator   evaluator.Evaluator
+	peerManager supervisor.PeerMgr
+	cfg         *config.SchedulerConfig
+}
+
+func (s *Scheduler) ScheduleChildren(peer *supervisor.Peer) (children []*supervisor.Peer) {
+	if s.evaluator.IsBadNode(peer) {
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("terminate schedule children flow because peer is bad node")
+		return
+	}
+	freeUpload := peer.Host.GetFreeUploadLoad()
+	candidateChildren := s.selectCandidateChildren(peer, freeUpload*2)
+	if len(candidateChildren) == 0 {
+		return nil
+	}
+	evalResult := make(map[float64][]*supervisor.Peer)
+	var evalScore []float64
+	for _, child := range candidateChildren {
+		score := s.evaluator.Evaluate(peer, child)
+		evalResult[score] = append(evalResult[score], child)
+		evalScore = append(evalScore, score)
+	}
+	sort.Float64s(evalScore)
+	for i := range evalScore {
+		if freeUpload <= 0 {
+			break
+		}
+		peers := evalResult[evalScore[len(evalScore)-i-1]]
+		for _, child := range peers {
+			if freeUpload <= 0 {
+				break
+			}
+			if child.GetParent() == peer {
+				continue
+			}
+			children = append(children, child)
+			freeUpload--
+		}
+	}
+	for _, child := range children {
+		child.ReplaceParent(peer)
+	}
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("schedule children result: %v", children)
+	return
+}
+
+func (s *Scheduler) ScheduleParent(peer *supervisor.Peer) (*supervisor.Peer, []*supervisor.Peer, bool) {
+	//if !s.evaluator.NeedAdjustParent(peer) {
+	//	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("stop schedule parent flow because peer is not need adjust parent", peer.PeerID)
+	//	if peer.GetParent() == nil {
+	//		return nil, nil, false
+	//	}
+	//	return peer.GetParent(), []*types.Peer{peer.GetParent()}, true
+	//}
+	candidateParents := s.selectCandidateParents(peer, s.cfg.CandidateParentCount)
+	if len(candidateParents) == 0 {
+		return nil, nil, false
+	}
+	evalResult := make(map[float64][]*supervisor.Peer)
+	var evalScore []float64
+	for _, parent := range candidateParents {
+		score := s.evaluator.Evaluate(parent, peer)
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("evaluate score candidate %s is %f", parent.PeerID, score)
+		evalResult[score] = append(evalResult[score], parent)
+		evalScore = append(evalScore, score)
+	}
+	sort.Float64s(evalScore)
+	var parents = make([]*supervisor.Peer, 0, len(candidateParents))
+	for i := range evalScore {
+		parents = append(parents, evalResult[evalScore[len(evalScore)-i-1]]...)
+	}
+	if parents[0] != peer.GetParent() {
+		peer.ReplaceParent(parents[0])
+	}
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("primary parent %s is selected", parents[0].PeerID)
+	return parents[0], parents[1:], true
+}
+
+func (s *Scheduler) selectCandidateChildren(peer *supervisor.Peer, limit int) (candidateChildren []*supervisor.Peer) {
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("start schedule children flow")
+	defer logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("finish schedule parent flow, select num %d candidate children, "+
+		"current task tree node count %d, back source peers: %s", len(candidateChildren), peer.Task.ListPeers().Size(), peer.Task.GetBackSourcePeers())
+	candidateChildren = peer.Task.Pick(limit, func(candidateNode *supervisor.Peer) bool {
+		if candidateNode == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer is not selected because it is nil******")
+			return false
+		}
+		if candidateNode.IsDone() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it has done******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsLeave() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it has left******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsWaiting() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it's status is Waiting******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode == peer {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because it and peer are the same******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsAncestorOf(peer) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because peer's ancestor is candidate peer******", candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetFinishedNum() >= peer.GetFinishedNum() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because it finished number of download is equal to or greater than peer's"+
+				"******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.Host != nil && candidateNode.Host.CDN {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it is a cdn host******",
+				candidateNode.PeerID)
+			return false
+		}
+		if !candidateNode.IsConnected() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it is not connected******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetParent() == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******[selected]candidate child peer %s is selected because it has not parent[selected]******",
+				candidateNode.PeerID)
+			return true
+		}
+
+		if candidateNode.GetParent() != nil && s.evaluator.IsBadNode(candidateNode.GetParent()) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******[selected]candidate child peer %s is selected because parent's status is not health[selected]******",
+				candidateNode.PeerID)
+			return true
+		}
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******[default]candidate child peer %s is selected[default]******", candidateNode.PeerID)
+		return true
+	})
+	return
+}
+
+func (s *Scheduler) selectCandidateParents(peer *supervisor.Peer, limit int) (candidateParents []*supervisor.Peer) {
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("start schedule parent flow")
+	defer logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("finish schedule parent flow, select num %d candidates parents, "+
+		"current task tree node count %d, back source peers: %s", len(candidateParents), peer.Task.ListPeers().Size(), peer.Task.GetBackSourcePeers())
+	if !peer.Task.CanSchedule() {
+		logger.WithTaskAndPeerID(peer.Task.TaskID,
+			peer.PeerID).Debugf("++++++peer can not be scheduled because task cannot be scheduled at this time，waiting task status become seeding. "+
+			"it current status is %s++++++", peer.Task.GetStatus())
+		return nil
+	}
+	candidateParents = peer.Task.PickReverse(limit, func(candidateNode *supervisor.Peer) bool {
+		if candidateNode == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer is not selected because it is nil++++++")
+			return false
+		}
+		if s.evaluator.IsBadNode(candidateNode) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it is badNode++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsLeave() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it has already left++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode == peer {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it and peer are the same++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsDescendantOf(peer) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's ancestor is peer++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.Host.GetFreeUploadLoad() <= 0 {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's free upload load equal to less than zero++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsWaiting() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's status is waiting++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetFinishedNum() <= peer.GetFinishedNum() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it finished number of download is equal to or smaller than peer"+
+				"'s++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++[default]candidate parent peer %s is selected[default]", candidateNode.PeerID)
+		return true
+	})
+	return
+}

--- a/scheduler/core/scheduler/exchangemax/exchangemax_scheduler.go
+++ b/scheduler/core/scheduler/exchangemax/exchangemax_scheduler.go
@@ -1,0 +1,308 @@
+/*
+ *     Copyright 2020 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package exchangemax
+
+import (
+	"sort"
+
+	logger "d7y.io/dragonfly/v2/internal/dflog"
+	"d7y.io/dragonfly/v2/scheduler/config"
+	"d7y.io/dragonfly/v2/scheduler/core/evaluator"
+	"d7y.io/dragonfly/v2/scheduler/core/evaluator/dynamic"
+	"d7y.io/dragonfly/v2/scheduler/core/scheduler"
+	"d7y.io/dragonfly/v2/scheduler/supervisor"
+)
+
+const name = "exchangeMax"
+
+func init() {
+	scheduler.Register(newExchangeMaxSchedulerBuilder())
+}
+
+type exchangeMaxSchedulerBuilder struct {
+	name string
+}
+
+func newExchangeMaxSchedulerBuilder() scheduler.Builder {
+	return &exchangeMaxSchedulerBuilder{
+		name: name,
+	}
+}
+
+var _ scheduler.Builder = (*exchangeMaxSchedulerBuilder)(nil)
+
+func (builder *exchangeMaxSchedulerBuilder) Build(cfg *config.SchedulerConfig, opts *scheduler.BuildOptions) (scheduler.Scheduler, error) {
+	logger.Debugf("start create exchange scheduler...")
+	evalFactory := evaluator.NewEvaluatorFactory(cfg)
+	evalFactory.Register("default", dynamic.NewEvaluator(cfg))
+	evalFactory.RegisterGetEvaluatorFunc(0, func(taskID string) (string, bool) { return "default", true })
+	sched := &Scheduler{
+		evaluator:   evalFactory,
+		peerManager: opts.PeerManager,
+		cfg:         cfg,
+	}
+	logger.Debugf("create exchange scheduler successfully")
+	return sched, nil
+}
+
+func (builder *exchangeMaxSchedulerBuilder) Name() string {
+	return builder.name
+}
+
+type Scheduler struct {
+	evaluator   evaluator.Evaluator
+	peerManager supervisor.PeerMgr
+	cfg         *config.SchedulerConfig
+}
+
+func (s *Scheduler) ScheduleChildren(peer *supervisor.Peer) (children []*supervisor.Peer) {
+	if s.evaluator.IsBadNode(peer) {
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("terminate schedule children flow because peer is bad node")
+		return
+	}
+	freeUpload := peer.Host.GetFreeUploadLoad()
+	candidateChildren := s.selectCandidateChildren(peer, freeUpload*2)
+	if len(candidateChildren) == 0 {
+		return nil
+	}
+	evalResult := make(map[float64][]*supervisor.Peer)
+	var evalScore []float64
+	for _, child := range candidateChildren {
+		score := s.evaluator.Evaluate(peer, child)
+		evalResult[score] = append(evalResult[score], child)
+		evalScore = append(evalScore, score)
+	}
+	sort.Float64s(evalScore)
+	for i := range evalScore {
+		if freeUpload <= 0 {
+			break
+		}
+		peers := evalResult[evalScore[len(evalScore)-i-1]]
+		for _, child := range peers {
+			if freeUpload <= 0 {
+				break
+			}
+			if child.GetParent() == peer {
+				continue
+			}
+			children = append(children, child)
+			freeUpload--
+		}
+	}
+	for _, child := range children {
+		child.ReplaceParent(peer)
+	}
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("schedule children result: %v", children)
+	return
+}
+
+func (s *Scheduler) ExchangeParents(peer *supervisor.Peer) (*supervisor.Peer, []*supervisor.Peer) {
+	// target can exchange
+	var into *supervisor.Peer
+	into = peer
+	var out *supervisor.Peer
+	var candidateParents []*supervisor.Peer
+	for {
+		candidateNode := into.Task.Pick(1, func(out *supervisor.Peer) bool {
+			diffOut := out.GetParent().GetFinishedNum() - out.GetFinishedNum()
+			diffIn := out.GetParent().GetFinishedNum() - into.GetFinishedNum()
+			if diffIn < diffOut && diffIn > 0 {
+				return true
+			} else {
+				return false
+			}
+		})
+		if len(candidateNode) == 0 {
+			break
+		} else {
+			out = candidateNode[0]
+		}
+		parent := out.GetParent()
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("for parent %s, exchange in %s and exchange out %s", parent.PeerID, into.PeerID, out.PeerID)
+
+		out.ReplaceParent(nil)
+		into.ReplaceParent(parent)
+		into = out
+	}
+	candidateParents = s.selectCandidateParents(into, s.cfg.CandidateParentCount)
+	return into, candidateParents
+}
+
+func (s *Scheduler) ScheduleParent(peer *supervisor.Peer) (*supervisor.Peer, []*supervisor.Peer, bool) {
+	//if !s.evaluator.NeedAdjustParent(peer) {
+	//	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("stop schedule parent flow because peer is not need adjust parent", peer.PeerID)
+	//	if peer.GetParent() == nil {
+	//		return nil, nil, false
+	//	}
+	//	return peer.GetParent(), []*types.Peer{peer.GetParent()}, true
+	//}
+	candidateParents := s.selectCandidateParents(peer, s.cfg.CandidateParentCount)
+	if len(candidateParents) == 0 {
+		peer, candidateParents = s.ExchangeParents(peer)
+		if len(candidateParents) == 0 {
+			return nil, nil, false
+		}
+	}
+	evalResult := make(map[float64][]*supervisor.Peer)
+	var evalScore []float64
+	for _, parent := range candidateParents {
+		score := s.evaluator.Evaluate(parent, peer)
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("evaluate score candidate %s is %f", parent.PeerID, score)
+		evalResult[score] = append(evalResult[score], parent)
+		evalScore = append(evalScore, score)
+	}
+	sort.Float64s(evalScore)
+	var parents = make([]*supervisor.Peer, 0, len(candidateParents))
+	for i := range evalScore {
+		parents = append(parents, evalResult[evalScore[len(evalScore)-i-1]]...)
+	}
+	if parents[0] != peer.GetParent() {
+		peer.ReplaceParent(parents[0])
+	}
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("primary parent %s is selected", parents[0].PeerID)
+	return parents[0], parents[1:], true
+}
+
+func (s *Scheduler) selectCandidateChildren(peer *supervisor.Peer, limit int) (candidateChildren []*supervisor.Peer) {
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("start schedule children flow")
+	defer logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("finish schedule parent flow, select num %d candidate children, "+
+		"current task tree node count %d, back source peers: %s", len(candidateChildren), peer.Task.ListPeers().Size(), peer.Task.GetBackSourcePeers())
+	candidateChildren = peer.Task.Pick(limit, func(candidateNode *supervisor.Peer) bool {
+		if candidateNode == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer is not selected because it is nil******")
+			return false
+		}
+		if candidateNode.IsDone() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it has done******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsLeave() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it has left******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsWaiting() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it's status is Waiting******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode == peer {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because it and peer are the same******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsAncestorOf(peer) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because peer's ancestor is candidate peer******", candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetFinishedNum() >= peer.GetFinishedNum() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because it finished number of download is equal to or greater than peer's"+
+				"******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.Host != nil && candidateNode.Host.CDN {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it is a cdn host******",
+				candidateNode.PeerID)
+			return false
+		}
+		if !candidateNode.IsConnected() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it is not connected******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetParent() == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******[selected]candidate child peer %s is selected because it has not parent[selected]******",
+				candidateNode.PeerID)
+			return true
+		}
+
+		if candidateNode.GetParent() != nil && s.evaluator.IsBadNode(candidateNode.GetParent()) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******[selected]candidate child peer %s is selected because parent's status is not health[selected]******",
+				candidateNode.PeerID)
+			return true
+		}
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******[default]candidate child peer %s is selected[default]******", candidateNode.PeerID)
+		return true
+	})
+	return
+}
+
+func (s *Scheduler) selectCandidateParents(peer *supervisor.Peer, limit int) (candidateParents []*supervisor.Peer) {
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("start schedule parent flow")
+	defer logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("finish schedule parent flow, select num %d candidates parents, "+
+		"current task tree node count %d, back source peers: %s", len(candidateParents), peer.Task.ListPeers().Size(), peer.Task.GetBackSourcePeers())
+	if !peer.Task.CanSchedule() {
+		logger.WithTaskAndPeerID(peer.Task.TaskID,
+			peer.PeerID).Debugf("++++++peer can not be scheduled because task cannot be scheduled at this time，waiting task status become seeding. "+
+			"it current status is %s++++++", peer.Task.GetStatus())
+		return nil
+	}
+	candidateParents = peer.Task.PickReverse(limit, func(candidateNode *supervisor.Peer) bool {
+		if candidateNode == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer is not selected because it is nil++++++")
+			return false
+		}
+		if s.evaluator.IsBadNode(candidateNode) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it is badNode++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsLeave() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it has already left++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode == peer {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it and peer are the same++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsDescendantOf(peer) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's ancestor is peer++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.Host.GetFreeUploadLoad() <= 0 {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's free upload load equal to less than zero++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsWaiting() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's status is waiting++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetFinishedNum() <= peer.GetFinishedNum() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it finished number of download is equal to or smaller than peer"+
+				"'s++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++[default]candidate parent peer %s is selected[default]", candidateNode.PeerID)
+		return true
+	})
+	return
+}

--- a/scheduler/core/scheduler/exchangemin/exchangemin_scheduler.go
+++ b/scheduler/core/scheduler/exchangemin/exchangemin_scheduler.go
@@ -1,0 +1,308 @@
+/*
+ *     Copyright 2020 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package exchangemax
+
+import (
+	"sort"
+
+	logger "d7y.io/dragonfly/v2/internal/dflog"
+	"d7y.io/dragonfly/v2/scheduler/config"
+	"d7y.io/dragonfly/v2/scheduler/core/evaluator"
+	"d7y.io/dragonfly/v2/scheduler/core/evaluator/dynamic"
+	"d7y.io/dragonfly/v2/scheduler/core/scheduler"
+	"d7y.io/dragonfly/v2/scheduler/supervisor"
+)
+
+const name = "exchangeMin"
+
+func init() {
+	scheduler.Register(newExchangeMinSchedulerBuilder())
+}
+
+type exchangeMinSchedulerBuilder struct {
+	name string
+}
+
+func newExchangeMinSchedulerBuilder() scheduler.Builder {
+	return &exchangeMinSchedulerBuilder{
+		name: name,
+	}
+}
+
+var _ scheduler.Builder = (*exchangeMinSchedulerBuilder)(nil)
+
+func (builder *exchangeMinSchedulerBuilder) Build(cfg *config.SchedulerConfig, opts *scheduler.BuildOptions) (scheduler.Scheduler, error) {
+	logger.Debugf("start create exchange scheduler...")
+	evalFactory := evaluator.NewEvaluatorFactory(cfg)
+	evalFactory.Register("default", dynamic.NewEvaluator(cfg))
+	evalFactory.RegisterGetEvaluatorFunc(0, func(taskID string) (string, bool) { return "default", true })
+	sched := &Scheduler{
+		evaluator:   evalFactory,
+		peerManager: opts.PeerManager,
+		cfg:         cfg,
+	}
+	logger.Debugf("create exchange scheduler successfully")
+	return sched, nil
+}
+
+func (builder *exchangeMinSchedulerBuilder) Name() string {
+	return builder.name
+}
+
+type Scheduler struct {
+	evaluator   evaluator.Evaluator
+	peerManager supervisor.PeerMgr
+	cfg         *config.SchedulerConfig
+}
+
+func (s *Scheduler) ScheduleChildren(peer *supervisor.Peer) (children []*supervisor.Peer) {
+	if s.evaluator.IsBadNode(peer) {
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("terminate schedule children flow because peer is bad node")
+		return
+	}
+	freeUpload := peer.Host.GetFreeUploadLoad()
+	candidateChildren := s.selectCandidateChildren(peer, freeUpload*2)
+	if len(candidateChildren) == 0 {
+		return nil
+	}
+	evalResult := make(map[float64][]*supervisor.Peer)
+	var evalScore []float64
+	for _, child := range candidateChildren {
+		score := s.evaluator.Evaluate(peer, child)
+		evalResult[score] = append(evalResult[score], child)
+		evalScore = append(evalScore, score)
+	}
+	sort.Float64s(evalScore)
+	for i := range evalScore {
+		if freeUpload <= 0 {
+			break
+		}
+		peers := evalResult[evalScore[len(evalScore)-i-1]]
+		for _, child := range peers {
+			if freeUpload <= 0 {
+				break
+			}
+			if child.GetParent() == peer {
+				continue
+			}
+			children = append(children, child)
+			freeUpload--
+		}
+	}
+	for _, child := range children {
+		child.ReplaceParent(peer)
+	}
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("schedule children result: %v", children)
+	return
+}
+
+func (s *Scheduler) ExchangeParents(peer *supervisor.Peer) (*supervisor.Peer, []*supervisor.Peer) {
+	// target can exchange
+	var into *supervisor.Peer
+	into = peer
+	var out *supervisor.Peer
+	var candidateParents []*supervisor.Peer
+	for {
+		candidateNode := into.Task.Pick(1, func(out *supervisor.Peer) bool {
+			diffOut := out.GetParent().GetFinishedNum() - out.GetFinishedNum()
+			diffIn := out.GetParent().GetFinishedNum() - into.GetFinishedNum()
+			if diffIn < diffOut && diffIn > 0 {
+				return true
+			} else {
+				return false
+			}
+		})
+		if len(candidateNode) == 0 {
+			break
+		} else {
+			out = candidateNode[0]
+		}
+		parent := out.GetParent()
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("for parent %s, exchange in %s and exchange out %s", parent.PeerID, into.PeerID, out.PeerID)
+
+		out.ReplaceParent(nil)
+		into.ReplaceParent(parent)
+		into = out
+	}
+	candidateParents = s.selectCandidateParents(into, s.cfg.CandidateParentCount)
+	return into, candidateParents
+}
+
+func (s *Scheduler) ScheduleParent(peer *supervisor.Peer) (*supervisor.Peer, []*supervisor.Peer, bool) {
+	//if !s.evaluator.NeedAdjustParent(peer) {
+	//	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("stop schedule parent flow because peer is not need adjust parent", peer.PeerID)
+	//	if peer.GetParent() == nil {
+	//		return nil, nil, false
+	//	}
+	//	return peer.GetParent(), []*types.Peer{peer.GetParent()}, true
+	//}
+	candidateParents := s.selectCandidateParents(peer, s.cfg.CandidateParentCount)
+	if len(candidateParents) == 0 {
+		peer, candidateParents = s.ExchangeParents(peer)
+		if len(candidateParents) == 0 {
+			return nil, nil, false
+		}
+	}
+	evalResult := make(map[float64][]*supervisor.Peer)
+	var evalScore []float64
+	for _, parent := range candidateParents {
+		score := s.evaluator.Evaluate(parent, peer)
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("evaluate score candidate %s is %f", parent.PeerID, score)
+		evalResult[score] = append(evalResult[score], parent)
+		evalScore = append(evalScore, score)
+	}
+	sort.Float64s(evalScore)
+	var parents = make([]*supervisor.Peer, 0, len(candidateParents))
+	for i := range evalScore {
+		parents = append(parents, evalResult[evalScore[len(evalScore)-i-1]]...)
+	}
+	if parents[0] != peer.GetParent() {
+		peer.ReplaceParent(parents[0])
+	}
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("primary parent %s is selected", parents[0].PeerID)
+	return parents[0], parents[1:], true
+}
+
+func (s *Scheduler) selectCandidateChildren(peer *supervisor.Peer, limit int) (candidateChildren []*supervisor.Peer) {
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("start schedule children flow")
+	defer logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("finish schedule parent flow, select num %d candidate children, "+
+		"current task tree node count %d, back source peers: %s", len(candidateChildren), peer.Task.ListPeers().Size(), peer.Task.GetBackSourcePeers())
+	candidateChildren = peer.Task.Pick(limit, func(candidateNode *supervisor.Peer) bool {
+		if candidateNode == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer is not selected because it is nil******")
+			return false
+		}
+		if candidateNode.IsDone() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it has done******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsLeave() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it has left******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsWaiting() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it's status is Waiting******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode == peer {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because it and peer are the same******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsAncestorOf(peer) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because peer's ancestor is candidate peer******", candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetFinishedNum() >= peer.GetFinishedNum() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******candidate child peer %s is not selected because it finished number of download is equal to or greater than peer's"+
+				"******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.Host != nil && candidateNode.Host.CDN {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it is a cdn host******",
+				candidateNode.PeerID)
+			return false
+		}
+		if !candidateNode.IsConnected() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******candidate child peer %s is not selected because it is not connected******",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetParent() == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******[selected]candidate child peer %s is selected because it has not parent[selected]******",
+				candidateNode.PeerID)
+			return true
+		}
+
+		if candidateNode.GetParent() != nil && s.evaluator.IsBadNode(candidateNode.GetParent()) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("******[selected]candidate child peer %s is selected because parent's status is not health[selected]******",
+				candidateNode.PeerID)
+			return true
+		}
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("******[default]candidate child peer %s is selected[default]******", candidateNode.PeerID)
+		return true
+	})
+	return
+}
+
+func (s *Scheduler) selectCandidateParents(peer *supervisor.Peer, limit int) (candidateParents []*supervisor.Peer) {
+	logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debug("start schedule parent flow")
+	defer logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("finish schedule parent flow, select num %d candidates parents, "+
+		"current task tree node count %d, back source peers: %s", len(candidateParents), peer.Task.ListPeers().Size(), peer.Task.GetBackSourcePeers())
+	if !peer.Task.CanSchedule() {
+		logger.WithTaskAndPeerID(peer.Task.TaskID,
+			peer.PeerID).Debugf("++++++peer can not be scheduled because task cannot be scheduled at this time，waiting task status become seeding. "+
+			"it current status is %s++++++", peer.Task.GetStatus())
+		return nil
+	}
+	candidateParents = peer.Task.PickReverse(limit, func(candidateNode *supervisor.Peer) bool {
+		if candidateNode == nil {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer is not selected because it is nil++++++")
+			return false
+		}
+		if s.evaluator.IsBadNode(candidateNode) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it is badNode++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsLeave() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it has already left++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode == peer {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it and peer are the same++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsDescendantOf(peer) {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's ancestor is peer++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.Host.GetFreeUploadLoad() <= 0 {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's free upload load equal to less than zero++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.IsWaiting() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it's status is waiting++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		if candidateNode.GetFinishedNum() <= peer.GetFinishedNum() {
+			logger.WithTaskAndPeerID(peer.Task.TaskID,
+				peer.PeerID).Debugf("++++++candidate parent peer %s is not selected because it finished number of download is equal to or smaller than peer"+
+				"'s++++++",
+				candidateNode.PeerID)
+			return false
+		}
+		logger.WithTaskAndPeerID(peer.Task.TaskID, peer.PeerID).Debugf("++++++[default]candidate parent peer %s is selected[default]", candidateNode.PeerID)
+		return true
+	})
+	return
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add 3 schedulers to scheduler/core
- dynamic: new profit calculation
- exchangeMax: new profit calculation + exchange parents as more as possible
- exchangeMax: new profit calculation + exchange parents as less as possible


## Related Issue

None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

Imporved in single machine:

| MIN/MEDIAN/MEAN/MAX(MS) | BASIC | DYNAMIC | EXCHANGEMAX |EXCHANGEMIN|
| :----:| :----: | :----: | :----: | :----: |
| 50MB_100                | 1884/2671/2691/3590  | 1724/3068/5213/11458 | 1772/3797/4640/9613 | 1703/2924/4238/8836 |
| 50MB_200                | 1559/2561/2533/3444  | 1858/4203/4547/9969  | 1724/2504/2566/3403 | 1795/2372/2467/3362 |
| 50MB_300                | 1763/3713/3643/5431  | 1856/3071/3009/3821  | 2009/3049/3020/3827 | 1907/2982/2968/3785 |
| 50MB_400                | 2104/4908/4923/7855  | 2136/4116/3990/5248  | 2393/4049/3990/5153 | 2074/4206/4075/5376 |
| 50MB_500                | 2632/7376/7325/11537 | 2664/5344/5265/6986  | 3105/5587/5540/7281 | 2518/5231/5072/6850 |


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
