### PR TITLE
fix: total pieces count not set cause digest invalid

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -416,8 +416,8 @@ func (pt *peerTaskConductor) storeTinyPeerTask() {
 			},
 			UnknownLength: false,
 			Reader:        bytes.NewBuffer(pt.tinyData.Content),
-			GenPieceDigest: func(n int64) bool {
-				return true
+			GenPieceDigest: func(n int64) (int32, bool) {
+				return 1, true
 			},
 		})
 	if err != nil {

--- a/client/daemon/peer/peertask_file_test.go
+++ b/client/daemon/peer/peertask_file_test.go
@@ -71,6 +71,7 @@ func TestFilePeerTask_BackSource_WithContentLength(t *testing.T) {
 			pieceSize:          uint32(pieceSize),
 			pieceParallelCount: pieceParallelCount,
 			backSource:         true,
+			content:            testBytes,
 		})
 	defer storageManager.CleanUp()
 
@@ -103,12 +104,14 @@ func TestFilePeerTask_BackSource_WithContentLength(t *testing.T) {
 		})
 
 	ptm := &peerTaskManager{
+		calculateDigest: true,
 		host: &scheduler.PeerHost{
 			Ip: "127.0.0.1",
 		},
 		conductorLock:    &sync.Mutex{},
 		runningPeerTasks: sync.Map{},
 		pieceManager: &pieceManager{
+			calculateDigest: true,
 			storageManager:  storageManager,
 			pieceDownloader: downloader,
 			computePieceSize: func(contentLength int64) uint32 {
@@ -186,6 +189,7 @@ func TestFilePeerTask_BackSource_WithoutContentLength(t *testing.T) {
 			pieceSize:          uint32(pieceSize),
 			pieceParallelCount: pieceParallelCount,
 			backSource:         true,
+			content:            testBytes,
 		})
 	defer storageManager.CleanUp()
 
@@ -219,12 +223,14 @@ func TestFilePeerTask_BackSource_WithoutContentLength(t *testing.T) {
 		})
 
 	ptm := &peerTaskManager{
+		calculateDigest: true,
 		host: &scheduler.PeerHost{
 			Ip: "127.0.0.1",
 		},
 		conductorLock:    &sync.Mutex{},
 		runningPeerTasks: sync.Map{},
 		pieceManager: &pieceManager{
+			calculateDigest: true,
 			storageManager:  storageManager,
 			pieceDownloader: downloader,
 			computePieceSize: func(contentLength int64) uint32 {

--- a/client/daemon/peer/peertask_stream_backsource_partial_test.go
+++ b/client/daemon/peer/peertask_stream_backsource_partial_test.go
@@ -208,6 +208,7 @@ func TestStreamPeerTask_BackSource_Partial_WithContentLength(t *testing.T) {
 			contentLength:      int64(mockContentLength),
 			pieceSize:          uint32(pieceSize),
 			pieceParallelCount: pieceParallelCount,
+			content:            testBytes,
 		})
 	defer storageManager.CleanUp()
 

--- a/client/daemon/peer/peertask_stream_test.go
+++ b/client/daemon/peer/peertask_stream_test.go
@@ -67,6 +67,7 @@ func TestStreamPeerTask_BackSource_WithContentLength(t *testing.T) {
 			contentLength:      int64(mockContentLength),
 			pieceSize:          uint32(pieceSize),
 			pieceParallelCount: pieceParallelCount,
+			content:            testBytes,
 		})
 	defer storageManager.CleanUp()
 
@@ -96,12 +97,14 @@ func TestStreamPeerTask_BackSource_WithContentLength(t *testing.T) {
 		})
 
 	ptm := &peerTaskManager{
+		calculateDigest: true,
 		host: &scheduler.PeerHost{
 			Ip: "127.0.0.1",
 		},
 		conductorLock:    &sync.Mutex{},
 		runningPeerTasks: sync.Map{},
 		pieceManager: &pieceManager{
+			calculateDigest: true,
 			storageManager:  storageManager,
 			pieceDownloader: downloader,
 			computePieceSize: func(contentLength int64) uint32 {
@@ -162,6 +165,7 @@ func TestStreamPeerTask_BackSource_WithoutContentLength(t *testing.T) {
 			pieceSize:          uint32(pieceSize),
 			pieceParallelCount: pieceParallelCount,
 			backSource:         true,
+			content:            testBytes,
 		})
 	defer storageManager.CleanUp()
 
@@ -191,12 +195,14 @@ func TestStreamPeerTask_BackSource_WithoutContentLength(t *testing.T) {
 		})
 
 	ptm := &peerTaskManager{
+		calculateDigest: true,
 		host: &scheduler.PeerHost{
 			Ip: "127.0.0.1",
 		},
 		conductorLock:    &sync.Mutex{},
 		runningPeerTasks: sync.Map{},
 		pieceManager: &pieceManager{
+			calculateDigest: true,
 			storageManager:  storageManager,
 			pieceDownloader: downloader,
 			computePieceSize: func(contentLength int64) uint32 {

--- a/client/daemon/storage/metadata.go
+++ b/client/daemon/storage/metadata.go
@@ -68,7 +68,7 @@ type WritePieceRequest struct {
 	UnknownLength bool
 	Reader        io.Reader
 	// GenPieceDigest is used after the last piece in back source case
-	GenPieceDigest func(n int64) bool
+	GenPieceDigest func(n int64) (total int32, gen bool)
 }
 
 type StoreRequest struct {


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

When back source in daemon, if total pieces count is not settled, piece md5 is missed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
