### PR TITLE
fix: client sync send unsafe call

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -142,6 +142,8 @@ type peerTaskConductor struct {
 	requestedPieces *Bitmap
 	// lock used by piece download worker
 	requestedPiecesLock sync.Mutex
+	// lock used by send piece result
+	sendPieceResultLock sync.Mutex
 	// limiter will be used when enable per peer task rate limit
 	limiter *rate.Limiter
 
@@ -1110,7 +1112,7 @@ func (pt *peerTaskConductor) waitLimit(ctx context.Context, request *DownloadPie
 	waitSpan.End()
 
 	// send error piece result
-	sendError := pt.peerPacketStream.Send(&scheduler.PieceResult{
+	sendError := pt.sendPieceResult(&scheduler.PieceResult{
 		TaskId:        pt.GetTaskID(),
 		SrcPid:        pt.GetPeerID(),
 		DstPid:        request.DstPid,
@@ -1179,7 +1181,7 @@ func (pt *peerTaskConductor) reportSuccessResult(request *DownloadPieceRequest, 
 	_, span := tracer.Start(pt.ctx, config.SpanReportPieceResult)
 	span.SetAttributes(config.AttributeWritePieceSuccess.Bool(true))
 
-	err := pt.peerPacketStream.Send(
+	err := pt.sendPieceResult(
 		&scheduler.PieceResult{
 			TaskId:        pt.GetTaskID(),
 			SrcPid:        pt.GetPeerID(),
@@ -1206,7 +1208,7 @@ func (pt *peerTaskConductor) reportFailResult(request *DownloadPieceRequest, res
 	_, span := tracer.Start(pt.ctx, config.SpanReportPieceResult)
 	span.SetAttributes(config.AttributeWritePieceSuccess.Bool(false))
 
-	err := pt.peerPacketStream.Send(&scheduler.PieceResult{
+	err := pt.sendPieceResult(&scheduler.PieceResult{
 		TaskId:        pt.GetTaskID(),
 		SrcPid:        pt.GetPeerID(),
 		DstPid:        request.DstPid,
@@ -1335,7 +1337,7 @@ func (pt *peerTaskConductor) done() {
 	defer peerResultSpan.End()
 
 	// send EOF piece result to scheduler
-	err := pt.peerPacketStream.Send(
+	err := pt.sendPieceResult(
 		schedulerclient.NewEndOfPiece(pt.taskID, pt.peerID, pt.readyPieces.Settled()))
 	pt.Debugf("end piece result sent: %v, peer task finished", err)
 
@@ -1386,7 +1388,7 @@ func (pt *peerTaskConductor) fail() {
 	pt.Log().Errorf("peer task failed, code: %d, reason: %s", pt.failedCode, pt.failedReason)
 
 	// send EOF piece result to scheduler
-	err := pt.peerPacketStream.Send(
+	err := pt.sendPieceResult(
 		schedulerclient.NewEndOfPiece(pt.taskID, pt.peerID, pt.readyPieces.Settled()))
 	pt.Debugf("end piece result sent: %v, peer task finished", err)
 
@@ -1476,4 +1478,11 @@ func (pt *peerTaskConductor) PublishPieceInfo(pieceNum int32, size uint32) {
 			Num:      pieceNum,
 			Finished: finished,
 		})
+}
+
+func (pt *peerTaskConductor) sendPieceResult(pr *scheduler.PieceResult) error {
+	pt.sendPieceResultLock.Lock()
+	err := pt.peerPacketStream.Send(pr)
+	pt.sendPieceResultLock.Unlock()
+	return err
 }

--- a/client/daemon/peer/peertask_piecetask_poller.go
+++ b/client/daemon/peer/peertask_piecetask_poller.go
@@ -121,7 +121,7 @@ retry:
 		code = de.Code
 	}
 	ptc.Errorf("get piece task from peer %s error: %s, code: %d", peer.PeerId, err, code)
-	sendError := ptc.peerPacketStream.Send(&scheduler.PieceResult{
+	sendError := ptc.sendPieceResult(&scheduler.PieceResult{
 		TaskId:        ptc.taskID,
 		SrcPid:        ptc.peerID,
 		DstPid:        peer.PeerId,
@@ -203,7 +203,7 @@ func (poller *pieceTaskPoller) getPieceTasksByPeer(
 		}
 
 		// by santong: when peer return empty, retry later
-		sendError := ptc.peerPacketStream.Send(&scheduler.PieceResult{
+		sendError := ptc.sendPieceResult(&scheduler.PieceResult{
 			TaskId:        ptc.taskID,
 			SrcPid:        ptc.peerID,
 			DstPid:        peer.PeerId,

--- a/client/daemon/peer/peertask_piecetask_synchronizer.go
+++ b/client/daemon/peer/peertask_piecetask_synchronizer.go
@@ -196,7 +196,7 @@ func compositePieceResult(peerTaskConductor *peerTaskConductor, destPeer *schedu
 }
 
 func (s *pieceTaskSyncManager) reportError(destPeer *scheduler.PeerPacket_DestPeer) {
-	sendError := s.peerTaskConductor.peerPacketStream.Send(compositePieceResult(s.peerTaskConductor, destPeer))
+	sendError := s.peerTaskConductor.sendPieceResult(compositePieceResult(s.peerTaskConductor, destPeer))
 	if sendError != nil {
 		s.peerTaskConductor.cancel(base.Code_SchedError, sendError.Error())
 		s.peerTaskConductor.Errorf("connect peer %s failed and send piece result with error: %s", destPeer.PeerId, sendError)
@@ -309,7 +309,7 @@ func (s *pieceTaskSynchronizer) acquire(request *base.PieceTaskRequest) {
 }
 
 func (s *pieceTaskSynchronizer) reportError() {
-	sendError := s.peerTaskConductor.peerPacketStream.Send(compositePieceResult(s.peerTaskConductor, s.dstPeer))
+	sendError := s.peerTaskConductor.sendPieceResult(compositePieceResult(s.peerTaskConductor, s.dstPeer))
 	if sendError != nil {
 		s.peerTaskConductor.cancel(base.Code_SchedError, sendError.Error())
 		s.peerTaskConductor.Errorf("sync piece info failed and send piece result with error: %s", sendError)


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

It is not safe to call SendMsg on the same stream in different goroutines at the same time.
Refer: https://github.com/grpc/grpc-go/blob/master/stream.go#L1405

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
