### PR TITLE
fix: delete peer's parent on PeerEventDownloadSucceeded event

### DIFF
--- a/scheduler/resource/peer.go
+++ b/scheduler/resource/peer.go
@@ -199,6 +199,7 @@ func NewPeer(id string, task *Task, host *Host) *Peer {
 					p.Task.BackToSourcePeers.Delete(p)
 				}
 
+				p.DeleteParent()
 				p.UpdateAt.Store(time.Now())
 				p.Log.Infof("peer state is %s", e.FSM.Current())
 			},


### PR DESCRIPTION
When a peer leaves, it calls scheduler's LeaveTask() interface to
notify scheduler that it's leaving. And LeaveTask() will re-schedule
all its children to find a new parent by calling ScheduleParent().

But some of this peer's children might be in PeerStateSucceeded
state, as they have finished downloading tasks from parent. So
ScheduleParent() on such children is pointless.

Let's delete peer's parent on PeerEventDownloadSucceeded event, so
its parent won't call ScheduleParent() on it again, when its parent
is leaving.

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
