### PR TITLE
feat: improve redirect to allow url rewrite

### DIFF
--- a/client/daemon/proxy/proxy.go
+++ b/client/daemon/proxy/proxy.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -546,7 +547,16 @@ func (proxy *Proxy) shouldUseDragonfly(req *http.Request) bool {
 			if rule.UseHTTPS {
 				req.URL.Scheme = schemaHTTPS
 			}
-			if rule.Redirect != "" {
+			if strings.Contains(rule.Redirect, "/") {
+				u, err := url.Parse(rule.Regx.ReplaceAllString(req.URL.String(), rule.Redirect))
+				if err != nil {
+					logger.Errorf("failed to rewrite url", err)
+					return false
+				}
+				req.URL = u
+				req.Host = req.URL.Host
+				req.RequestURI = req.URL.RequestURI()
+			} else if rule.Redirect != "" {
 				req.URL.Host = rule.Redirect
 				req.Host = rule.Redirect
 			}

--- a/docs/en/deployment/configuration/dfget.yaml
+++ b/docs/en/deployment/configuration/dfget.yaml
@@ -236,6 +236,9 @@ proxy:
     # proxy requests with redirect
     - regx: some-registry
       redirect: another-registry
+    # the same with url rewrite like apache ProxyPass directive
+    - regx: ^http://some-registry/(.*)
+      redirect: http://another-registry/$1
 
   hijackHTTPS:
     # key pair used to hijack https requests

--- a/docs/zh-CN/deployment/configuration/dfget.yaml
+++ b/docs/zh-CN/deployment/configuration/dfget.yaml
@@ -209,6 +209,9 @@ proxy:
     # 转发流量到指定地址
     - regx: some-registry
       redirect: another-registry
+    # the same with url rewrite like apache ProxyPass directive
+    - regx: ^http://some-registry/(.*)
+      redirect: http://another-registry/$1
 
   hijackHTTPS:
     # https 劫持的证书和密钥


### PR DESCRIPTION
Signed-off-by: momiji <teq1uila-free01@yahoo.fr>

Improve redirect usage to allow rewriting url in direct and proxy mode.

## Description

When redirect contains a `/`, it is considered as an rewrite url instead of a hostname replacement.
Rewrite is similar to apache ProxyPass directive everybody is used to.

## Related Issue

#959 

## Motivation and Context

With full url rewrite, it is now possible to completely change url and not only hostname.
It also applies to direct mode when useProxies is set, allowing to serve multiple (registry) mirrors based on the url.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
