### PR TITLE
Fix empty client output path

### DIFF
--- a/client/config/dfget.go
+++ b/client/config/dfget.go
@@ -163,12 +163,6 @@ func (cfg *ClientOption) Validate() error {
 }
 
 func (cfg *ClientOption) Convert(args []string) error {
-	var err error
-
-	if cfg.Output, err = filepath.Abs(cfg.Output); err != nil {
-		return err
-	}
-
 	if cfg.URL == "" && len(args) > 0 {
 		cfg.URL = args[0]
 	}

--- a/client/config/dfget.go
+++ b/client/config/dfget.go
@@ -163,28 +163,6 @@ func (cfg *ClientOption) Validate() error {
 }
 
 func (cfg *ClientOption) Convert(args []string) error {
-	if cfg.URL == "" && len(args) > 0 {
-		cfg.URL = args[0]
-	}
-
-	if cfg.Digest != "" {
-		cfg.Tag = ""
-	}
-
-	if cfg.Console {
-		cfg.ShowProgress = false
-	}
-
-	return nil
-}
-
-func (cfg *ClientOption) String() string {
-	js, _ := json.Marshal(cfg)
-	return string(js)
-}
-
-// This function must be called after checkURL
-func (cfg *ClientOption) checkOutput() error {
 	if stringutils.IsBlank(cfg.Output) {
 		url := strings.TrimRight(cfg.URL, "/")
 		idx := strings.LastIndexByte(url, '/')
@@ -201,7 +179,30 @@ func (cfg *ClientOption) checkOutput() error {
 		}
 		cfg.Output = absPath
 	}
+	if cfg.URL == "" && len(args) > 0 {
+		cfg.URL = args[0]
+	}
 
+	if cfg.Digest != "" {
+		cfg.Tag = ""
+	}
+
+	if cfg.Console {
+		cfg.ShowProgress = false
+	}
+	return nil
+}
+
+func (cfg *ClientOption) String() string {
+	js, _ := json.Marshal(cfg)
+	return string(js)
+}
+
+// This function must be called after checkURL
+func (cfg *ClientOption) checkOutput() error {
+	if !filepath.IsAbs(cfg.Output) {
+		return fmt.Errorf("path[%s] is not absolute path", cfg.Output)
+	}
 	outputDir, _ := path.Split(cfg.Output)
 	if err := MkdirAll(outputDir, 0777, basic.UserID, basic.UserGroup); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: sunwp <244372610@qq.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
If the client output parameter is not specified, the client cannot automatically obtain the target file path
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
