### PR TITLE
feat: change default scheduler filter parent limit

### DIFF
--- a/manager/database/mysql.go
+++ b/manager/database/mysql.go
@@ -29,17 +29,7 @@ import (
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/manager/config"
 	"d7y.io/dragonfly/v2/manager/model"
-)
-
-const (
-	// Default number of cdn load limit
-	DefaultCDNLoadLimit = 300
-
-	// Default number of client load limit
-	DefaultClientLoadLimit = 50
-
-	// Default number of pieces to download in parallel
-	DefaultClientParallelCount = 4
+	schedulerconfig "d7y.io/dragonfly/v2/scheduler/config"
 )
 
 func newMyqsl(cfg *config.MysqlConfig) (*gorm.DB, error) {
@@ -133,7 +123,7 @@ func seed(db *gorm.DB) error {
 			},
 			Name: "cdn-cluster-1",
 			Config: map[string]interface{}{
-				"load_limit": DefaultCDNLoadLimit,
+				"load_limit": schedulerconfig.DefaultCDNLoadLimit,
 			},
 			IsDefault: true,
 		}).Error; err != nil {
@@ -150,11 +140,13 @@ func seed(db *gorm.DB) error {
 			Model: model.Model{
 				ID: uint(1),
 			},
-			Name:   "scheduler-cluster-1",
-			Config: map[string]interface{}{},
+			Name: "scheduler-cluster-1",
+			Config: map[string]interface{}{
+				"filter_parent_limit": schedulerconfig.DefaultSchedulerFilterParentLimit,
+			},
 			ClientConfig: map[string]interface{}{
-				"load_limit":     DefaultClientLoadLimit,
-				"parallel_count": DefaultClientParallelCount,
+				"load_limit":     schedulerconfig.DefaultClientLoadLimit,
+				"parallel_count": schedulerconfig.DefaultClientParallelCount,
 			},
 			Scopes:    map[string]interface{}{},
 			IsDefault: true,

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -1,0 +1,31 @@
+/*
+ *     Copyright 2020 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+const (
+	// Default number of cdn load limit
+	DefaultCDNLoadLimit = 300
+
+	// Default number of client load limit
+	DefaultClientLoadLimit = 50
+
+	// Default number of pieces to download in parallel
+	DefaultClientParallelCount = 4
+
+	// Default limit the number of filter traversals
+	DefaultSchedulerFilterParentLimit = 3
+)

--- a/scheduler/resource/cdn_test.go
+++ b/scheduler/resource/cdn_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"d7y.io/dragonfly/v2/internal/dfnet"
-	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/manager/types"
 	rpcscheduler "d7y.io/dragonfly/v2/pkg/rpc/scheduler"
 	"d7y.io/dragonfly/v2/scheduler/config"
@@ -353,7 +352,7 @@ func TestCDNClient_cdnsToHosts(t *testing.T) {
 				assert.Equal(hosts[mockRawCDNHost.Uuid].IDC, mockRawCDNHost.Idc)
 				assert.Equal(hosts[mockRawCDNHost.Uuid].NetTopology, "")
 				assert.Equal(hosts[mockRawCDNHost.Uuid].Location, mockRawCDNHost.Location)
-				assert.Equal(hosts[mockRawCDNHost.Uuid].UploadLoadLimit.Load(), int32(database.DefaultClientLoadLimit))
+				assert.Equal(hosts[mockRawCDNHost.Uuid].UploadLoadLimit.Load(), int32(config.DefaultClientLoadLimit))
 				assert.Empty(hosts[mockRawCDNHost.Uuid].Peers)
 				assert.Equal(hosts[mockRawCDNHost.Uuid].IsCDN, true)
 				assert.NotEqual(hosts[mockRawCDNHost.Uuid].CreateAt.Load(), 0)

--- a/scheduler/resource/host.go
+++ b/scheduler/resource/host.go
@@ -23,8 +23,8 @@ import (
 	"go.uber.org/atomic"
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
-	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/pkg/rpc/scheduler"
+	"d7y.io/dragonfly/v2/scheduler/config"
 )
 
 // HostOption is a functional option for configuring the host
@@ -110,7 +110,7 @@ func NewHost(rawHost *scheduler.PeerHost, options ...HostOption) *Host {
 		IDC:             rawHost.Idc,
 		NetTopology:     rawHost.NetTopology,
 		Location:        rawHost.Location,
-		UploadLoadLimit: atomic.NewInt32(database.DefaultClientLoadLimit),
+		UploadLoadLimit: atomic.NewInt32(config.DefaultClientLoadLimit),
 		Peers:           &sync.Map{},
 		PeerCount:       atomic.NewInt32(0),
 		IsCDN:           false,

--- a/scheduler/resource/host_test.go
+++ b/scheduler/resource/host_test.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/pkg/idgen"
 	"d7y.io/dragonfly/v2/pkg/rpc/scheduler"
+	"d7y.io/dragonfly/v2/scheduler/config"
 )
 
 var (
@@ -73,7 +73,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert.Equal(host.Location, mockRawHost.Location)
 				assert.Equal(host.IDC, mockRawHost.Idc)
 				assert.Equal(host.NetTopology, mockRawHost.NetTopology)
-				assert.Equal(host.UploadLoadLimit.Load(), int32(database.DefaultClientLoadLimit))
+				assert.Equal(host.UploadLoadLimit.Load(), int32(config.DefaultClientLoadLimit))
 				assert.Equal(host.PeerCount.Load(), int32(0))
 				assert.Equal(host.IsCDN, false)
 				assert.NotEqual(host.CreateAt.Load(), 0)
@@ -96,7 +96,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert.Equal(host.Location, mockRawCDNHost.Location)
 				assert.Equal(host.IDC, mockRawCDNHost.Idc)
 				assert.Equal(host.NetTopology, mockRawCDNHost.NetTopology)
-				assert.Equal(host.UploadLoadLimit.Load(), int32(database.DefaultClientLoadLimit))
+				assert.Equal(host.UploadLoadLimit.Load(), int32(config.DefaultClientLoadLimit))
 				assert.Equal(host.PeerCount.Load(), int32(0))
 				assert.Equal(host.IsCDN, true)
 				assert.NotEqual(host.CreateAt.Load(), 0)
@@ -384,7 +384,7 @@ func TestHost_FreeUploadLoad(t *testing.T) {
 				host.StorePeer(mockPeer)
 				mockPeer.ID = idgen.PeerID("0.0.0.0")
 				host.StorePeer(mockPeer)
-				assert.Equal(host.FreeUploadLoad(), int32(database.DefaultClientLoadLimit-2))
+				assert.Equal(host.FreeUploadLoad(), int32(config.DefaultClientLoadLimit-2))
 			},
 		},
 		{
@@ -392,7 +392,7 @@ func TestHost_FreeUploadLoad(t *testing.T) {
 			rawHost: mockRawHost,
 			expect: func(t *testing.T, host *Host, mockPeer *Peer) {
 				assert := assert.New(t)
-				assert.Equal(host.FreeUploadLoad(), int32(database.DefaultClientLoadLimit))
+				assert.Equal(host.FreeUploadLoad(), int32(config.DefaultClientLoadLimit))
 			},
 		},
 	}

--- a/scheduler/scheduler/scheduler.go
+++ b/scheduler/scheduler/scheduler.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 	"time"
 
-	"d7y.io/dragonfly/v2/manager/database"
 	"d7y.io/dragonfly/v2/pkg/container/set"
 	"d7y.io/dragonfly/v2/pkg/rpc/base"
 	rpcscheduler "d7y.io/dragonfly/v2/pkg/rpc/scheduler"
@@ -33,9 +32,6 @@ import (
 )
 
 const (
-	// Default limit the number of filter traversals
-	defaultFilterParentLimit = 10
-
 	// Default tree available depth
 	defaultAvailableDepth = 2
 
@@ -219,7 +215,7 @@ func (s *scheduler) FindParent(ctx context.Context, peer *resource.Peer, blockli
 
 // Filter the parent that can be scheduled
 func (s *scheduler) filterParents(peer *resource.Peer, blocklist set.SafeSet) []*resource.Peer {
-	filterParentLimit := defaultFilterParentLimit
+	filterParentLimit := config.DefaultSchedulerFilterParentLimit
 	if config, ok := s.dynconfig.GetSchedulerClusterConfig(); ok && filterParentLimit > 0 {
 		filterParentLimit = int(config.FilterParentLimit)
 	}
@@ -293,7 +289,7 @@ func (s *scheduler) filterParents(peer *resource.Peer, blocklist set.SafeSet) []
 
 // Construct peer successful packet
 func constructSuccessPeerPacket(dynconfig config.DynconfigInterface, peer *resource.Peer, parent *resource.Peer, candidateParents []*resource.Peer) *rpcscheduler.PeerPacket {
-	parallelCount := database.DefaultClientParallelCount
+	parallelCount := config.DefaultClientParallelCount
 	if config, ok := dynconfig.GetSchedulerClusterClientConfig(); ok && config.ParallelCount > 0 {
 		parallelCount = int(config.ParallelCount)
 	}


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Change `DefaultSchedulerFilterParentLimit` value.
- Add default tag value for metrics.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
