### PR TITLE
Avoid using up the bandwidth of the CDN

### DIFF
--- a/scheduler/core/evaluator/basic/basic_evaluator.go
+++ b/scheduler/core/evaluator/basic/basic_evaluator.go
@@ -96,7 +96,7 @@ func (eval *baseEvaluator) Evaluate(parent *supervisor.Peer, child *supervisor.P
 
 	load := getHostLoad(parent.Host)
 
-	dist := getDistance(parent, child)
+	dist := getSimilarity(parent, child)
 
 	return profits * load * dist
 }
@@ -128,8 +128,8 @@ func getHostLoad(host *supervisor.Host) float64 {
 	return 1.0 - host.GetUploadLoadPercent()
 }
 
-// getDistance 0.0~1.0 larger and better
-func getDistance(dst *supervisor.Peer, src *supervisor.Peer) float64 {
+// getAffinity 0.0~1.0 larger and better
+func getAffinity(dst *supervisor.Peer, src *supervisor.Peer) float64 {
 	hostDist := 40.0
 	if dst.Host == src.Host {
 		hostDist = 0.0

--- a/scheduler/core/evaluator/basic/basic_evaluator.go
+++ b/scheduler/core/evaluator/basic/basic_evaluator.go
@@ -96,7 +96,7 @@ func (eval *baseEvaluator) Evaluate(parent *supervisor.Peer, child *supervisor.P
 
 	load := getHostLoad(parent.Host)
 
-	dist := getSimilarity(parent, child)
+	dist := getAffinity(parent, child)
 
 	return profits * load * dist
 }

--- a/scheduler/supervisor/peer.go
+++ b/scheduler/supervisor/peer.go
@@ -404,8 +404,12 @@ func (peer *Peer) SortedValue() int {
 	defer peer.lock.RUnlock()
 
 	pieceCount := peer.TotalPieceCount.Load()
-	hostLoad := peer.getFreeLoad()
-	return int(pieceCount*HostMaxLoad + hostLoad)
+	freeLoad := peer.getFreeLoad()
+	if peer.Host.IsCDN {
+		// if peer's host is CDN, peer has the lowest priority among all peers with the same number of pieces
+		return int(pieceCount * HostMaxLoad)
+	}
+	return int(pieceCount*HostMaxLoad + freeLoad)
 }
 
 func (peer *Peer) getFreeLoad() int32 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 if peer's host is CDN, peer has the lowest priority among all peers with the same number of pieces. This prevents clients from downloading data from the CDN preferentially, which may occupy the BANDWIDTH of the CDN
<!--- Describe your changes in detail -->

## Related Issue
fix #788 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
