### PR TITLE
feat: dfdaemon get available scheduler addresses in the same cluster

### DIFF
--- a/client/daemon/daemon_test.go
+++ b/client/daemon/daemon_test.go
@@ -42,12 +42,14 @@ func TestDaemonSchedulersToAvailableNetAddrs(t *testing.T) {
 			name: "available ip",
 			schedulers: []*manager.Scheduler{
 				{
-					Ip:   "127.0.0.1",
-					Port: int32(3000),
+					Ip:                 "127.0.0.1",
+					Port:               int32(3000),
+					SchedulerClusterId: 1,
 				},
 				{
-					Ip:   "127.0.0.1",
-					Port: int32(3001),
+					Ip:                 "127.0.0.1",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
 				},
 			},
 			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
@@ -59,14 +61,16 @@ func TestDaemonSchedulersToAvailableNetAddrs(t *testing.T) {
 			name: "available host",
 			schedulers: []*manager.Scheduler{
 				{
-					Ip:       "foo",
-					HostName: "localhost",
-					Port:     int32(3000),
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3000),
+					SchedulerClusterId: 1,
 				},
 				{
-					Ip:       "foo",
-					HostName: "localhost",
-					Port:     int32(3001),
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
 				},
 			},
 			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
@@ -78,29 +82,34 @@ func TestDaemonSchedulersToAvailableNetAddrs(t *testing.T) {
 			name: "available ip and host",
 			schedulers: []*manager.Scheduler{
 				{
-					Ip:       "foo",
-					HostName: "localhost",
-					Port:     int32(3000),
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3000),
+					SchedulerClusterId: 1,
 				},
 				{
-					Ip:       "foo",
-					HostName: "localhost",
-					Port:     int32(3001),
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
 				},
 				{
-					Ip:       "127.0.0.1",
-					HostName: "foo",
-					Port:     int32(3001),
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
 				},
 				{
-					Ip:       "127.0.0.1",
-					HostName: "foo",
-					Port:     int32(3000),
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3000),
+					SchedulerClusterId: 1,
 				},
 				{
-					Ip:       "127.0.0.1",
-					HostName: "foo",
-					Port:     int32(3001),
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
 				},
 			},
 			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
@@ -115,14 +124,16 @@ func TestDaemonSchedulersToAvailableNetAddrs(t *testing.T) {
 			name: "unreachable",
 			schedulers: []*manager.Scheduler{
 				{
-					Ip:       "foo",
-					HostName: "localhost",
-					Port:     int32(3001),
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
 				},
 				{
-					Ip:       "127.0.0.1",
-					HostName: "foo",
-					Port:     int32(3001),
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
 				},
 			},
 			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
@@ -136,6 +147,102 @@ func TestDaemonSchedulersToAvailableNetAddrs(t *testing.T) {
 			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
 				assert := assert.New(t)
 				assert.EqualValues(addrs, []dfnet.NetAddr{})
+			},
+		},
+		{
+			name: "available ip with different scheduler cluster",
+			schedulers: []*manager.Scheduler{
+				{
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3000),
+					SchedulerClusterId: 1,
+				},
+				{
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3000),
+					SchedulerClusterId: 1,
+				},
+				{
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3001),
+					SchedulerClusterId: 2,
+				},
+			},
+			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
+				assert := assert.New(t)
+				assert.EqualValues(addrs, []dfnet.NetAddr{
+					{Type: dfnet.TCP, Addr: "127.0.0.1:3000"},
+					{Type: dfnet.TCP, Addr: "127.0.0.1:3000"},
+				})
+			},
+		},
+		{
+			name: "available host with different scheduler cluster",
+			schedulers: []*manager.Scheduler{
+				{
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
+				},
+				{
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3000),
+					SchedulerClusterId: 2,
+				},
+				{
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3000),
+					SchedulerClusterId: 2,
+				},
+			},
+			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
+				assert := assert.New(t)
+				assert.EqualValues(addrs, []dfnet.NetAddr{
+					{Type: dfnet.TCP, Addr: "localhost:3000"},
+					{Type: dfnet.TCP, Addr: "localhost:3000"},
+				})
+			},
+		},
+		{
+			name: "available host and ip with different scheduler cluster",
+			schedulers: []*manager.Scheduler{
+				{
+					Ip:                 "foo",
+					HostName:           "localhost",
+					Port:               int32(3000),
+					SchedulerClusterId: 2,
+				},
+				{
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3001),
+					SchedulerClusterId: 1,
+				},
+				{
+					Ip:                 "127.0.0.1",
+					HostName:           "goo",
+					Port:               int32(3000),
+					SchedulerClusterId: 2,
+				},
+				{
+					Ip:                 "127.0.0.1",
+					HostName:           "foo",
+					Port:               int32(3000),
+					SchedulerClusterId: 1,
+				},
+			},
+			expect: func(t *testing.T, addrs []dfnet.NetAddr) {
+				assert := assert.New(t)
+				assert.EqualValues(addrs, []dfnet.NetAddr{
+					{Type: dfnet.TCP, Addr: "localhost:3000"},
+					{Type: dfnet.TCP, Addr: "127.0.0.1:3000"},
+				})
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Dfdaemon get avaliable scheduler addresses in the same cluster
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
