### PR TITLE
chore:make piece size util code clean

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -16,27 +16,39 @@
 
 package util
 
+//TODO we should let following params make sense in future
 const (
-	// DefaultPieceSize 4M
-	DefaultPieceSize = 4 * 1024 * 1024
+	// PieceSizeUpperBound 16M
+	PieceSizeUpperBound = 1 << 24
 
-	// DefaultPieceSizeLimit 15M
-	DefaultPieceSizeLimit = 15 * 1024 * 1024
+	// PieceSizeLowerBound 4M
+	PieceSizeLowerBound = 1 << 22
+
+	// FileUpperBound 1G
+	FileUpperBound = 1 << 30
+
+	// FileLowerBound 256M
+	FileLowerBound = 1 << 28
 )
 
 // ComputePieceSize computes the piece size with specified fileLength.
 //
 // If the fileLength<0, which means failed to get fileLength
 // and then use the DefaultPieceSize.
+// so the pieceSize will increase as the file size increases as shown followed
+//  piece size (in MB) 16 ^            -----
+//                        |          /
+//                        |        /
+//                        |      /
+//                      4 |-----
+//                        |---------------------->
+//                        0     256   1024        file size (in MB)
 func ComputePieceSize(length int64) uint32 {
-	if length <= 0 || length <= 200*1024*1024 {
-		return DefaultPieceSize
+	if length <= FileLowerBound {
+		return PieceSizeLowerBound
 	}
-
-	gapCount := length / int64(100*1024*1024)
-	mpSize := (gapCount-2)*1024*1024 + DefaultPieceSize
-	if mpSize > DefaultPieceSizeLimit {
-		return DefaultPieceSizeLimit
+	if length >= FileUpperBound {
+		return PieceSizeUpperBound
 	}
-	return uint32(mpSize)
+	return uint32(length >> int64(6))
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -30,35 +30,41 @@ func TestComputePieceSize(t *testing.T) {
 		want uint32
 	}{
 		{
-			name: "length equal 200M and get default piece size",
+			name: "length is equal to 256M and get default piece size",
 			args: args{
-				length: 200 * 1024 * 1024,
+				length: 256 * 1024 * 1024,
 			},
-			want: DefaultPieceSize,
+			want: PieceSizeLowerBound,
 		}, {
-			name: "length smaller than 200M and get default piece size",
+			name: "length is smaller than 256M and get default piece size",
 			args: args{
-				length: 100 * 1024 * 1024,
+				length: 128 * 1024 * 1024,
 			},
-			want: DefaultPieceSize,
+			want: PieceSizeLowerBound,
 		}, {
-			name: "length greater than 200M",
+			name: "length is greater than 256M but smaller than 1G #1",
 			args: args{
-				length: 205 * 1024 * 1024,
+				length: (256 + 64) * 1024 * 1024,
 			},
-			want: DefaultPieceSize,
+			want: PieceSizeLowerBound + 1024*1024,
 		}, {
-			name: "length greater than 300M",
+			name: "length is greater than 256M but smaller than 1G #2",
 			args: args{
-				length: 310 * 1024 * 1024,
+				length: 512 * 1024 * 1024,
 			},
-			want: DefaultPieceSize + 1*1024*1024,
+			want: PieceSizeLowerBound * 2,
+		}, {
+			name: "length is equal to 1G",
+			args: args{
+				length: 1024 * 1024 * 1024,
+			},
+			want: PieceSizeUpperBound,
 		}, {
 			name: "length reach piece size limit",
 			args: args{
-				length: 3100 * 1024 * 1024,
+				length: 2056 * 1024 * 1024,
 			},
-			want: DefaultPieceSizeLimit,
+			want: PieceSizeUpperBound,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
refactor ComputePieceSize since it's a bit ugly, and of course we need to make the piece downloader calculator more flexible and intelligible in future.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
