### PR TITLE
feat: if the number of failed peers in the task is greater than FailedPeerCountLimit, then scheduler notifies running peers of failure

### DIFF
--- a/manager/rpcserver/rpcserver.go
+++ b/manager/rpcserver/rpcserver.go
@@ -578,6 +578,7 @@ func (s *Server) KeepAlive(stream manager.Manager_KeepAliveServer) error {
 				logger.Infof("%s close keepalive in cluster %d", hostName, clusterID)
 				return nil
 			}
+
 			logger.Errorf("%s keepalive failed in cluster %d: %v", hostName, clusterID, err)
 			return status.Error(codes.Unknown, err.Error())
 		}

--- a/scheduler/resource/peer.go
+++ b/scheduler/resource/peer.go
@@ -231,11 +231,13 @@ func NewPeer(id string, task *Task, host *Host, options ...PeerOption) *Peer {
 
 				p.DeleteParent()
 				p.Host.DeletePeer(p.ID)
+				p.Task.PeerFailedCount.Store(0)
 				p.UpdateAt.Store(time.Now())
 				p.Log.Infof("peer state is %s", e.FSM.Current())
 			},
 			PeerEventDownloadFailed: func(e *fsm.Event) {
 				if e.Src == PeerStateBackToSource {
+					p.Task.PeerFailedCount.Inc()
 					p.Task.BackToSourcePeers.Delete(p)
 				}
 

--- a/scheduler/service/service_test.go
+++ b/scheduler/service/service_test.go
@@ -2520,6 +2520,18 @@ func TestService_handleTaskFail(t *testing.T) {
 				assert.True(task.FSM.Is(resource.TaskStateFailed))
 			},
 		},
+		{
+			name: "number of failed peers in the task is greater than FailedPeerCountLimit",
+			mock: func(task *resource.Task) {
+				task.FSM.SetState(resource.TaskStateFailed)
+				task.PeerFailedCount.Store(201)
+			},
+			expect: func(t *testing.T, task *resource.Task) {
+				assert := assert.New(t)
+				assert.True(task.FSM.Is(resource.TaskStateFailed))
+				assert.Equal(task.PeerFailedCount.Load(), int32(0))
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
if the number of failed peers in the task is greater than FailedPeerCountLimit, then scheduler notifies running peers of failure.

Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- If the number of failed peers in the task is greater than FailedPeerCountLimit, then scheduler notifies running peers of failure.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
