### PR TITLE
feat: when peers create a tree, no need to add peers to host and task

### DIFF
--- a/scheduler/resource/cdn.go
+++ b/scheduler/resource/cdn.go
@@ -80,7 +80,7 @@ func (c *cdn) TriggerTask(ctx context.Context, task *Task) (*Peer, *rpcscheduler
 
 		// Handle begin of piece
 		if piece.PieceInfo != nil && piece.PieceInfo.PieceNum == common.BeginOfPiece {
-			task.Log.Infof("receive begin o piece: %#v %#v", piece, piece.PieceInfo)
+			task.Log.Infof("receive begin of piece: %#v %#v", piece, piece.PieceInfo)
 			peer, err = c.initPeer(task, piece)
 			if err != nil {
 				return nil, nil, err

--- a/scheduler/resource/host.go
+++ b/scheduler/resource/host.go
@@ -167,7 +167,7 @@ func (h *Host) LenPeers() int {
 
 // LeavePeers set peer state to PeerStateLeave
 func (h *Host) LeavePeers() {
-	h.Peers.Range(func(key, value interface{}) bool {
+	h.Peers.Range(func(_, value interface{}) bool {
 		if peer, ok := value.(*Peer); ok {
 			if err := peer.FSM.Event(PeerEventDownloadFailed); err != nil {
 				peer.Log.Errorf("peer fsm event failed: %v", err)
@@ -179,7 +179,7 @@ func (h *Host) LeavePeers() {
 				return true
 			}
 
-			peer.Log.Info("peer has been left")
+			h.Log.Infof("peer %s has been left", peer.ID)
 		}
 
 		return true

--- a/scheduler/resource/peer.go
+++ b/scheduler/resource/peer.go
@@ -234,8 +234,6 @@ func (p *Peer) StoreChild(child *Peer) {
 	defer p.mu.Unlock()
 
 	p.Children.Store(child.ID, child)
-	p.Host.Peers.Store(child.ID, child)
-	p.Task.Peers.Store(child.ID, child)
 	child.Parent.Store(p)
 }
 
@@ -250,8 +248,6 @@ func (p *Peer) DeleteChild(key string) {
 	}
 
 	p.Children.Delete(child.ID)
-	p.Host.DeletePeer(child.ID)
-	p.Task.DeletePeer(child.ID)
 	child.Parent = &atomic.Value{}
 }
 
@@ -283,8 +279,6 @@ func (p *Peer) StoreParent(parent *Peer) {
 
 	p.Parent.Store(parent)
 	parent.Children.Store(p.ID, p)
-	parent.Host.Peers.Store(p.ID, p)
-	parent.Task.Peers.Store(p.ID, p)
 }
 
 // DeleteParent deletes peer parent
@@ -299,8 +293,6 @@ func (p *Peer) DeleteParent() {
 
 	p.Parent = &atomic.Value{}
 	parent.Children.Delete(p.ID)
-	parent.Host.Peers.Delete(p.ID)
-	parent.Task.Peers.Delete(p.ID)
 }
 
 // ReplaceParent replaces peer parent

--- a/scheduler/resource/peer_test.go
+++ b/scheduler/resource/peer_test.go
@@ -148,12 +148,6 @@ func TestPeer_StoreChild(t *testing.T) {
 				child, ok = peer.LoadChild(childID)
 				assert.Equal(ok, true)
 				assert.Equal(child.ID, childID)
-				child, ok = peer.Host.LoadPeer(childID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, childID)
-				child, ok = peer.Task.LoadPeer(childID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, childID)
 				parent, ok = child.LoadParent()
 				assert.Equal(ok, true)
 				assert.Equal(parent.ID, peer.ID)
@@ -171,12 +165,6 @@ func TestPeer_StoreChild(t *testing.T) {
 					ok     bool
 				)
 				child, ok = peer.LoadChild(childID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, childID)
-				child, ok = peer.Host.LoadPeer(childID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, childID)
-				child, ok = peer.Task.LoadPeer(childID)
 				assert.Equal(ok, true)
 				assert.Equal(child.ID, childID)
 				parent, ok = child.LoadParent()
@@ -215,10 +203,6 @@ func TestPeer_DeleteChild(t *testing.T) {
 				var ok bool
 				_, ok = peer.LoadChild(mockChildPeer.ID)
 				assert.Equal(ok, false)
-				_, ok = peer.Host.LoadPeer(mockChildPeer.ID)
-				assert.Equal(ok, false)
-				_, ok = peer.Task.LoadPeer(mockChildPeer.ID)
-				assert.Equal(ok, false)
 				_, ok = mockChildPeer.LoadParent()
 				assert.Equal(ok, false)
 			},
@@ -236,12 +220,6 @@ func TestPeer_DeleteChild(t *testing.T) {
 					ok     bool
 				)
 				child, ok = peer.LoadChild(mockChildPeer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, mockChildPeer.ID)
-				child, ok = peer.Host.LoadPeer(mockChildPeer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, mockChildPeer.ID)
-				child, ok = peer.Task.LoadPeer(mockChildPeer.ID)
 				assert.Equal(ok, true)
 				assert.Equal(child.ID, mockChildPeer.ID)
 				parent, ok = child.LoadParent()
@@ -379,12 +357,6 @@ func TestPeer_StoreParent(t *testing.T) {
 				child, ok = parent.LoadChild(peer.ID)
 				assert.Equal(ok, true)
 				assert.Equal(child.ID, peer.ID)
-				child, ok = peer.Task.LoadPeer(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
-				child, ok = peer.Host.LoadPeer(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
 			},
 		},
 		{
@@ -402,12 +374,6 @@ func TestPeer_StoreParent(t *testing.T) {
 				assert.Equal(ok, true)
 				assert.Equal(parent.ID, parentID)
 				child, ok = parent.LoadChild(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
-				child, ok = peer.Task.LoadPeer(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
-				child, ok = peer.Host.LoadPeer(peer.ID)
 				assert.Equal(ok, true)
 				assert.Equal(child.ID, peer.ID)
 			},
@@ -446,10 +412,6 @@ func TestPeer_DeleteParent(t *testing.T) {
 				assert.Equal(ok, false)
 				_, ok = mockParentPeer.LoadChild(peer.ID)
 				assert.Equal(ok, false)
-				_, ok = mockParentPeer.Task.LoadPeer(peer.ID)
-				assert.Equal(ok, false)
-				_, ok = mockParentPeer.Host.LoadPeer(peer.ID)
-				assert.Equal(ok, false)
 			},
 		},
 		{
@@ -463,10 +425,6 @@ func TestPeer_DeleteParent(t *testing.T) {
 				_, ok = peer.LoadParent()
 				assert.Equal(ok, false)
 				_, ok = mockParentPeer.LoadChild(peer.ID)
-				assert.Equal(ok, false)
-				_, ok = mockParentPeer.Task.LoadPeer(peer.ID)
-				assert.Equal(ok, false)
-				_, ok = mockParentPeer.Host.LoadPeer(peer.ID)
 				assert.Equal(ok, false)
 			},
 		},
@@ -513,12 +471,6 @@ func TestPeer_ReplaceParent(t *testing.T) {
 				child, ok = mockNewParentPeer.LoadChild(peer.ID)
 				assert.Equal(ok, true)
 				assert.Equal(child.ID, peer.ID)
-				child, ok = mockNewParentPeer.Task.LoadPeer(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
-				child, ok = mockNewParentPeer.Host.LoadPeer(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
 			},
 		},
 		{
@@ -540,12 +492,6 @@ func TestPeer_ReplaceParent(t *testing.T) {
 				_, ok = mockOldParentPeer.LoadChild(peer.ID)
 				assert.Equal(ok, false)
 				child, ok = mockNewParentPeer.LoadChild(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
-				child, ok = mockNewParentPeer.Task.LoadPeer(peer.ID)
-				assert.Equal(ok, true)
-				assert.Equal(child.ID, peer.ID)
-				child, ok = mockNewParentPeer.Host.LoadPeer(peer.ID)
 				assert.Equal(ok, true)
 				assert.Equal(child.ID, peer.ID)
 			},

--- a/scheduler/service/callback.go
+++ b/scheduler/service/callback.go
@@ -318,6 +318,10 @@ func (c *callback) PeerLeave(ctx context.Context, peer *resource.Peer) {
 // 1. CDN downloads the resource successfully
 // 2. Dfdaemon back-to-source to download successfully
 func (c *callback) TaskSuccess(ctx context.Context, task *resource.Task, result *rpcscheduler.PeerResult) {
+	if task.FSM.Is(resource.TaskStateSucceeded) {
+		return
+	}
+
 	if err := task.FSM.Event(resource.TaskEventDownloadSucceeded); err != nil {
 		task.Log.Errorf("task fsm event failed: %v", err)
 		return
@@ -332,6 +336,10 @@ func (c *callback) TaskSuccess(ctx context.Context, task *resource.Task, result 
 // 1. CDN downloads the resource falied
 // 2. Dfdaemon back-to-source to download failed
 func (c *callback) TaskFail(ctx context.Context, task *resource.Task) {
+	if task.FSM.Is(resource.TaskStateFailed) {
+		return
+	}
+
 	if err := task.FSM.Event(resource.TaskEventDownloadFailed); err != nil {
 		task.Log.Errorf("task fsm event failed: %v", err)
 		return


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- When peers create a tree, no need to add peers to host and task.
<!--- Describe your changes in detail -->

## Related Issue
Fixes #1043 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
