### PR TITLE
fix: sync pieces hang

### DIFF
--- a/client/daemon/peer/peertask_piecetask_synchronizer.go
+++ b/client/daemon/peer/peertask_piecetask_synchronizer.go
@@ -165,6 +165,7 @@ func (s *pieceTaskSyncManager) newMultiPieceTaskSynchronizer(
 		}
 		err := s.newPieceTaskSynchronizer(s.ctx, peer, request)
 		if err == nil {
+			s.peerTaskConductor.Infof("connected to peer: %s", peer.PeerId)
 			continue
 		}
 		legacyPeers = append(legacyPeers, peer)

--- a/client/daemon/rpcserver/rpcserver.go
+++ b/client/daemon/rpcserver/rpcserver.go
@@ -137,7 +137,12 @@ func (s *server) GetPieceTasks(ctx context.Context, request *base.PieceTaskReque
 
 // sendExistPieces will send as much as possible pieces
 func (s *server) sendExistPieces(request *base.PieceTaskRequest, sync dfdaemongrpc.Daemon_SyncPieceTasksServer, sentMap map[int32]struct{}) (total int32, sent int, err error) {
-	return sendExistPieces(sync.Context(), s.GetPieceTasks, request, sync, sentMap)
+	return sendExistPieces(sync.Context(), s.GetPieceTasks, request, sync, sentMap, true)
+}
+
+// sendFirstPieceTasks will send as much as possible pieces, even if no available pieces
+func (s *server) sendFirstPieceTasks(request *base.PieceTaskRequest, sync dfdaemongrpc.Daemon_SyncPieceTasksServer, sentMap map[int32]struct{}) (total int32, sent int, err error) {
+	return sendExistPieces(sync.Context(), s.GetPieceTasks, request, sync, sentMap, false)
 }
 
 func (s *server) SyncPieceTasks(sync dfdaemongrpc.Daemon_SyncPieceTasksServer) error {
@@ -147,7 +152,7 @@ func (s *server) SyncPieceTasks(sync dfdaemongrpc.Daemon_SyncPieceTasksServer) e
 	}
 	skipPieceCount := request.StartNum
 	var sentMap = make(map[int32]struct{})
-	total, sent, err := s.sendExistPieces(request, sync, sentMap)
+	total, sent, err := s.sendFirstPieceTasks(request, sync, sentMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

For legacy peers, when call SyncPieceTasks, we must receive at least one piece tasks.

If scheduler :
1. send to peer A with peer packet, main peer: peer x, steal peers: B
2. send to peer B with peer packet, main peer: peer x, steal peers: A

Both of peer A and peer B do not have any pieces, they will hang at receiving the first piece tasks.

So we need send an empty piece tasks to each others to avoid this hang bug.

## Related Issue

Fix #1220

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
