### PR TITLE
fix: when cdn download failed, scheduler should set cdn peer state PeerStateFailed

### DIFF
--- a/scheduler/resource/cdn.go
+++ b/scheduler/resource/cdn.go
@@ -81,6 +81,14 @@ func (c *cdn) TriggerTask(ctx context.Context, task *Task) (*Peer, *rpcscheduler
 	for {
 		piece, err := stream.Recv()
 		if err != nil {
+			// If the peer initialization succeeds and the download fails,
+			// set peer status is PeerStateFailed.
+			if peer != nil {
+				if err := peer.FSM.Event(PeerEventDownloadFailed); err != nil {
+					return nil, nil, err
+				}
+			}
+
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixed not setting peer state to `PeerStateFailed` when cdn peer download failed.
<!--- Describe your changes in detail -->

## Related Issue
Fixes #1065
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
