### PR TITLE
Add useProxies to registryMirror allowing to mirror more than docker registries

### DIFF
--- a/cdn/config/old_config.go
+++ b/cdn/config/old_config.go
@@ -232,7 +232,7 @@ func NewDefaultBaseProperties() *BaseProperties {
 		},
 		Host: HostConfig{},
 		Metrics: &RestConfig{
-			Addr: ":8080",
+			Addr: ":8000",
 		},
 	}
 }

--- a/cdn/metrics/config.go
+++ b/cdn/metrics/config.go
@@ -38,7 +38,7 @@ func (c Config) applyDefaults() Config {
 		c.Net = DefaultNetwork
 	}
 	if c.Addr == "" {
-		c.Addr = ":8080"
+		c.Addr = ":8000"
 	}
 	return c
 }

--- a/client/config/peerhost.go
+++ b/client/config/peerhost.go
@@ -527,6 +527,9 @@ type RegistryMirror struct {
 
 	// Request the remote registry directly.
 	Direct bool `yaml:"direct" mapstructure:"direct"`
+
+	// Whether to use proxies to decide when to use dragonfly
+	UseProxies bool `yaml:"useProxies" mapstructure:"useProxies"`
 }
 
 // TLSConfig returns the tls.Config used to communicate with the mirror.

--- a/client/daemon/proxy/proxy.go
+++ b/client/daemon/proxy/proxy.go
@@ -556,7 +556,14 @@ func (proxy *Proxy) shouldUseDragonfly(req *http.Request) bool {
 // shouldUseDragonflyForMirror returns whether we should use dragonfly to proxy a request
 // when we use registry mirror.
 func (proxy *Proxy) shouldUseDragonflyForMirror(req *http.Request) bool {
-	return proxy.registry != nil && !proxy.registry.Direct && transport.NeedUseDragonfly(req)
+	if proxy.registry == nil || proxy.registry.Direct {
+		return false
+	}
+	if proxy.registry.UseProxies {
+		return proxy.shouldUseDragonfly(req)
+	} else {
+		return transport.NeedUseDragonfly(req)
+	}
 }
 
 // tunnelHTTPS handles a CONNECT request and proxy an https request through an

--- a/client/daemon/proxy/proxy.go
+++ b/client/daemon/proxy/proxy.go
@@ -269,8 +269,11 @@ func (proxy *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// check direct request
+	directRequest := r.Method != http.MethodConnect && r.URL.Scheme == ""
+
 	// check whiteList
-	if !proxy.checkWhiteList(r) {
+	if !directRequest && !proxy.checkWhiteList(r) {
 		status := http.StatusUnauthorized
 		http.Error(w, http.StatusText(status), status)
 		logger.Debugf("not in whitelist: %s, url：%s", r.Host, r.URL.String())

--- a/docs/en/deployment/configuration/dfget.yaml
+++ b/docs/en/deployment/configuration/dfget.yaml
@@ -221,6 +221,8 @@ proxy:
     certs: []
     # whether to request the remote registry directly
     direct: false
+    # whether to use proxies to decide if dragonfly should be used
+    useProxies: false
 
   proxies:
     # proxy all http image layer download requests with dfget

--- a/docs/zh-CN/deployment/configuration/dfget.yaml
+++ b/docs/zh-CN/deployment/configuration/dfget.yaml
@@ -194,6 +194,8 @@ proxy:
     certs: []
     # 是否直连镜像中心，true 的话，流量不再走 p2p
     direct: false
+    # whether to use proxies to decide if dragonfly should be used
+    useProxies: false
 
   proxies:
     # 代理镜像 blobs 信息

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,7 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=

--- a/test/e2e/dfget_test.go
+++ b/test/e2e/dfget_test.go
@@ -42,6 +42,29 @@ var _ = Describe("Download with dfget and proxy", func() {
 	})
 })
 
+var _ = AfterSuite(func() {
+	// copy log files to artifact directory
+	for i := 0; i < 3; i++ {
+		out, err := e2eutil.KubeCtlCommand("-n", dragonflyE2ENamespace, "get", "pod", "-l", fmt.Sprintf("statefulset.kubernetes.io/pod-name=proxy-%d", i),
+			"-o", "jsonpath='{range .items[*]}{.metadata.name}{end}'").CombinedOutput()
+		if err != nil {
+			fmt.Printf("get pod error: %s\n", err)
+			continue
+		}
+		podName := strings.Trim(string(out), "'")
+		pod := e2eutil.NewPodExec(dragonflyE2ENamespace, podName, "proxy")
+
+		out, err = pod.Command("sh", "-c", fmt.Sprintf(`
+              set -x
+              cp /var/log/dragonfly/daemon/core.log /tmp/artifact/daemon/proxy-%d-core.log
+              cp /var/log/dragonfly/daemon/grpc.log /tmp/artifact/daemon/proxy-%d-grpc.log
+              `, i, i)).CombinedOutput()
+		if err != nil {
+			fmt.Printf("copy log output: %s, error: %s\n", string(out), err)
+		}
+	}
+})
+
 func singleDfgetTest(name, ns, label, podNamePrefix, container string) {
 	It(name, func() {
 		out, err := e2eutil.KubeCtlCommand("-n", ns, "get", "pod", "-l", label,

--- a/test/testdata/k8s/proxy.yaml
+++ b/test/testdata/k8s/proxy.yaml
@@ -66,8 +66,8 @@ data:
         insecure: false
         url: https://index.docker.io
       proxies:
-        - regx: blobs/sha256.*
-        - regx: file-server
+      - regx: blobs/sha256.*
+      - regx: file-server
 
 ---
 
@@ -116,16 +116,21 @@ spec:
         volumeMounts:
         - mountPath: /etc/dragonfly
           name: config
-        - mountPath: /var/log/dragonfly/daemon
+        - mountPath: /var/log/dragonfly/
           name: logs
-        - mountPath: /root/.dragonfly/dfget-daemon/
+        - mountPath: /var/lib/dragonfly/
           name: data
+        - mountPath: /tmp/artifact
+          name: artifact
       volumes:
-      - configMap:
-          defaultMode: 420
+      - name: config
+        configMap:
           name: proxy
-        name: config
-      - emptyDir: {}
-        name: data
-      - emptyDir: {}
-        name: logs
+          defaultMode: 420
+      - name: data
+        emptyDir: { }
+      - name: logs
+        emptyDir: { }
+      - name: artifact
+        hostPath:
+          path: /tmp/artifact


### PR DESCRIPTION
## Description

Add a new field in registryMirror, allowing to use proxies list to decide whether to use dragonfly.
By doing this, it is now possible to cache more than only `blobs/sha256` urls, allowing to use dragonfly2 for other usage thatn docker registries, like yum repositories.

Also fix the whiteList test which is tested on direct request, although host is empty and canno tbe tested.

Please update the documentation in Chinese, I just can't do it.

## Related Issue

#959

## Motivation and Context

This PR now allows to use dragonfly to mirror yum repositories, at least.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist:

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
