### PR TITLE
fix: use 'parent' as mainPeer in PeerPacket in removePeerFromCurrentTree()

### DIFF
--- a/scheduler/core/events.go
+++ b/scheduler/core/events.go
@@ -420,7 +420,7 @@ func removePeerFromCurrentTree(peer *supervisor.Peer, s *state) {
 	if ok {
 		children := s.sched.ScheduleChildren(parent, sets.NewString(peer.ID))
 		for _, child := range children {
-			if err := child.SendSchedulePacket(constructSuccessPeerPacket(child, peer, nil)); err != nil {
+			if err := child.SendSchedulePacket(constructSuccessPeerPacket(child, parent, nil)); err != nil {
 				sendErrorHandler(err, s, child)
 			}
 		}


### PR DESCRIPTION

We've removed 'peer' from current tree, and ScheduleChildren() set
'parent' as parent of peers in 'children', so we should inform children
that 'parent' is the destination peer, not the removed 'peer'.

Fixes: #956
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
