### PR TITLE
add peer to task failed because InnerBucketMaxLength is small

### DIFF
--- a/pkg/structure/sortedlist/sorted_list.go
+++ b/pkg/structure/sortedlist/sorted_list.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 )
 
-const BucketMaxLength = 10000
-const InnerBucketMaxLength = 100
+const BucketMaxLength = 100000
+const InnerBucketMaxLength = 10000
 
 type Item interface {
 	GetSortKeys() (key1 int, key2 int)

--- a/scheduler/supervisor/task.go
+++ b/scheduler/supervisor/task.go
@@ -261,16 +261,26 @@ func (task *Task) UpdateSuccess(pieceCount int32, contentLength int64) {
 }
 
 func (task *Task) AddPeer(peer *Peer) {
-	task.peers.UpdateOrAdd(peer)
+	err := task.peers.UpdateOrAdd(peer)
+	if err != nil {
+		task.logger.Errorf("add peer %s failed: %v", peer.ID, err)
+	}
 	task.logger.Debugf("peer %s has been added, current total peer count is %d", peer.ID, task.peers.Size())
 }
 
 func (task *Task) UpdatePeer(peer *Peer) {
-	task.peers.Update(peer)
+	err := task.peers.Update(peer)
+	if err != nil {
+		task.logger.Errorf("update peer %s failed: %v", peer.ID, err)
+	}
+	task.logger.Debugf("peer %s has been updated, current total peer count is %d", peer.ID, task.peers.Size())
 }
 
 func (task *Task) DeletePeer(peer *Peer) {
-	task.peers.Delete(peer)
+	err := task.peers.Delete(peer)
+	if err != nil {
+		task.logger.Errorf("delete peer %s failed: %v", peer.ID, err)
+	}
 	task.logger.Debugf("peer %s has been deleted, current total peer count is %d", peer.ID, task.peers.Size())
 }
 


### PR DESCRIPTION
Signed-off-by: santong <weipeng.swp@alibaba-inc.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
add peer to task failed because InnerBucketMaxLength is small
<!--- Describe your changes in detail -->

## Related Issue
#760 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
