### PR TITLE
[WIP] Split peer into success/failed/running group

### DIFF
--- a/scheduler/core/scheduler/basic/basic_scheduler.go
+++ b/scheduler/core/scheduler/basic/basic_scheduler.go
@@ -142,7 +142,8 @@ func (s *Scheduler) selectCandidateChildren(peer *supervisor.Peer, limit int, bl
 	peer.Log().Debug("start schedule children flow")
 	defer peer.Log().Debugf("finish schedule parent flow, select num %d candidate children, "+
 		"current task tree node count %d, back source peers: %v", len(candidateChildren), peer.Task.GetPeers().Size(), peer.Task.GetBackToSourcePeers())
-	candidateChildren = peer.Task.Pick(limit, func(candidateNode *supervisor.Peer) bool {
+	selectStatus := []supervisor.PeerStatus{supervisor.PeerStatusRunning, supervisor.PeerStatusSuccess}
+	candidateChildren = peer.Task.Pick(limit, selectStatus, func(candidateNode *supervisor.Peer) bool {
 		if candidateNode == nil {
 			peer.Log().Debugf("******candidate child peer is not selected because it is nil******")
 			return false
@@ -220,7 +221,8 @@ func (s *Scheduler) selectCandidateParents(peer *supervisor.Peer, limit int, bla
 			"it current status is %s++++++", peer.Task.GetStatus())
 		return nil
 	}
-	candidateParents = peer.Task.PickReverse(limit, func(candidateNode *supervisor.Peer) bool {
+	selectStatus := []supervisor.PeerStatus{supervisor.PeerStatusRunning}
+	candidateParents = peer.Task.PickReverse(limit, selectStatus, func(candidateNode *supervisor.Peer) bool {
 		if candidateNode == nil {
 			peer.Log().Debugf("++++++candidate parent peer is not selected because it is nil++++++")
 			return false

--- a/scheduler/supervisor/peer.go
+++ b/scheduler/supervisor/peer.go
@@ -186,6 +186,8 @@ const (
 	PeerStatusZombie
 	PeerStatusFail
 	PeerStatusSuccess
+	// Invalid should be always at end as a flag
+	PeerInvalid
 )
 
 type Peer struct {
@@ -231,6 +233,7 @@ func NewPeer(id string, task *Task, host *Host) *Peer {
 	}
 
 	peer.status.Store(PeerStatusWaiting)
+	peer.Task.peersStatus[PeerStatusWaiting].Add(peer)
 	return peer
 }
 
@@ -406,6 +409,7 @@ func (peer *Peer) getFreeLoad() int {
 }
 
 func (peer *Peer) SetStatus(status PeerStatus) {
+	peer.Task.Transition(peer, status)
 	peer.status.Store(status)
 }
 


### PR DESCRIPTION
#665 

在peer中，增加了PeerStatus状态PeerInvalid用于判定全部PeerStatus数量

在task中，增加了peersStatus字典，用于区分不同状态的peers集合

在task中，增加了Transition接口用于peer在不同状态集合中的转移

在task中，增加了GetPeersByStatus接口用于获得特定状态peer的集合

在task中，修改了Pick/PickReverse/pick三个接口，在其中增加了指定不同集合的参数statusList

在basic_scheduler中，修改了selectCandidateParents函数内部只使用PeerStatusRunning状态的peer，selectCandidateChildren函数内部只使用PeerStatusRunning和PeerStatusSuccess状态的peer

是否需要关于状态集合的相关测试？如果需要增加在哪里？


