### PR TITLE
chore: register to scheduler after updated running tasks

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	reasonContextCanceled       = "context canceled"
+	//reasonContextCanceled       = "context canceled"
 	reasonScheduleTimeout       = "wait first peer packet from scheduler timeout"
 	reasonReScheduleTimeout     = "wait more available peers from scheduler timeout"
 	reasonPeerGoneFromScheduler = "scheduler says client should disconnect"
@@ -138,14 +138,10 @@ type peerTaskConductor struct {
 	// limiter will be used when enable per peer task rate limit
 	limiter *rate.Limiter
 
-	start time.Time
+	startTime time.Time
 }
 
-func (ptm *peerTaskManager) newPeerTaskConductor(
-	ctx context.Context,
-	request *scheduler.PeerTaskRequest,
-	limit rate.Limit) (*peerTaskConductor, error) {
-
+func (ptm *peerTaskManager) newPeerTaskConductor(ctx context.Context, request *scheduler.PeerTaskRequest, limit rate.Limit) *peerTaskConductor {
 	metrics.PeerTaskCount.Add(1)
 	// use a new context with span info
 	ctx = trace.ContextWithSpan(context.Background(), trace.SpanFromContext(ctx))
@@ -155,43 +151,7 @@ func (ptm *peerTaskManager) newPeerTaskConductor(
 	span.SetAttributes(config.AttributePeerID.String(request.PeerId))
 	span.SetAttributes(semconv.HTTPURLKey.String(request.Url))
 
-	logger.Debugf("request overview, pid: %s, url: %s, filter: %s, meta: %s, tag: %s",
-		request.PeerId, request.Url, request.UrlMeta.Filter, request.UrlMeta, request.UrlMeta.Tag)
-	// trace register
-	regCtx, cancel := context.WithTimeout(ctx, ptm.schedulerOption.ScheduleTimeout.Duration)
-	defer cancel()
-	regCtx, regSpan := tracer.Start(regCtx, config.SpanRegisterTask)
-	logger.Infof("step 1: peer %s start to register", request.PeerId)
-	schedulerClient := ptm.schedulerClient
-	result, err := schedulerClient.RegisterPeerTask(regCtx, request)
-	regSpan.RecordError(err)
-	regSpan.End()
-
-	var needBackSource bool
-	if err != nil {
-		if err == context.DeadlineExceeded {
-			logger.Errorf("scheduler did not response in %s", ptm.schedulerOption.ScheduleTimeout.Duration)
-		}
-		logger.Errorf("step 1: peer %s register failed: %s", request.PeerId, err)
-		if ptm.schedulerOption.DisableAutoBackSource {
-			logger.Errorf("register peer task failed: %s, peer id: %s, auto back source disabled", err, request.PeerId)
-			span.RecordError(err)
-			span.End()
-			return nil, err
-		}
-		needBackSource = true
-		// can not detect source or scheduler error, create a new dummy scheduler client
-		schedulerClient = &dummySchedulerClient{}
-		result = &scheduler.RegisterResult{TaskId: idgen.TaskID(request.Url, request.UrlMeta)}
-		logger.Warnf("register peer task failed: %s, peer id: %s, try to back source", err, request.PeerId)
-	}
-
-	if result == nil {
-		defer span.End()
-		span.RecordError(err)
-		err = errors.Errorf("empty schedule result")
-		return nil, err
-	}
+	taskID := idgen.TaskID(request.Url, request.UrlMeta)
 
 	var (
 		log     *logger.SugaredLoggerOnWith
@@ -201,76 +161,30 @@ func (ptm *peerTaskManager) newPeerTaskConductor(
 	if traceID.IsValid() {
 		log = logger.With(
 			"peer", request.PeerId,
-			"task", result.TaskId,
+			"task", taskID,
 			"component", "PeerTask",
 			"trace", traceID.String())
 	} else {
 		log = logger.With(
 			"peer", request.PeerId,
-			"task", result.TaskId,
+			"task", taskID,
 			"component", "PeerTask")
 	}
 
-	span.SetAttributes(config.AttributeTaskID.String(result.TaskId))
-	log.Infof("register task success, SizeScope: %s", base.SizeScope_name[int32(result.SizeScope)])
-
-	var (
-		singlePiece *scheduler.SinglePiece
-		tinyData    *TinyData
-	)
-	if !needBackSource {
-		switch result.SizeScope {
-		case base.SizeScope_NORMAL:
-			span.SetAttributes(config.AttributePeerTaskSizeScope.String("normal"))
-		case base.SizeScope_SMALL:
-			span.SetAttributes(config.AttributePeerTaskSizeScope.String("small"))
-			if piece, ok := result.DirectPiece.(*scheduler.RegisterResult_SinglePiece); ok {
-				singlePiece = piece.SinglePiece
-			}
-		case base.SizeScope_TINY:
-			defer span.End()
-			span.SetAttributes(config.AttributePeerTaskSizeScope.String("tiny"))
-			if piece, ok := result.DirectPiece.(*scheduler.RegisterResult_PieceContent); ok {
-				tinyData = &TinyData{
-					span:    span,
-					TaskID:  result.TaskId,
-					PeerID:  request.PeerId,
-					Content: piece.PieceContent,
-				}
-			} else {
-				err = errors.Errorf("scheduler return tiny piece but can not parse piece content")
-				span.RecordError(err)
-				log.Errorf("%s", err)
-				return nil, err
-			}
-		}
-	}
-
-	peerPacketStream, err := schedulerClient.ReportPieceResult(ctx, result.TaskId, request)
-	log.Infof("step 2: start report piece result")
-	if err != nil {
-		defer span.End()
-		span.RecordError(err)
-		return nil, err
-	}
+	span.SetAttributes(config.AttributeTaskID.String(taskID))
 
 	ptc := &peerTaskConductor{
-		start:               time.Now(),
+		startTime:           time.Now(),
 		ctx:                 ctx,
 		broker:              newPieceBroker(),
 		host:                ptm.host,
-		needBackSource:      atomic.NewBool(needBackSource),
 		request:             request,
-		peerPacketStream:    peerPacketStream,
 		pieceManager:        ptm.pieceManager,
 		storageManager:      ptm.storageManager,
 		peerTaskManager:     ptm,
 		peerPacketReady:     make(chan bool, 1),
 		peerID:              request.PeerId,
-		taskID:              result.TaskId,
-		sizeScope:           result.SizeScope,
-		singlePiece:         singlePiece,
-		tinyData:            tinyData,
+		taskID:              taskID,
 		successCh:           make(chan struct{}),
 		failCh:              make(chan struct{}),
 		span:                span,
@@ -283,7 +197,6 @@ func (ptm *peerTaskManager) newPeerTaskConductor(
 		pieceParallelCount:  atomic.NewInt32(0),
 		totalPiece:          -1,
 		schedulerOption:     ptm.schedulerOption,
-		schedulerClient:     schedulerClient,
 		limiter:             rate.NewLimiter(limit, int(limit)),
 		completedLength:     atomic.NewInt64(0),
 		usedTraffic:         atomic.NewUint64(0),
@@ -293,12 +206,106 @@ func (ptm *peerTaskManager) newPeerTaskConductor(
 		getPiecesMaxRetry: ptm.getPiecesMaxRetry,
 		peerTaskConductor: ptc,
 	}
-	return ptc, nil
+	return ptc
 }
 
-func (pt *peerTaskConductor) startPullAndBroadcastPieces() {
+// register to scheduler, if error and disable auto back source, return error, otherwise return nil
+func (pt *peerTaskConductor) register() error {
+	logger.Debugf("request overview, pid: %s, url: %s, filter: %s, meta: %s, tag: %s",
+		pt.request.PeerId, pt.request.Url, pt.request.UrlMeta.Filter, pt.request.UrlMeta, pt.request.UrlMeta.Tag)
+	// trace register
+	regCtx, cancel := context.WithTimeout(pt.ctx, pt.peerTaskManager.schedulerOption.ScheduleTimeout.Duration)
+	defer cancel()
+	regCtx, regSpan := tracer.Start(regCtx, config.SpanRegisterTask)
+
+	var (
+		needBackSource bool
+		sizeScope      base.SizeScope
+		singlePiece    *scheduler.SinglePiece
+		tinyData       *TinyData
+	)
+
+	logger.Infof("step 1: peer %s start to register", pt.request.PeerId)
+	schedulerClient := pt.peerTaskManager.schedulerClient
+
+	result, err := schedulerClient.RegisterPeerTask(regCtx, pt.request)
+	regSpan.RecordError(err)
+	regSpan.End()
+
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			logger.Errorf("scheduler did not response in %s", pt.peerTaskManager.schedulerOption.ScheduleTimeout.Duration)
+		}
+		logger.Errorf("step 1: peer %s register failed: %s", pt.request.PeerId, err)
+		if pt.peerTaskManager.schedulerOption.DisableAutoBackSource {
+			logger.Errorf("register peer task failed: %s, peer id: %s, auto back source disabled", err, pt.request.PeerId)
+			pt.span.RecordError(err)
+			pt.cancel(base.Code_SchedError, err.Error())
+			return err
+		}
+		needBackSource = true
+		// can not detect source or scheduler error, create a new dummy scheduler client
+		schedulerClient = &dummySchedulerClient{}
+		result = &scheduler.RegisterResult{TaskId: pt.taskID}
+		logger.Warnf("register peer task failed: %s, peer id: %s, try to back source", err, pt.request.PeerId)
+	}
+
+	pt.Infof("register task success, SizeScope: %s", base.SizeScope_name[int32(result.SizeScope)])
+
+	if !needBackSource {
+		sizeScope = result.SizeScope
+		switch result.SizeScope {
+		case base.SizeScope_NORMAL:
+			pt.span.SetAttributes(config.AttributePeerTaskSizeScope.String("normal"))
+		case base.SizeScope_SMALL:
+			pt.span.SetAttributes(config.AttributePeerTaskSizeScope.String("small"))
+			if piece, ok := result.DirectPiece.(*scheduler.RegisterResult_SinglePiece); ok {
+				singlePiece = piece.SinglePiece
+			}
+		case base.SizeScope_TINY:
+			pt.span.SetAttributes(config.AttributePeerTaskSizeScope.String("tiny"))
+			if piece, ok := result.DirectPiece.(*scheduler.RegisterResult_PieceContent); ok {
+				tinyData = &TinyData{
+					TaskID:  result.TaskId,
+					PeerID:  pt.request.PeerId,
+					Content: piece.PieceContent,
+				}
+			} else {
+				err = errors.Errorf("scheduler return tiny piece but can not parse piece content")
+				pt.span.RecordError(err)
+				pt.Errorf("%s", err)
+				pt.cancel(base.Code_SchedError, err.Error())
+				return err
+			}
+		}
+	}
+
+	peerPacketStream, err := schedulerClient.ReportPieceResult(pt.ctx, result.TaskId, pt.request)
+	pt.Infof("step 2: start report piece result")
+	if err != nil {
+		pt.span.RecordError(err)
+		pt.cancel(base.Code_SchedError, err.Error())
+		return err
+	}
+
+	pt.peerPacketStream = peerPacketStream
+	pt.schedulerClient = schedulerClient
+	pt.sizeScope = sizeScope
+	pt.singlePiece = singlePiece
+	pt.tinyData = tinyData
+	pt.needBackSource = atomic.NewBool(needBackSource)
+	return nil
+}
+
+func (pt *peerTaskConductor) start() error {
+	// register to scheduler
+	if err := pt.register(); err != nil {
+		return err
+	}
+
 	go pt.broker.Start()
 	go pt.pullPieces()
+	return nil
 }
 
 func (pt *peerTaskConductor) GetPeerID() string {
@@ -806,7 +813,7 @@ func (pt *peerTaskConductor) waitFirstPeerPacket() (done bool, backSource bool) 
 		if ok {
 			// preparePieceTasksByPeer func already send piece result with error
 			pt.Infof("new peer client ready, scheduler time cost: %dus, main peer: %s",
-				time.Now().Sub(pt.start).Microseconds(), pt.peerPacket.Load().(*scheduler.PeerPacket).MainPeer)
+				time.Now().Sub(pt.startTime).Microseconds(), pt.peerPacket.Load().(*scheduler.PeerPacket).MainPeer)
 			return true, false
 		}
 		// when scheduler says base.Code_SchedNeedBackSource, receivePeerPacket will close pt.peerPacketReady
@@ -1145,7 +1152,7 @@ func (pt *peerTaskConductor) done() {
 		pt.span.End()
 	}()
 	var (
-		cost    = time.Now().Sub(pt.start).Milliseconds()
+		cost    = time.Now().Sub(pt.startTime).Milliseconds()
 		success = true
 		code    = base.Code_Success
 	)
@@ -1252,7 +1259,7 @@ func (pt *peerTaskConductor) fail() {
 			ContentLength:   pt.GetContentLength(),
 			Traffic:         pt.GetTraffic(),
 			TotalPieceCount: pt.totalPiece,
-			Cost:            uint32(end.Sub(pt.start).Milliseconds()),
+			Cost:            uint32(end.Sub(pt.startTime).Milliseconds()),
 			Success:         false,
 			Code:            pt.failedCode,
 		})

--- a/client/daemon/peer/peertask_manager.go
+++ b/client/daemon/peer/peertask_manager.go
@@ -29,7 +29,6 @@ import (
 	"d7y.io/dragonfly/v2/client/daemon/metrics"
 	"d7y.io/dragonfly/v2/client/daemon/storage"
 	logger "d7y.io/dragonfly/v2/internal/dflog"
-	"d7y.io/dragonfly/v2/pkg/rpc/base"
 	"d7y.io/dragonfly/v2/pkg/rpc/scheduler"
 	schedulerclient "d7y.io/dragonfly/v2/pkg/rpc/scheduler/client"
 )
@@ -86,8 +85,6 @@ type Logger interface {
 }
 
 type TinyData struct {
-	// span is used by peer task manager to record events without peer task
-	span    trace.Span
 	TaskID  string
 	PeerID  string
 	Content []byte
@@ -167,7 +164,9 @@ func (ptm *peerTaskManager) getPeerTaskConductor(ctx context.Context,
 		return nil, err
 	}
 	if created {
-		ptc.startPullAndBroadcastPieces()
+		if err = ptc.start(); err != nil {
+			return nil, err
+		}
 	}
 	return ptc, err
 }
@@ -183,20 +182,13 @@ func (ptm *peerTaskManager) getOrCreatePeerTaskConductor(
 		logger.Debugf("peer task found: %s/%s", ptc.taskID, ptc.peerID)
 		return ptc, false, nil
 	}
-	// FIXME merge register peer tasks
-	ptc, err := ptm.newPeerTaskConductor(ctx, request, limit)
-	if err != nil {
-		return nil, false, err
-	}
+	ptc := ptm.newPeerTaskConductor(ctx, request, limit)
 
 	ptm.conductorLock.Lock()
 	// double check
 	if p, ok := ptm.findPeerTaskConductor(taskID); ok {
 		ptm.conductorLock.Unlock()
-		logger.Debugf("same peer task found: %s/%s, cancel created peer task %s/%s",
-			p.taskID, p.peerID, ptc.taskID, ptc.peerID)
-		// cancel duplicate peer task
-		ptc.cancel(base.Code_ClientContextCanceled, reasonContextCanceled)
+		logger.Debugf("peer task found: %s/%s", p.taskID, p.peerID)
 		return p, false, nil
 	}
 	ptm.runningPeerTasks.Store(taskID, ptc)

--- a/client/daemon/peer/peertask_manager_test.go
+++ b/client/daemon/peer/peertask_manager_test.go
@@ -607,13 +607,6 @@ func (ts *testSpec) runConductorTest(assert *testifyassert.Assertions, require *
 	assert.Nil(err, "load first peerTaskConductor")
 	assert.True(created, "should create a new peerTaskConductor")
 
-	switch ts.sizeScope {
-	case base.SizeScope_TINY:
-		require.NotNil(ptc.tinyData)
-	case base.SizeScope_SMALL:
-		require.NotNil(ptc.singlePiece)
-	}
-
 	var ptcCount = 100
 	var wg = &sync.WaitGroup{}
 	wg.Add(ptcCount + 1)
@@ -661,7 +654,15 @@ func (ts *testSpec) runConductorTest(assert *testifyassert.Assertions, require *
 		go syncFunc(i, p)
 	}
 
-	ptc.startPullAndBroadcastPieces()
+	require.Nil(ptc.start(), "peerTaskConductor start should be ok")
+
+	switch ts.sizeScope {
+	case base.SizeScope_TINY:
+		require.NotNil(ptc.tinyData)
+	case base.SizeScope_SMALL:
+		require.NotNil(ptc.singlePiece)
+	}
+
 	wg.Wait()
 
 	for i, r := range result {


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

When multiple same tasks come, we should register to schedulers only one.
So we need move registering after updated running tasks.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
