### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cdn/storedriver/local/local_driver.go
+++ b/cdn/storedriver/local/local_driver.go
@@ -19,7 +19,6 @@ package local
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -156,7 +155,7 @@ func (ds *driver) GetBytes(raw *storedriver.Raw) (data []byte, err error) {
 		return nil, err
 	}
 	if raw.Length == 0 {
-		data, err = ioutil.ReadAll(f)
+		data, err = io.ReadAll(f)
 	} else {
 		data = make([]byte, raw.Length)
 		_, err = f.Read(data)

--- a/cdn/storedriver/local/local_driver_test.go
+++ b/cdn/storedriver/local/local_driver_test.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ type LocalDriverTestSuite struct {
 }
 
 func (s *LocalDriverTestSuite) SetupSuite() {
-	s.workHome, _ = ioutil.TempDir("/tmp", "cdn-local-driver-repo")
+	s.workHome, _ = os.MkdirTemp("/tmp", "cdn-local-driver-repo")
 	pluginProps := map[plugins.PluginType][]*plugins.PluginProperties{
 		plugins.StorageDriverPlugin: {
 			&plugins.PluginProperties{
@@ -296,7 +295,7 @@ func (s *LocalDriverTestSuite) TestGetPut() {
 			r, err := s.Get(v.getRaw)
 			s.True(v.getErrCheck(err))
 			if err == nil {
-				result, err := ioutil.ReadAll(r)
+				result, err := io.ReadAll(r)
 				s.Nil(err)
 				s.Equal(v.expected, string(result))
 			}
@@ -386,7 +385,7 @@ func (s *LocalDriverTestSuite) TestAppendBytes() {
 			r, err := s.Get(v.getRaw)
 			s.True(v.getErrCheck(err))
 			if err == nil {
-				result, err := ioutil.ReadAll(r)
+				result, err := io.ReadAll(r)
 				s.Nil(err)
 				s.Equal(v.expected, string(result))
 			}
@@ -466,7 +465,7 @@ func (s *LocalDriverTestSuite) TestPutTrunc() {
 		s.Nil(err)
 
 		if err == nil {
-			result, err := ioutil.ReadAll(r)
+			result, err := io.ReadAll(r)
 			s.Nil(err)
 			s.Equal(string(result[:]), v.expectedData)
 		}

--- a/cdn/supervisor/cdn/cache_detector.go
+++ b/cdn/supervisor/cdn/cache_detector.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -270,7 +269,7 @@ func checkPieceContent(reader io.Reader, pieceRecord *storage.PieceMetaRecord, f
 	// TODO Analyze the original data for the slice format to calculate fileMd5
 	pieceMd5 := md5.New()
 	tee := io.TeeReader(io.TeeReader(io.LimitReader(reader, int64(pieceRecord.PieceLen)), pieceMd5), fileDigest)
-	if n, err := io.Copy(ioutil.Discard, tee); n != int64(pieceRecord.PieceLen) || err != nil {
+	if n, err := io.Copy(io.Discard, tee); n != int64(pieceRecord.PieceLen) || err != nil {
 		return errors.Wrap(err, "read piece content")
 	}
 	realPieceMd5 := digestutils.ToHashString(pieceMd5)

--- a/cdn/supervisor/cdn/cache_detector_test.go
+++ b/cdn/supervisor/cdn/cache_detector_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/md5"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -66,21 +65,21 @@ func (suite *CacheDetectorTestSuite) SetupSuite() {
 	storageManager.EXPECT().ReadFileMetadata(noCache.taskID).Return(noCache.fileMeta, os.ErrNotExist).AnyTimes()
 	storageManager.EXPECT().ReadDownloadFile(fullNoExpiredCache.taskID).DoAndReturn(
 		func(taskID string) (io.ReadCloser, error) {
-			content, err := ioutil.ReadFile("../../testdata/cdn/go.html")
+			content, err := os.ReadFile("../../testdata/cdn/go.html")
 			suite.Nil(err)
-			return ioutil.NopCloser(strings.NewReader(string(content))), nil
+			return io.NopCloser(strings.NewReader(string(content))), nil
 		}).AnyTimes()
 	storageManager.EXPECT().ReadDownloadFile(partialNotSupportRangeCache.taskID).DoAndReturn(
 		func(taskID string) (io.ReadCloser, error) {
-			content, err := ioutil.ReadFile("../../testdata/cdn/go.html")
+			content, err := os.ReadFile("../../testdata/cdn/go.html")
 			suite.Nil(err)
-			return ioutil.NopCloser(strings.NewReader(string(content))), nil
+			return io.NopCloser(strings.NewReader(string(content))), nil
 		}).AnyTimes()
 	storageManager.EXPECT().ReadDownloadFile(partialSupportRangeCache.taskID).DoAndReturn(
 		func(taskID string) (io.ReadCloser, error) {
-			content, err := ioutil.ReadFile("../../testdata/cdn/go.html")
+			content, err := os.ReadFile("../../testdata/cdn/go.html")
 			suite.Nil(err)
-			return ioutil.NopCloser(strings.NewReader(string(content))), nil
+			return io.NopCloser(strings.NewReader(string(content))), nil
 		}).AnyTimes()
 	storageManager.EXPECT().ReadDownloadFile(noCache.taskID).Return(nil, os.ErrNotExist).AnyTimes()
 	storageManager.EXPECT().ReadPieceMetaRecords(fullNoExpiredCache.taskID).Return(fullNoExpiredCache.pieces, nil).AnyTimes()
@@ -421,7 +420,7 @@ func (suite *CacheDetectorTestSuite) TestParseByReadMetaFile() {
 }
 
 func (suite *CacheDetectorTestSuite) TestCheckPieceContent() {
-	content, err := ioutil.ReadFile("../../testdata/cdn/go.html")
+	content, err := os.ReadFile("../../testdata/cdn/go.html")
 	suite.Nil(err)
 	type args struct {
 		reader       io.Reader

--- a/cdn/supervisor/cdn/cache_writer_test.go
+++ b/cdn/supervisor/cdn/cache_writer_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -83,7 +82,7 @@ func NewPlugins(workHome string) map[plugins.PluginType][]*plugins.PluginPropert
 }
 
 func (suite *CacheWriterTestSuite) SetupSuite() {
-	suite.workHome, _ = ioutil.TempDir("/tmp", "cdn-CacheWriterDetectorTestSuite-")
+	suite.workHome, _ = os.MkdirTemp("/tmp", "cdn-CacheWriterDetectorTestSuite-")
 	suite.T().Log("workHome:", suite.workHome)
 	suite.Nil(plugins.Initialize(NewPlugins(suite.workHome)))
 	storeMgr, ok := storage.Get(config.DefaultStorageMode)
@@ -105,7 +104,7 @@ func (suite *CacheWriterTestSuite) TearDownSuite() {
 }
 
 func (suite *CacheWriterTestSuite) TestStartWriter() {
-	content, err := ioutil.ReadFile("../../testdata/cdn/go.html")
+	content, err := os.ReadFile("../../testdata/cdn/go.html")
 	suite.Nil(err)
 	contentLen := int64(len(content))
 	type args struct {

--- a/cdn/supervisor/cdn/manager_test.go
+++ b/cdn/supervisor/cdn/manager_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -54,7 +53,7 @@ type CDNManagerTestSuite struct {
 }
 
 func (suite *CDNManagerTestSuite) SetupSuite() {
-	suite.workHome, _ = ioutil.TempDir("/tmp", "cdn-ManagerTestSuite-")
+	suite.workHome, _ = os.MkdirTemp("/tmp", "cdn-ManagerTestSuite-")
 	fmt.Printf("workHome: %s", suite.workHome)
 	suite.Nil(plugins.Initialize(NewPlugins(suite.workHome)))
 	storeMgr, ok := storage.Get(config.DefaultStorageMode)
@@ -93,26 +92,26 @@ func (suite *CDNManagerTestSuite) TestTriggerCDN() {
 	sourceClient.EXPECT().IsExpired(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 	sourceClient.EXPECT().Download(gomock.Any()).DoAndReturn(
 		func(request *source.Request) (io.ReadCloser, error) {
-			content, _ := ioutil.ReadFile("../../testdata/cdn/go.html")
+			content, _ := os.ReadFile("../../testdata/cdn/go.html")
 			if request.Header.Get(source.Range) != "" {
 				parsed, _ := rangeutils.GetRange(request.Header.Get(source.Range))
-				return ioutil.NopCloser(io.NewSectionReader(strings.NewReader(string(content)), int64(parsed.StartIndex), int64(parsed.EndIndex))), nil
+				return io.NopCloser(io.NewSectionReader(strings.NewReader(string(content)), int64(parsed.StartIndex), int64(parsed.EndIndex))), nil
 			}
-			return ioutil.NopCloser(strings.NewReader(string(content))), nil
+			return io.NopCloser(strings.NewReader(string(content))), nil
 		},
 	).AnyTimes()
 	sourceClient.EXPECT().DownloadWithExpireInfo(gomock.Any()).DoAndReturn(
 		func(request *source.Request) (io.ReadCloser, *source.ExpireInfo, error) {
-			content, _ := ioutil.ReadFile("../../testdata/cdn/go.html")
+			content, _ := os.ReadFile("../../testdata/cdn/go.html")
 			if request.Header.Get(source.Range) != "" {
 				parsed, _ := rangeutils.GetRange(request.Header.Get(source.Range))
-				return ioutil.NopCloser(io.NewSectionReader(strings.NewReader(string(content)), int64(parsed.StartIndex), int64(parsed.EndIndex))),
+				return io.NopCloser(io.NewSectionReader(strings.NewReader(string(content)), int64(parsed.StartIndex), int64(parsed.EndIndex))),
 					&source.ExpireInfo{
 						LastModified: "Sun, 06 Jun 2021 12:52:30 GMT",
 						ETag:         "etag",
 					}, nil
 			}
-			return ioutil.NopCloser(strings.NewReader(string(content))),
+			return io.NopCloser(strings.NewReader(string(content))),
 				&source.ExpireInfo{
 					LastModified: "Sun, 06 Jun 2021 12:52:30 GMT",
 					ETag:         "etag",

--- a/client/config/dfget_darwin.go
+++ b/client/config/dfget_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 /*

--- a/client/config/dfget_linux.go
+++ b/client/config/dfget_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/client/config/dynconfig_test.go
+++ b/client/config/dynconfig_test.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,10 +31,7 @@ import (
 )
 
 func TestDynconfigNewDynconfig(t *testing.T) {
-	mockCacheDir, err := ioutil.TempDir("", "dragonfly-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockCacheDir := t.TempDir()
 
 	mockCachePath := filepath.Join(mockCacheDir, cacheFileName)
 	tests := []struct {
@@ -125,10 +121,7 @@ func TestDynconfigNewDynconfig(t *testing.T) {
 }
 
 func TestDynconfigGet(t *testing.T) {
-	mockCacheDir, err := ioutil.TempDir("", "dragonfly-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockCacheDir := t.TempDir()
 
 	mockCachePath := filepath.Join(mockCacheDir, cacheFileName)
 	tests := []struct {
@@ -310,10 +303,7 @@ func TestDynconfigGet(t *testing.T) {
 }
 
 func TestDynconfigGetSchedulers(t *testing.T) {
-	mockCacheDir, err := ioutil.TempDir("", "dragonfly-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockCacheDir := t.TempDir()
 
 	mockCachePath := filepath.Join(mockCacheDir, cacheFileName)
 	tests := []struct {

--- a/client/config/peerhost.go
+++ b/client/config/peerhost.go
@@ -22,9 +22,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -70,7 +70,7 @@ func NewDaemonConfig() *DaemonOption {
 }
 
 func (p *DaemonOption) Load(path string) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("unable to load peer host configuration from %q [%v]", path, err)
 	}
@@ -206,7 +206,7 @@ func (p *ProxyOption) UnmarshalJSON(b []byte) error {
 
 	switch value := v.(type) {
 	case string:
-		file, err := ioutil.ReadFile(value)
+		file, err := os.ReadFile(value)
 		if err != nil {
 			return err
 		}
@@ -232,7 +232,7 @@ func (p *ProxyOption) UnmarshalYAML(node *yaml.Node) error {
 			return err
 		}
 
-		file, err := ioutil.ReadFile(path)
+		file, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -445,7 +445,7 @@ func (f *FileString) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	file, err := ioutil.ReadFile(s)
+	file, err := os.ReadFile(s)
 	if err != nil {
 		return err
 	}
@@ -465,7 +465,7 @@ func (f *FileString) UnmarshalYAML(node *yaml.Node) error {
 		return errors.New("invalid filestring")
 	}
 
-	file, err := ioutil.ReadFile(s)
+	file, err := os.ReadFile(s)
 	if err != nil {
 		return err
 	}
@@ -628,7 +628,7 @@ func certPoolFromFiles(files ...string) (*x509.CertPool, error) {
 
 	roots := x509.NewCertPool()
 	for _, f := range files {
-		cert, err := ioutil.ReadFile(f)
+		cert, err := os.ReadFile(f)
 		if err != nil {
 			return nil, errors.Wrapf(err, "read cert file %s", f)
 		}

--- a/client/daemon/daemon.go
+++ b/client/daemon/daemon.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -226,7 +225,7 @@ func New(opt *config.DaemonOption, d dfpath.Dfpath) (Daemon, error) {
 
 func loadGPRCTLSCredentials(opt config.SecurityOption) (credentials.TransportCredentials, error) {
 	// Load certificate of the CA who signed client's certificate
-	pemClientCA, err := ioutil.ReadFile(opt.CACert)
+	pemClientCA, err := os.ReadFile(opt.CACert)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +300,7 @@ func (*clientDaemon) prepareTCPListener(opt config.ListenOption, withTLS bool) (
 	}
 	tlsConfig := opt.Security.TLSConfig
 	if opt.Security.CACert != "" {
-		caCert, err := ioutil.ReadFile(opt.Security.CACert)
+		caCert, err := os.ReadFile(opt.Security.CACert)
 		if err != nil {
 			return nil, -1, err
 		}

--- a/client/daemon/daemon_linux.go
+++ b/client/daemon/daemon_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/client/daemon/daemon_stub.go
+++ b/client/daemon/daemon_stub.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/client/daemon/peer/peertask_file_test.go
+++ b/client/daemon/peer/peertask_file_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -47,7 +46,7 @@ func TestFilePeerTask_BackSource_WithContentLength(t *testing.T) {
 	require := testifyrequire.New(t)
 	ctrl := gomock.NewController(t)
 
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -77,7 +76,7 @@ func TestFilePeerTask_BackSource_WithContentLength(t *testing.T) {
 
 	downloader := NewMockPieceDownloader(ctrl)
 	downloader.EXPECT().DownloadPiece(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(task *DownloadPieceRequest) (io.Reader, io.Closer, error) {
-		rc := ioutil.NopCloser(
+		rc := io.NopCloser(
 			bytes.NewBuffer(
 				testBytes[task.piece.RangeStart : task.piece.RangeStart+uint64(task.piece.RangeSize)],
 			))
@@ -98,7 +97,7 @@ func TestFilePeerTask_BackSource_WithContentLength(t *testing.T) {
 	sourceClient.EXPECT().Download(gomock.Any()).DoAndReturn(
 		func(request *source.Request) (io.ReadCloser, error) {
 			if request.URL.String() == url {
-				return ioutil.NopCloser(bytes.NewBuffer(testBytes)), nil
+				return io.NopCloser(bytes.NewBuffer(testBytes)), nil
 			}
 			return nil, fmt.Errorf("unexpect url: %s", request.URL.String())
 		})
@@ -162,7 +161,7 @@ func TestFilePeerTask_BackSource_WithContentLength(t *testing.T) {
 	assert.NotNil(p)
 	assert.True(p.PeerTaskDone)
 
-	outputBytes, err := ioutil.ReadFile(output)
+	outputBytes, err := os.ReadFile(output)
 	assert.Nil(err, "load output file")
 	assert.Equal(testBytes, outputBytes, "output and desired output must match")
 }
@@ -172,7 +171,7 @@ func TestFilePeerTask_BackSource_WithoutContentLength(t *testing.T) {
 	require := testifyrequire.New(t)
 	ctrl := gomock.NewController(t)
 
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -203,7 +202,7 @@ func TestFilePeerTask_BackSource_WithoutContentLength(t *testing.T) {
 	downloader := NewMockPieceDownloader(ctrl)
 	downloader.EXPECT().DownloadPiece(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
 		func(ctx context.Context, task *DownloadPieceRequest) (io.Reader, io.Closer, error) {
-			rc := ioutil.NopCloser(
+			rc := io.NopCloser(
 				bytes.NewBuffer(
 					testBytes[task.piece.RangeStart : task.piece.RangeStart+uint64(task.piece.RangeSize)],
 				))
@@ -223,7 +222,7 @@ func TestFilePeerTask_BackSource_WithoutContentLength(t *testing.T) {
 	sourceClient.EXPECT().Download(gomock.Any()).DoAndReturn(
 		func(request *source.Request) (io.ReadCloser, error) {
 			if request.URL.String() == url {
-				return ioutil.NopCloser(bytes.NewBuffer(testBytes)), nil
+				return io.NopCloser(bytes.NewBuffer(testBytes)), nil
 			}
 			return nil, fmt.Errorf("unexpect url: %s", request.URL.String())
 		})
@@ -287,7 +286,7 @@ func TestFilePeerTask_BackSource_WithoutContentLength(t *testing.T) {
 	assert.NotNil(p)
 	assert.True(p.PeerTaskDone)
 
-	outputBytes, err := ioutil.ReadFile(output)
+	outputBytes, err := os.ReadFile(output)
 	assert.Nil(err, "load output file")
 	assert.Equal(testBytes, outputBytes, "output and desired output must match")
 }

--- a/client/daemon/peer/peertask_manager.go
+++ b/client/daemon/peer/peertask_manager.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"time"
@@ -228,7 +227,7 @@ func (ptm *peerTaskManager) StartStreamPeerTask(ctx context.Context, req *schedu
 		ptm.storeTinyPeerTask(ctx, tiny)
 		logger.Infof("copied tasks data %d bytes to buffer", len(tiny.Content))
 		tiny.span.SetAttributes(config.AttributePeerTaskSuccess.Bool(true))
-		return ioutil.NopCloser(bytes.NewBuffer(tiny.Content)), map[string]string{
+		return io.NopCloser(bytes.NewBuffer(tiny.Content)), map[string]string{
 			headers.ContentLength: fmt.Sprintf("%d", len(tiny.Content)),
 		}, nil
 	}

--- a/client/daemon/peer/peertask_manager_test.go
+++ b/client/daemon/peer/peertask_manager_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -152,7 +151,7 @@ func setupPeerTaskManagerComponents(ctrl *gomock.Controller, opt componentsOptio
 		func(ctx context.Context, pr *scheduler.PeerResult, opts ...grpc.CallOption) error {
 			return nil
 		})
-	tempDir, _ := ioutil.TempDir("", "d7y-test-*")
+	tempDir, _ := os.MkdirTemp("", "d7y-test-*")
 	storageManager, _ := storage.NewStorageManager(
 		config.SimpleLocalTaskStoreStrategy,
 		&config.StorageOption{
@@ -169,7 +168,7 @@ func TestPeerTaskManager_StartFilePeerTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -200,7 +199,7 @@ func TestPeerTaskManager_StartFilePeerTask(t *testing.T) {
 	downloader.EXPECT().DownloadPiece(gomock.Any(), gomock.Any()).Times(
 		int(math.Ceil(float64(len(testBytes)) / float64(pieceSize)))).DoAndReturn(
 		func(ctx context.Context, task *DownloadPieceRequest) (io.Reader, io.Closer, error) {
-			rc := ioutil.NopCloser(
+			rc := io.NopCloser(
 				bytes.NewBuffer(
 					testBytes[task.piece.RangeStart : task.piece.RangeStart+uint64(task.piece.RangeSize)],
 				))
@@ -246,7 +245,7 @@ func TestPeerTaskManager_StartFilePeerTask(t *testing.T) {
 	assert.NotNil(p)
 	assert.True(p.PeerTaskDone)
 
-	outputBytes, err := ioutil.ReadFile(output)
+	outputBytes, err := os.ReadFile(output)
 	assert.Nil(err, "load output file")
 	assert.Equal(testBytes, outputBytes, "output and desired output must match")
 }
@@ -256,7 +255,7 @@ func TestPeerTaskManager_StartStreamPeerTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -282,7 +281,7 @@ func TestPeerTaskManager_StartStreamPeerTask(t *testing.T) {
 	downloader := NewMockPieceDownloader(ctrl)
 	downloader.EXPECT().DownloadPiece(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
 		func(ctx context.Context, task *DownloadPieceRequest) (io.Reader, io.Closer, error) {
-			rc := ioutil.NopCloser(
+			rc := io.NopCloser(
 				bytes.NewBuffer(
 					testBytes[task.piece.RangeStart : task.piece.RangeStart+uint64(task.piece.RangeSize)],
 				))
@@ -315,7 +314,7 @@ func TestPeerTaskManager_StartStreamPeerTask(t *testing.T) {
 	})
 	assert.Nil(err, "start stream peer task")
 
-	outputBytes, err := ioutil.ReadAll(r)
+	outputBytes, err := io.ReadAll(r)
 	assert.Nil(err, "load read data")
 	assert.Equal(testBytes, outputBytes, "output and desired output must match")
 }
@@ -325,7 +324,7 @@ func TestPeerTaskManager_StartStreamPeerTask_BackSource(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -388,7 +387,7 @@ func TestPeerTaskManager_StartStreamPeerTask_BackSource(t *testing.T) {
 	})
 	assert.Nil(err, "start stream peer task")
 
-	outputBytes, err := ioutil.ReadAll(r)
+	outputBytes, err := io.ReadAll(r)
 	assert.Nil(err, "load read data")
 	assert.Equal(testBytes, outputBytes, "output and desired output must match")
 }

--- a/client/daemon/peer/peertask_stream_test.go
+++ b/client/daemon/peer/peertask_stream_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -45,7 +45,7 @@ func TestStreamPeerTask_BackSource_WithContentLength(t *testing.T) {
 	require := testifyrequire.New(t)
 	ctrl := gomock.NewController(t)
 
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -73,7 +73,7 @@ func TestStreamPeerTask_BackSource_WithContentLength(t *testing.T) {
 	downloader := NewMockPieceDownloader(ctrl)
 	downloader.EXPECT().DownloadPiece(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
 		func(ctx context.Context, task *DownloadPieceRequest) (io.Reader, io.Closer, error) {
-			rc := ioutil.NopCloser(
+			rc := io.NopCloser(
 				bytes.NewBuffer(
 					testBytes[task.piece.RangeStart : task.piece.RangeStart+uint64(task.piece.RangeSize)],
 				))
@@ -92,7 +92,7 @@ func TestStreamPeerTask_BackSource_WithContentLength(t *testing.T) {
 		})
 	sourceClient.EXPECT().Download(source.RequestEq(request.URL.String())).DoAndReturn(
 		func(request *source.Request) (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewBuffer(testBytes)), nil
+			return io.NopCloser(bytes.NewBuffer(testBytes)), nil
 		})
 
 	ptm := &peerTaskManager{
@@ -145,7 +145,7 @@ func TestStreamPeerTask_BackSource_WithContentLength(t *testing.T) {
 	rc, _, err := pt.Start(ctx)
 	assert.Nil(err, "start stream peer task")
 
-	outputBytes, err := ioutil.ReadAll(rc)
+	outputBytes, err := io.ReadAll(rc)
 	assert.Nil(err, "load read data")
 	assert.Equal(testBytes, outputBytes, "output and desired output must match")
 }
@@ -155,7 +155,7 @@ func TestStreamPeerTask_BackSource_WithoutContentLength(t *testing.T) {
 	require := testifyrequire.New(t)
 	ctrl := gomock.NewController(t)
 
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -183,7 +183,7 @@ func TestStreamPeerTask_BackSource_WithoutContentLength(t *testing.T) {
 	downloader := NewMockPieceDownloader(ctrl)
 	downloader.EXPECT().DownloadPiece(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
 		func(ctx context.Context, task *DownloadPieceRequest) (io.Reader, io.Closer, error) {
-			rc := ioutil.NopCloser(
+			rc := io.NopCloser(
 				bytes.NewBuffer(
 					testBytes[task.piece.RangeStart : task.piece.RangeStart+uint64(task.piece.RangeSize)],
 				))
@@ -202,7 +202,7 @@ func TestStreamPeerTask_BackSource_WithoutContentLength(t *testing.T) {
 		})
 	sourceClient.EXPECT().Download(source.RequestEq(request.URL.String())).DoAndReturn(
 		func(request *source.Request) (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewBuffer(testBytes)), nil
+			return io.NopCloser(bytes.NewBuffer(testBytes)), nil
 		})
 
 	ptm := &peerTaskManager{
@@ -255,7 +255,7 @@ func TestStreamPeerTask_BackSource_WithoutContentLength(t *testing.T) {
 	rc, _, err := pt.Start(ctx)
 	assert.Nil(err, "start stream peer task")
 
-	outputBytes, err := ioutil.ReadAll(rc)
+	outputBytes, err := io.ReadAll(rc)
 	assert.Nil(err, "load read data")
 	assert.Equal(testBytes, outputBytes, "output and desired output must match")
 }

--- a/client/daemon/peer/piece_downloader.go
+++ b/client/daemon/peer/piece_downloader.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
@@ -101,7 +100,7 @@ func (p *pieceDownloader) DownloadPiece(ctx context.Context, d *DownloadPieceReq
 		return nil, nil, err
 	}
 	if resp.StatusCode > 299 {
-		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		return nil, nil, fmt.Errorf("download piece failed with http code: %s", resp.Status)
 	}

--- a/client/daemon/peer/piece_downloader_test.go
+++ b/client/daemon/peer/piece_downloader_test.go
@@ -21,11 +21,12 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -47,7 +48,7 @@ func TestPieceDownloader_DownloadPiece(t *testing.T) {
 	source.UnRegister("http")
 	require.Nil(t, source.Register("http", httpprotocol.NewHTTPSourceClient(), httpprotocol.Adapter))
 	defer source.UnRegister("http")
-	testData, err := ioutil.ReadFile(test.File)
+	testData, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 	pieceDownloadTimeout := 30 * time.Second
 
@@ -152,7 +153,7 @@ func TestPieceDownloader_DownloadPiece(t *testing.T) {
 			})
 			assert.Nil(err, "downloaded piece should success")
 
-			data, err := ioutil.ReadAll(r)
+			data, err := io.ReadAll(r)
 			assert.Nil(err, "read piece data should success")
 			c.Close()
 

--- a/client/daemon/peer/piece_manager_test.go
+++ b/client/daemon/peer/piece_manager_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -53,7 +52,7 @@ func TestPieceManager_DownloadSource(t *testing.T) {
 	source.UnRegister("http")
 	require.Nil(t, source.Register("http", httpprotocol.NewHTTPSourceClient(), httpprotocol.Adapter))
 	defer source.UnRegister("http")
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var (
@@ -63,11 +62,10 @@ func TestPieceManager_DownloadSource(t *testing.T) {
 	)
 
 	pieceDownloadTimeout := 30 * time.Second
-	tempDir, _ := ioutil.TempDir("", "d7y-piece-manager-test-*")
 	storageManager, _ := storage.NewStorageManager(
 		config.SimpleLocalTaskStoreStrategy,
 		&config.StorageOption{
-			DataPath: tempDir,
+			DataPath: t.TempDir(),
 			TaskExpireTime: clientutil.Duration{
 				Duration: -1 * time.Second,
 			},
@@ -219,7 +217,7 @@ func TestPieceManager_DownloadSource(t *testing.T) {
 				})
 			assert.Nil(err)
 
-			outputBytes, err := ioutil.ReadFile(output)
+			outputBytes, err := os.ReadFile(output)
 			assert.Nil(err, "load output file")
 			assert.Equal(testBytes, outputBytes, "output and desired output must match")
 		})

--- a/client/daemon/storage/local_storage.go
+++ b/client/daemon/storage/local_storage.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -71,7 +70,7 @@ func (t *localTaskStore) WritePiece(ctx context.Context, req *WritePieceRequest)
 	if piece, ok := t.Pieces[req.Num]; ok {
 		t.RUnlock()
 		// discard data for back source
-		n, err := io.Copy(ioutil.Discard, io.LimitReader(req.Reader, req.Range.Length))
+		n, err := io.Copy(io.Discard, io.LimitReader(req.Reader, req.Range.Length))
 		if err != nil && err != io.EOF {
 			return n, err
 		}
@@ -394,7 +393,7 @@ func (t *localTaskStore) Reclaim() error {
 	t.Infof("purged task work directory: %s", t.dataDir)
 
 	taskDir := path.Dir(t.dataDir)
-	if dirs, err := ioutil.ReadDir(taskDir); err != nil {
+	if dirs, err := os.ReadDir(taskDir); err != nil {
 		t.Warnf("stat task directory %q error: %s", taskDir, err)
 	} else {
 		if len(dirs) == 0 {

--- a/client/daemon/storage/local_storage_test.go
+++ b/client/daemon/storage/local_storage_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -46,7 +45,7 @@ func TestMain(m *testing.M) {
 
 func TestLocalTaskStore_PutAndGetPiece_Simple(t *testing.T) {
 	assert := testifyassert.New(t)
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	dst := path.Join(test.DataDir, taskData+".copy")
@@ -155,7 +154,7 @@ func TestLocalTaskStore_PutAndGetPiece_Simple(t *testing.T) {
 			},
 		})
 		assert.Nil(err, "get piece should be ok")
-		data, err := ioutil.ReadAll(rd)
+		data, err := io.ReadAll(rd)
 		cl.Close()
 		assert.Nil(err, "read piece should be ok")
 		assert.Equal(p.end-p.start, len(data), "piece length should match")
@@ -177,7 +176,7 @@ func TestLocalTaskStore_StoreTaskData_Simple(t *testing.T) {
 	meta := path.Join(test.DataDir, taskData+".meta")
 	// prepare test data
 	testData := []byte("test data")
-	err := ioutil.WriteFile(src, testData, defaultFileMode)
+	err := os.WriteFile(src, testData, defaultFileMode)
 	assert.Nil(err, "prepare test data")
 	defer os.Remove(src)
 	defer os.Remove(dst)
@@ -207,7 +206,7 @@ func TestLocalTaskStore_StoreTaskData_Simple(t *testing.T) {
 		},
 	})
 	assert.Nil(err, "store test data")
-	bs, err := ioutil.ReadFile(dst)
+	bs, err := os.ReadFile(dst)
 	assert.Nil(err, "read output test data")
 	assert.Equal(testData, bs, "data must match")
 }
@@ -218,7 +217,7 @@ func TestLocalTaskStore_ReloadPersistentTask_Simple(t *testing.T) {
 
 func TestLocalTaskStore_PutAndGetPiece_Advance(t *testing.T) {
 	assert := testifyassert.New(t)
-	testBytes, err := ioutil.ReadFile(test.File)
+	testBytes, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	dst := path.Join(test.DataDir, taskData+".copy")
@@ -328,7 +327,7 @@ func TestLocalTaskStore_PutAndGetPiece_Advance(t *testing.T) {
 			},
 		})
 		assert.Nil(err, "get piece should be ok")
-		data, err := ioutil.ReadAll(rd)
+		data, err := io.ReadAll(rd)
 		cl.Close()
 		assert.Nil(err, "read piece should be ok")
 		assert.Equal(p.end-p.start, len(data), "piece length should match")

--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -466,7 +465,7 @@ func (s *storageManager) IsInvalid(req *PeerTaskMetadata) (bool, error) {
 }
 
 func (s *storageManager) ReloadPersistentTask(gcCallback GCCallback) error {
-	dirs, err := ioutil.ReadDir(s.storeOption.DataPath)
+	dirs, err := os.ReadDir(s.storeOption.DataPath)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -479,7 +478,7 @@ func (s *storageManager) ReloadPersistentTask(gcCallback GCCallback) error {
 	)
 	for _, dir := range dirs {
 		taskID := dir.Name()
-		peerDirs, err := ioutil.ReadDir(path.Join(s.storeOption.DataPath, taskID))
+		peerDirs, err := os.ReadDir(path.Join(s.storeOption.DataPath, taskID))
 		if err != nil {
 			continue
 		}
@@ -502,7 +501,7 @@ func (s *storageManager) ReloadPersistentTask(gcCallback GCCallback) error {
 					Warnf("open task metadata error: %s", err)
 				continue
 			}
-			bytes, err0 := ioutil.ReadAll(t.metadataFile)
+			bytes, err0 := io.ReadAll(t.metadataFile)
 			if err0 != nil {
 				loadErrs = append(loadErrs, err0)
 				loadErrDirs = append(loadErrDirs, dataDir)

--- a/client/daemon/transport/transport_test.go
+++ b/client/daemon/transport/transport_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -40,7 +39,7 @@ func TestMain(m *testing.M) {
 func TestTransport_RoundTrip(t *testing.T) {
 	assert := testifyassert.New(t)
 	ctrl := gomock.NewController(t)
-	testData, err := ioutil.ReadFile(test.File)
+	testData, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	var url = "http://x/y"
@@ -48,7 +47,7 @@ func TestTransport_RoundTrip(t *testing.T) {
 	peerTaskManager.EXPECT().StartStreamPeerTask(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, req *scheduler.PeerTaskRequest) (io.ReadCloser, map[string]string, error) {
 			assert.Equal(req.Url, url)
-			return ioutil.NopCloser(bytes.NewBuffer(testData)), nil, nil
+			return io.NopCloser(bytes.NewBuffer(testData)), nil, nil
 		},
 	)
 	rt, _ := New(
@@ -65,7 +64,7 @@ func TestTransport_RoundTrip(t *testing.T) {
 		return
 	}
 	defer resp.Body.Close()
-	output, err := ioutil.ReadAll(resp.Body)
+	output, err := io.ReadAll(resp.Body)
 	assert.Nil(err)
 	if err != nil {
 		return

--- a/client/daemon/upload/upload_manager_test.go
+++ b/client/daemon/upload/upload_manager_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -46,14 +45,14 @@ func TestUploadManager_Serve(t *testing.T) {
 	defer ctrl.Finish()
 
 	assert := testifyassert.New(t)
-	testData, err := ioutil.ReadFile(test.File)
+	testData, err := os.ReadFile(test.File)
 	assert.Nil(err, "load test file")
 
 	mockStorageManager := mock_storage.NewMockManager(ctrl)
 	mockStorageManager.EXPECT().ReadPiece(gomock.Any(), gomock.Any()).AnyTimes().
 		DoAndReturn(func(ctx context.Context, req *storage.ReadPieceRequest) (io.Reader, io.Closer, error) {
 			return bytes.NewBuffer(testData[req.Range.Start : req.Range.Start+req.Range.Length]),
-				ioutil.NopCloser(nil), nil
+				io.NopCloser(nil), nil
 		})
 
 	um, err := NewUploadManager(mockStorageManager, WithLimiter(rate.NewLimiter(16*1024, 16*1024)))
@@ -103,7 +102,7 @@ func TestUploadManager_Serve(t *testing.T) {
 		resp, err := http.DefaultClient.Do(req)
 		assert.Nil(err, "get piece data")
 
-		data, _ := ioutil.ReadAll(resp.Body)
+		data, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		assert.Equal(tt.targetPieceData, data)
 	}

--- a/client/dfget/dfget.go
+++ b/client/dfget/dfget.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,7 +141,7 @@ func downloadFromSource(ctx context.Context, cfg *config.DfgetConfig, hdr map[st
 	wLog.Info("try to download from source and ignore rate limit")
 	fmt.Println("try to download from source and ignore rate limit")
 
-	if target, err = ioutil.TempFile(filepath.Dir(cfg.Output), ".df_"); err != nil {
+	if target, err = os.CreateTemp(filepath.Dir(cfg.Output), ".df_"); err != nil {
 		return err
 	}
 	defer os.Remove(target.Name())

--- a/client/dfget/dfget_test.go
+++ b/client/dfget/dfget_test.go
@@ -18,7 +18,7 @@ package dfget
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +56,7 @@ func Test_downloadFromSource(t *testing.T) {
 	}
 	request, err := source.NewRequest(cfg.URL)
 	assert.Nil(t, err)
-	sourceClient.EXPECT().Download(request).Return(ioutil.NopCloser(strings.NewReader(content)), nil)
+	sourceClient.EXPECT().Download(request).Return(io.NopCloser(strings.NewReader(content)), nil)
 
 	err = downloadFromSource(context.Background(), cfg, nil)
 	assert.Nil(t, err)

--- a/cmd/dependency/plugin_cmd.go
+++ b/cmd/dependency/plugin_cmd.go
@@ -19,7 +19,6 @@ package dependency
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -48,7 +47,7 @@ func ListAvailablePlugins() {
 	}
 
 	fmt.Fprintf(os.Stderr, "search plugin in %s\n", d.PluginDir())
-	files, err := ioutil.ReadDir(d.PluginDir())
+	files, err := os.ReadDir(d.PluginDir())
 	if os.IsNotExist(err) {
 		fmt.Fprintf(os.Stderr, "no plugin found\n")
 		return

--- a/docs/en/developer-guide/plugin.md
+++ b/docs/en/developer-guide/plugin.md
@@ -55,7 +55,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"d7y.io/dragonfly/v2/pkg/source"
@@ -88,11 +87,11 @@ func (c *client) IsExpired(ctx context.Context, url string, header source.Reques
 }
 
 func (c *client) Download(ctx context.Context, url string, header source.RequestHeader, rang *rangeutils.Range) (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewBufferString(data)), nil
+	return io.NopCloser(bytes.NewBufferString(data)), nil
 }
 
 func (c *client) DownloadWithResponseHeader(ctx context.Context, url string, header source.RequestHeader, rang *rangeutils.Range) (io.ReadCloser, source.ResponseHeader, error) {
-	return ioutil.NopCloser(bytes.NewBufferString(data)), map[string]string{}, nil
+	return io.NopCloser(bytes.NewBufferString(data)), map[string]string{}, nil
 }
 
 func (c *client) GetLastModifiedMillis(ctx context.Context, url string, header source.RequestHeader) (int64, error) {

--- a/internal/dynconfig/dynconfig_local.go
+++ b/internal/dynconfig/dynconfig_local.go
@@ -17,7 +17,7 @@
 package dynconfig
 
 import (
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -38,7 +38,7 @@ func newDynconfigLocal(path string) (*dynconfigLocal, error) {
 // Unmarshal unmarshals the config into a Struct. Make sure that the tags
 // on the fields of the structure are properly set.
 func (d *dynconfigLocal) Unmarshal(rawVal interface{}) error {
-	b, err := ioutil.ReadFile(d.filepath)
+	b, err := os.ReadFile(d.filepath)
 	if err != nil {
 		return err
 	}

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -17,7 +17,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
@@ -76,7 +76,7 @@ func TestManagerConfig_Load(t *testing.T) {
 	}
 
 	managerConfigYAML := &Config{}
-	contentYAML, _ := ioutil.ReadFile("./testdata/manager.yaml")
+	contentYAML, _ := os.ReadFile("./testdata/manager.yaml")
 	var dataYAML map[string]interface{}
 	if err := yaml.Unmarshal(contentYAML, &dataYAML); err != nil {
 		t.Fatal(err)

--- a/manager/job/preheat.go
+++ b/manager/job/preheat.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -230,7 +230,7 @@ func (p *preheat) getManifests(ctx context.Context, url string, header http.Head
 }
 
 func (p *preheat) parseLayers(resp *http.Response, url, filter string, header http.Header, image *preheatImage) ([]*internaljob.PreheatRequest, error) {
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func getAuthToken(ctx context.Context, header http.Header) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	var result map[string]interface{}
 	if err := json.Unmarshal(body, &result); err != nil {
 		return "", err

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -18,7 +18,7 @@ package cache
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -331,7 +331,7 @@ func TestFileSerialization(t *testing.T) {
 		t.Error(err)
 	}
 
-	f, err := ioutil.TempFile("", "go-cache-cache.dat")
+	f, err := os.CreateTemp("", "go-cache-cache.dat")
 	if err != nil {
 		t.Fatal("Couldn't create cache file:", err)
 	}

--- a/pkg/source/hdfsprotocol/hdfs_source_client_test.go
+++ b/pkg/source/hdfsprotocol/hdfs_source_client_test.go
@@ -21,7 +21,6 @@ package hdfsprotocol
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -231,7 +230,7 @@ func Test_Download_FileExist_ByRange(t *testing.T) {
 
 	download, err := sourceClient.Download(request)
 	assert.Nil(t, err)
-	data, _ := ioutil.ReadAll(download)
+	data, _ := io.ReadAll(download)
 
 	assert.Equal(t, hdfsExistFileContent, string(data))
 }
@@ -290,7 +289,7 @@ func Test_DownloadWithResponseHeader_FileExist_ByRange(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, hdfsExistFileLastModified, expireInfo.LastModified)
 
-	data, _ := ioutil.ReadAll(body)
+	data, _ := io.ReadAll(body)
 	assert.Equal(t, string(data), string([]byte(hdfsExistFileContent)[hdfsExistFileRangeStart:hdfsExistFileRangeEnd]))
 }
 

--- a/pkg/source/httpprotocol/http_source_client_test.go
+++ b/pkg/source/httpprotocol/http_source_client_test.go
@@ -19,7 +19,7 @@ package httpprotocol
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -208,7 +208,7 @@ func (suite *HTTPSourceClientTestSuite) TestHttpSourceClientDownloadWithResponse
 				suite.True(tt.wantErr.Error() == err.Error())
 				return
 			}
-			bytes, err := ioutil.ReadAll(reader)
+			bytes, err := io.ReadAll(reader)
 			suite.Nil(err)
 			suite.Equal(tt.content, string(bytes))
 			suite.Equal(tt.expireInfo, expireInfo)
@@ -325,7 +325,7 @@ func (suite *HTTPSourceClientTestSuite) TestHttpSourceClientDoRequest() {
 	suite.Nil(err)
 	res, err := suite.httpClient.doRequest(http.MethodGet, request)
 	suite.Nil(err)
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	suite.Nil(err)
 	suite.EqualValues("ok", string(bytes))
 }

--- a/pkg/source/testdata/main.go
+++ b/pkg/source/testdata/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"d7y.io/dragonfly/v2/pkg/source"
@@ -45,7 +45,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	if err != nil {
 		fmt.Printf("read error: %s\n", err)
 		os.Exit(1)

--- a/pkg/source/testdata/plugin/dfs.go
+++ b/pkg/source/testdata/plugin/dfs.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"d7y.io/dragonfly/v2/pkg/source"
 )
@@ -44,11 +43,11 @@ func (c *client) IsExpired(request *source.Request, info *source.ExpireInfo) (bo
 }
 
 func (c *client) Download(request *source.Request) (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewBufferString(data)), nil
+	return io.NopCloser(bytes.NewBufferString(data)), nil
 }
 
 func (c *client) DownloadWithExpireInfo(request *source.Request) (io.ReadCloser, *source.ExpireInfo, error) {
-	return ioutil.NopCloser(bytes.NewBufferString(data)), nil, nil
+	return io.NopCloser(bytes.NewBufferString(data)), nil, nil
 }
 
 func (c *client) GetLastModified(request *source.Request) (int64, error) {

--- a/pkg/util/digestutils/digest_reader_test.go
+++ b/pkg/util/digestutils/digest_reader_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestNewDigestReader(t *testing.T) {
 
 	buf := bytes.NewBuffer(testBytes)
 	reader := NewDigestReader(logger.With("test", "test"), buf, digest)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 
 	assert.Nil(err)
 	assert.Equal(testBytes, data)

--- a/pkg/util/fileutils/test/file_utils_test.go
+++ b/pkg/util/fileutils/test/file_utils_test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -49,7 +48,7 @@ func Test(t *testing.T) {
 }
 
 func (s *FileUtilsTestSuite) SetupSuite() {
-	s.workDir, _ = ioutil.TempDir(basic.TmpDir, "DF-FileUtilsTestSuite-")
+	s.workDir, _ = os.MkdirTemp(basic.TmpDir, "DF-FileUtilsTestSuite-")
 	s.username = basic.Username
 }
 
@@ -154,7 +153,7 @@ func (s *FileUtilsTestSuite) TestCopyFile() {
 	_, err = filerw.CopyFile(s.testFile, s.testFile+".new")
 	s.Require().Nil(err)
 
-	content, err := ioutil.ReadFile(s.testFile + ".new")
+	content, err := os.ReadFile(s.testFile + ".new")
 	s.Require().Nil(err)
 	s.Require().Equal("hello,world", string(content))
 }

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -17,7 +17,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -79,7 +79,7 @@ func TestSchedulerConfig_Load(t *testing.T) {
 	}
 
 	schedulerConfigYAML := &Config{}
-	contentYAML, _ := ioutil.ReadFile("./testdata/scheduler.yaml")
+	contentYAML, _ := os.ReadFile("./testdata/scheduler.yaml")
 	var dataYAML map[string]interface{}
 	if err := yaml.Unmarshal(contentYAML, &dataYAML); err != nil {
 		t.Fatal(err)

--- a/scheduler/config/dynconfig.go
+++ b/scheduler/config/dynconfig.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -223,7 +222,7 @@ func (d *dynconfig) Get() (*DynconfigData, error) {
 }
 
 func (d *dynconfig) getCDNFromDirPath() ([]*CDN, error) {
-	files, err := ioutil.ReadDir(d.cdnDirPath)
+	files, err := os.ReadDir(d.cdnDirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +235,7 @@ func (d *dynconfig) getCDNFromDirPath() ([]*CDN, error) {
 		}
 
 		p := filepath.Join(d.cdnDirPath, file.Name())
-		if file.Mode()&os.ModeSymlink != 0 {
+		if file.Type()&os.ModeSymlink != 0 {
 			stat, err := os.Stat(p)
 			if err != nil {
 				logger.Errorf("stat %s error: %s", file.Name(), err)
@@ -247,7 +246,7 @@ func (d *dynconfig) getCDNFromDirPath() ([]*CDN, error) {
 				continue
 			}
 		}
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		if err != nil {
 			return nil, err
 		}

--- a/scheduler/config/dynconfig_test.go
+++ b/scheduler/config/dynconfig_test.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,10 +32,7 @@ import (
 )
 
 func TestDynconfigGet_ManagerSourceType(t *testing.T) {
-	mockCacheDir, err := ioutil.TempDir("", "dragonfly-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockCacheDir := t.TempDir()
 
 	mockCachePath := filepath.Join(mockCacheDir, cacheFileName)
 	tests := []struct {
@@ -139,10 +135,7 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 }
 
 func TestDynconfigGet_LocalSourceType(t *testing.T) {
-	mockCacheDir, err := ioutil.TempDir("", "dragonfly-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockCacheDir := t.TempDir()
 
 	tests := []struct {
 		name       string
@@ -197,10 +190,7 @@ func TestDynconfigGet_LocalSourceType(t *testing.T) {
 }
 
 func TestDynconfigGetCDNFromDirPath(t *testing.T) {
-	mockCacheDir, err := ioutil.TempDir("", "dragonfly-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mockCacheDir := t.TempDir()
 
 	tests := []struct {
 		name       string

--- a/scheduler/supervisor/cdn.go
+++ b/scheduler/supervisor/cdn.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"sync"
@@ -235,7 +234,7 @@ func downloadTinyFile(ctx context.Context, task *Task, cdnHost *Host) ([]byte, e
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/scheduler/supervisor/cdn_test.go
+++ b/scheduler/supervisor/cdn_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -471,7 +470,7 @@ func TestCDN_Initial(t *testing.T) {
 
 				const testwords string = "dragonfly-scheduler-test"
 				res := &http.Response{
-					Body: ioutil.NopCloser(
+					Body: io.NopCloser(
 						bytes.NewBuffer([]byte(testwords))),
 				}
 				httpRet := []gomonkey.OutputCell{

--- a/test/tools/stress/main.go
+++ b/test/tools/stress/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -166,7 +165,7 @@ func process(ctx context.Context, wg *sync.WaitGroup, result chan *Result) {
 			continue
 		}
 		var msg string
-		n, err := io.Copy(ioutil.Discard, resp.Body)
+		n, err := io.Copy(io.Discard, resp.Body)
 		if err != nil {
 			msg = err.Error()
 			log.Printf("discard data error: %s", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces two small changes:

1. Synchronizes `//go:build` lines with `// +build` lines by running `go fmt ./...`. 

2. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.
    - `ioutil.Discard` => `io.Discard`
    - `ioutil.NopCloser` => `io.NopCloser`
    - `ioutil.ReadAll` => `io.ReadAll`
    - `ioutil.ReadDir` => `os.ReadDir`
    - `ioutil.ReadFile` => `os.ReadFile`
    - `ioutil.TempDir` => `os.MkdirTemp`
    - `ioutil.TempFile` => `os.CreateTemp`
    - `ioutil.WriteFile` => `os.WriteFile`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

While the `io/ioutil` package is still usable under the Go 1 compatibility promise, we shall start using the new definitions in `io` and `os` packages for code consistency in the future.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
