### PR TITLE
feat: when peer downloads finished, host remove peer and compatible with ReportPeerResult and ReportPieceResult are called in no order

### DIFF
--- a/manager/database/mysql.go
+++ b/manager/database/mysql.go
@@ -33,10 +33,13 @@ import (
 
 const (
 	// Default number of cdn load limit
-	defaultCDNLoadLimit = 300
+	DefaultCDNLoadLimit = 300
 
 	// Default number of client load limit
-	defaultClientLoadLimit = 50
+	DefaultClientLoadLimit = 50
+
+	// Default number of pieces to download in parallel
+	DefaultClientParallelCount = 4
 )
 
 func newMyqsl(cfg *config.MysqlConfig) (*gorm.DB, error) {
@@ -130,7 +133,7 @@ func seed(db *gorm.DB) error {
 			},
 			Name: "cdn-cluster-1",
 			Config: map[string]interface{}{
-				"load_limit": defaultCDNLoadLimit,
+				"load_limit": DefaultCDNLoadLimit,
 			},
 			IsDefault: true,
 		}).Error; err != nil {
@@ -150,7 +153,8 @@ func seed(db *gorm.DB) error {
 			Name:   "scheduler-cluster-1",
 			Config: map[string]interface{}{},
 			ClientConfig: map[string]interface{}{
-				"load_limit": defaultClientLoadLimit,
+				"load_limit":     DefaultClientLoadLimit,
+				"parallel_count": DefaultClientParallelCount,
 			},
 			Scopes:    map[string]interface{}{},
 			IsDefault: true,

--- a/scheduler/config/dynconfig.go
+++ b/scheduler/config/dynconfig.go
@@ -214,6 +214,7 @@ func (d *dynconfig) Get() (*DynconfigData, error) {
 	if err := d.Unmarshal(&config); err != nil {
 		return nil, err
 	}
+
 	return &config, nil
 }
 

--- a/scheduler/resource/cdn.go
+++ b/scheduler/resource/cdn.go
@@ -259,7 +259,7 @@ func cdnsToHosts(cdns []*config.CDN) map[string]*Host {
 	for _, cdn := range cdns {
 		var netTopology string
 		options := []HostOption{WithIsCDN(true)}
-		if config, ok := cdn.GetCDNClusterConfig(); ok {
+		if config, ok := cdn.GetCDNClusterConfig(); ok && config.LoadLimit > 0 {
 			options = append(options, WithUploadLoadLimit(int32(config.LoadLimit)))
 			netTopology = config.NetTopology
 		}

--- a/scheduler/resource/cdn_test.go
+++ b/scheduler/resource/cdn_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"d7y.io/dragonfly/v2/internal/dfnet"
+	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/manager/types"
 	rpcscheduler "d7y.io/dragonfly/v2/pkg/rpc/scheduler"
 	"d7y.io/dragonfly/v2/scheduler/config"
@@ -352,7 +353,7 @@ func TestCDNClient_cdnsToHosts(t *testing.T) {
 				assert.Equal(hosts[mockRawCDNHost.Uuid].IDC, mockRawCDNHost.Idc)
 				assert.Equal(hosts[mockRawCDNHost.Uuid].NetTopology, "")
 				assert.Equal(hosts[mockRawCDNHost.Uuid].Location, mockRawCDNHost.Location)
-				assert.Equal(hosts[mockRawCDNHost.Uuid].UploadLoadLimit.Load(), int32(defaultUploadLoadLimit))
+				assert.Equal(hosts[mockRawCDNHost.Uuid].UploadLoadLimit.Load(), int32(database.DefaultClientLoadLimit))
 				assert.Empty(hosts[mockRawCDNHost.Uuid].Peers)
 				assert.Equal(hosts[mockRawCDNHost.Uuid].IsCDN, true)
 				assert.NotEqual(hosts[mockRawCDNHost.Uuid].CreateAt.Load(), 0)

--- a/scheduler/resource/host.go
+++ b/scheduler/resource/host.go
@@ -23,12 +23,8 @@ import (
 	"go.uber.org/atomic"
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
+	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/pkg/rpc/scheduler"
-)
-
-const (
-	// Host default upload load limit
-	defaultUploadLoadLimit = 100
 )
 
 // HostOption is a functional option for configuring the host
@@ -114,7 +110,7 @@ func NewHost(rawHost *scheduler.PeerHost, options ...HostOption) *Host {
 		IDC:             rawHost.Idc,
 		NetTopology:     rawHost.NetTopology,
 		Location:        rawHost.Location,
-		UploadLoadLimit: atomic.NewInt32(defaultUploadLoadLimit),
+		UploadLoadLimit: atomic.NewInt32(database.DefaultClientLoadLimit),
 		Peers:           &sync.Map{},
 		PeerCount:       atomic.NewInt32(0),
 		IsCDN:           false,

--- a/scheduler/resource/host_test.go
+++ b/scheduler/resource/host_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/pkg/idgen"
 	"d7y.io/dragonfly/v2/pkg/rpc/scheduler"
 )
@@ -72,7 +73,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert.Equal(host.Location, mockRawHost.Location)
 				assert.Equal(host.IDC, mockRawHost.Idc)
 				assert.Equal(host.NetTopology, mockRawHost.NetTopology)
-				assert.Equal(host.UploadLoadLimit.Load(), int32(defaultUploadLoadLimit))
+				assert.Equal(host.UploadLoadLimit.Load(), int32(database.DefaultClientLoadLimit))
 				assert.Equal(host.PeerCount.Load(), int32(0))
 				assert.Equal(host.IsCDN, false)
 				assert.NotEqual(host.CreateAt.Load(), 0)
@@ -95,7 +96,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert.Equal(host.Location, mockRawCDNHost.Location)
 				assert.Equal(host.IDC, mockRawCDNHost.Idc)
 				assert.Equal(host.NetTopology, mockRawCDNHost.NetTopology)
-				assert.Equal(host.UploadLoadLimit.Load(), int32(defaultUploadLoadLimit))
+				assert.Equal(host.UploadLoadLimit.Load(), int32(database.DefaultClientLoadLimit))
 				assert.Equal(host.PeerCount.Load(), int32(0))
 				assert.Equal(host.IsCDN, true)
 				assert.NotEqual(host.CreateAt.Load(), 0)
@@ -383,7 +384,7 @@ func TestHost_FreeUploadLoad(t *testing.T) {
 				host.StorePeer(mockPeer)
 				mockPeer.ID = idgen.PeerID("0.0.0.0")
 				host.StorePeer(mockPeer)
-				assert.Equal(host.FreeUploadLoad(), int32(defaultUploadLoadLimit-2))
+				assert.Equal(host.FreeUploadLoad(), int32(database.DefaultClientLoadLimit-2))
 			},
 		},
 		{
@@ -391,7 +392,7 @@ func TestHost_FreeUploadLoad(t *testing.T) {
 			rawHost: mockRawHost,
 			expect: func(t *testing.T, host *Host, mockPeer *Peer) {
 				assert := assert.New(t)
-				assert.Equal(host.FreeUploadLoad(), int32(defaultUploadLoadLimit))
+				assert.Equal(host.FreeUploadLoad(), int32(database.DefaultClientLoadLimit))
 			},
 		},
 	}

--- a/scheduler/scheduler/evaluator/evaluator_base_test.go
+++ b/scheduler/scheduler/evaluator/evaluator_base_test.go
@@ -290,7 +290,7 @@ func TestEvaluatorBase_calculateFreeLoadScore(t *testing.T) {
 			},
 			expect: func(t *testing.T, score float64) {
 				assert := assert.New(t)
-				assert.Equal(score, float64(0.99))
+				assert.Equal(score, float64(0.98))
 			},
 		},
 		{

--- a/scheduler/service/service.go
+++ b/scheduler/service/service.go
@@ -376,7 +376,6 @@ func (s *Service) LeaveTask(ctx context.Context, req *rpcscheduler.PeerTarget) e
 		return true
 	})
 
-	peer.DeleteParent()
 	s.resource.PeerManager().Delete(peer.ID)
 	return nil
 }
@@ -420,7 +419,7 @@ func (s *Service) registerHost(ctx context.Context, req *rpcscheduler.PeerTaskRe
 	if !ok {
 		// Get scheduler cluster client config by manager
 		var options []resource.HostOption
-		if clientConfig, ok := s.dynconfig.GetSchedulerClusterClientConfig(); ok {
+		if clientConfig, ok := s.dynconfig.GetSchedulerClusterClientConfig(); ok && clientConfig.LoadLimit > 0 {
 			options = append(options, resource.WithUploadLoadLimit(int32(clientConfig.LoadLimit)))
 		}
 


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- When peer downloads finished, host remove peer.
- Since ReportPeerResult and ReportPieceResult are called in no order, the result may be reported after the register is successful. Fix state machine switching problem.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
