### PR TITLE
feat: set peer state to running when scope size is SizeScope_TINY

### DIFF
--- a/deploy/docker-compose/config/scheduler.yaml
+++ b/deploy/docker-compose/config/scheduler.yaml
@@ -9,5 +9,11 @@ worker:
   senderNum: 10
   senderJobPoolSize: 10000
 
+manager:
+  enable: false
+
+job:
+  enable: false
+
 dynconfig:
-  cdnDirPath: /opt/dragonfly/scheduler-cdn
+  cdnDir: /opt/dragonfly/scheduler-cdn

--- a/scheduler/resource/peer.go
+++ b/scheduler/resource/peer.go
@@ -63,9 +63,6 @@ const (
 )
 
 const (
-	// Peer is downloading
-	PeerEventDownload = "Download"
-
 	// Peer is registered as tiny scope size
 	PeerEventRegisterTiny = "RegisterTiny"
 
@@ -74,6 +71,9 @@ const (
 
 	// Peer is registered as normal scope size
 	PeerEventRegisterNormal = "RegisterNormal"
+
+	// Peer is downloading
+	PeerEventDownload = "Download"
 
 	// Peer is downloading from back-to-source
 	PeerEventDownloadFromBackToSource = "DownloadFromBackToSource"

--- a/scheduler/rpcserver/rpcserver.go
+++ b/scheduler/rpcserver/rpcserver.go
@@ -76,6 +76,7 @@ func (s *Server) RegisterPeerTask(ctx context.Context, req *scheduler.PeerTaskRe
 					return nil, dferr
 				}
 
+				// Dfdaemon does not report piece info when scope size is SizeScope_TINY
 				if err := peer.FSM.Event(resource.PeerEventDownload); err != nil {
 					dferr := dferrors.New(base.Code_SchedError, err.Error())
 					peer.Log.Errorf("peer %s register is failed: %v", req.PeerId, err)

--- a/scheduler/rpcserver/rpcserver.go
+++ b/scheduler/rpcserver/rpcserver.go
@@ -76,6 +76,12 @@ func (s *Server) RegisterPeerTask(ctx context.Context, req *scheduler.PeerTaskRe
 					return nil, dferr
 				}
 
+				if err := peer.FSM.Event(resource.PeerEventDownload); err != nil {
+					dferr := dferrors.New(base.Code_SchedError, err.Error())
+					peer.Log.Errorf("peer %s register is failed: %v", req.PeerId, err)
+					return nil, dferr
+				}
+
 				return &scheduler.RegisterResult{
 					TaskId:    task.ID,
 					SizeScope: sizeScope,
@@ -96,6 +102,12 @@ func (s *Server) RegisterPeerTask(ctx context.Context, req *scheduler.PeerTaskRe
 			parent, ok := s.service.Scheduler().FindParent(ctx, peer, set.NewSafeSet())
 			if !ok {
 				peer.Log.Warn("task size scope is small and it can not select parent")
+				if err := peer.FSM.Event(resource.PeerEventRegisterNormal); err != nil {
+					dferr := dferrors.New(base.Code_SchedError, err.Error())
+					peer.Log.Errorf("peer %s register is failed: %v", req.PeerId, err)
+					return nil, dferr
+				}
+
 				return &scheduler.RegisterResult{
 					TaskId:    task.ID,
 					SizeScope: sizeScope,
@@ -105,6 +117,12 @@ func (s *Server) RegisterPeerTask(ctx context.Context, req *scheduler.PeerTaskRe
 			firstPiece, ok := task.LoadPiece(0)
 			if !ok {
 				peer.Log.Warn("task size scope is small and it can not get first piece")
+				if err := peer.FSM.Event(resource.PeerEventRegisterNormal); err != nil {
+					dferr := dferrors.New(base.Code_SchedError, err.Error())
+					peer.Log.Errorf("peer %s register is failed: %v", req.PeerId, err)
+					return nil, dferr
+				}
+
 				return &scheduler.RegisterResult{
 					TaskId:    task.ID,
 					SizeScope: sizeScope,

--- a/scheduler/rpcserver/rpcserver_test.go
+++ b/scheduler/rpcserver/rpcserver_test.go
@@ -95,7 +95,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 		name   string
 		req    *rpcscheduler.PeerTaskRequest
 		mock   func(req *rpcscheduler.PeerTaskRequest, mockPeer *resource.Peer, mockHost *resource.Host, mockTask *resource.Task, scheduler scheduler.Scheduler, ms *mocks.MockServiceMockRecorder, msched *schedulermocks.MockSchedulerMockRecorder)
-		expect func(t *testing.T, result *rpcscheduler.RegisterResult, err error)
+		expect func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error)
 	}{
 		{
 			name: "service register failed",
@@ -103,7 +103,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 			mock: func(req *rpcscheduler.PeerTaskRequest, mockPeer *resource.Peer, mockHost *resource.Host, mockTask *resource.Task, scheduler scheduler.Scheduler, ms *mocks.MockServiceMockRecorder, msched *schedulermocks.MockSchedulerMockRecorder) {
 				ms.RegisterTask(context.Background(), req).Return(nil, errors.New("foo"))
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				dferr, ok := err.(*dferrors.DfError)
 				assert.True(ok)
@@ -122,7 +122,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					ms.LoadOrStorePeer(context.Background(), req, gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_NORMAL)
@@ -141,7 +141,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					ms.LoadOrStorePeer(context.Background(), req, gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				dferr, ok := err.(*dferrors.DfError)
 				assert.True(ok)
@@ -160,7 +160,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					ms.LoadOrStorePeer(context.Background(), req, gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_NORMAL)
@@ -179,7 +179,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					ms.LoadOrStorePeer(context.Background(), req, gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				dferr, ok := err.(*dferrors.DfError)
 				assert.True(ok)
@@ -199,13 +199,14 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					ms.LoadOrStorePeer(context.Background(), req, gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_TINY)
 				assert.Equal(result.DirectPiece, &rpcscheduler.RegisterResult_PieceContent{
 					PieceContent: []byte{1},
 				})
+				assert.True(peer.FSM.Is(resource.PeerStateRunning))
 			},
 		},
 		{
@@ -222,10 +223,11 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					msched.FindParent(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_TINY)
+				assert.True(peer.FSM.Is(resource.PeerStateReceivedNormal))
 			},
 		},
 		{
@@ -243,10 +245,11 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					msched.FindParent(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_SMALL)
+				assert.True(peer.FSM.Is(resource.PeerStateReceivedNormal))
 			},
 		},
 		{
@@ -265,10 +268,11 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					msched.FindParent(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_SMALL)
+				assert.True(peer.FSM.Is(resource.PeerStateReceivedNormal))
 			},
 		},
 		{
@@ -290,7 +294,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					msched.FindParent(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_SMALL)
@@ -303,6 +307,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 						},
 					},
 				})
+				assert.True(peer.FSM.Is(resource.PeerStateReceivedSmall))
 			},
 		},
 		{
@@ -319,10 +324,11 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					ms.LoadOrStorePeer(context.Background(), req, gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				assert.Equal(result.TaskId, mockTaskID)
 				assert.Equal(result.SizeScope, base.SizeScope_NORMAL)
+				assert.True(peer.FSM.Is(resource.PeerStateReceivedNormal))
 			},
 		},
 		{
@@ -340,11 +346,12 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 					ms.LoadOrStorePeer(context.Background(), req, gomock.Any(), gomock.Any()).Return(mockPeer, true).Times(1),
 				)
 			},
-			expect: func(t *testing.T, result *rpcscheduler.RegisterResult, err error) {
+			expect: func(t *testing.T, peer *resource.Peer, result *rpcscheduler.RegisterResult, err error) {
 				assert := assert.New(t)
 				dferr, ok := err.(*dferrors.DfError)
 				assert.True(ok)
 				assert.Equal(dferr.Code, base.Code_SchedError)
+				assert.True(peer.FSM.Is(resource.PeerStateFailed))
 			},
 		},
 	}
@@ -362,7 +369,7 @@ func TestRPCServer_RegisterPeerTask(t *testing.T) {
 			tc.mock(tc.req, mockPeer, mockHost, mockTask, scheduler, svc.EXPECT(), scheduler.EXPECT())
 			svr := New(svc)
 			result, err := svr.RegisterPeerTask(context.Background(), tc.req)
-			tc.expect(t, result, err)
+			tc.expect(t, mockPeer, result, err)
 		})
 	}
 }

--- a/scheduler/service/callback.go
+++ b/scheduler/service/callback.go
@@ -143,14 +143,6 @@ func (c *callback) BeginOfPiece(ctx context.Context, peer *resource.Peer) {
 		// Back to the source download process, peer directly returns
 		peer.Log.Info("peer back to source")
 		return
-	case resource.PeerStateReceivedTiny:
-		// When the task is tiny,
-		// the peer data has already returned to the parent when registering
-		peer.Log.Info("file type is tiny, peer data has already returned to the parent when registering")
-		if err := peer.FSM.Event(resource.PeerEventDownload); err != nil {
-			peer.Log.Errorf("peer fsm event failed: %v", err)
-			return
-		}
 	case resource.PeerStateReceivedSmall:
 		// When the task is small,
 		// the peer has already returned to the parent when registering

--- a/scheduler/service/callback_test.go
+++ b/scheduler/service/callback_test.go
@@ -210,16 +210,6 @@ func TestCallback_BeginOfPiece(t *testing.T) {
 			},
 		},
 		{
-			name: "peer state is PeerStateReceivedTiny",
-			mock: func(peer *resource.Peer, scheduler *mocks.MockSchedulerMockRecorder) {
-				peer.FSM.SetState(resource.PeerStateReceivedTiny)
-			},
-			expect: func(t *testing.T, peer *resource.Peer) {
-				assert := assert.New(t)
-				assert.True(peer.FSM.Is(resource.PeerStateRunning))
-			},
-		},
-		{
 			name: "peer state is PeerStateReceivedSmall",
 			mock: func(peer *resource.Peer, scheduler *mocks.MockSchedulerMockRecorder) {
 				peer.FSM.SetState(resource.PeerStateReceivedSmall)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Set peer state to running when scope size is SizeScope_TINY.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
