### PR TITLE
fix: client unexpected timeout

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -925,18 +925,6 @@ func (pt *peerTaskConductor) waitAvailablePeerPacket() (int32, bool) {
 		pt.span.AddEvent("back source due to scheduler says need back source ")
 		// TODO optimize back source when already downloaded some pieces
 		pt.backSource()
-	case <-time.After(pt.schedulerOption.ScheduleTimeout.Duration):
-		if pt.schedulerOption.DisableAutoBackSource {
-			pt.cancel(base.Code_ClientScheduleTimeout, reasonBackSourceDisabled)
-			err := fmt.Errorf("%s, auto back source disabled", pt.failedReason)
-			pt.span.RecordError(err)
-			pt.Errorf(err.Error())
-		} else {
-			pt.Warnf("start download from source due to %s", reasonReScheduleTimeout)
-			pt.span.AddEvent("back source due to schedule timeout")
-			pt.needBackSource.Store(true)
-			pt.backSource()
-		}
 	}
 	return -1, false
 }

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -45,9 +45,10 @@ import (
 )
 
 const (
-	//reasonContextCanceled       = "context canceled"
+	// TODO implement peer task health check
+	// reasonContextCanceled       = "context canceled"
+	// reasonReScheduleTimeout     = "wait more available peers from scheduler timeout"
 	reasonScheduleTimeout       = "wait first peer packet from scheduler timeout"
-	reasonReScheduleTimeout     = "wait more available peers from scheduler timeout"
 	reasonPeerGoneFromScheduler = "scheduler says client should disconnect"
 	reasonBackSourceDisabled    = "download from source disabled"
 


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

When all peers are using `SyncPieceTasks` GRPC,  `waitAvailablePeerPacket` will always timeout.
We need remove timeout check in `waitAvailablePeerPacket`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
