### PR TITLE
feat: redirect daemon stdout stderr to file

### DIFF
--- a/cmd/dfget/cmd/daemon.go
+++ b/cmd/dfget/cmd/daemon.go
@@ -85,10 +85,6 @@ it supports container engine, wget and other downloading tools through proxy fun
 // daemon will be launched by dfget command
 // redirect stdout and stderr to file for debugging
 func redirectStdoutAndStderr(console bool, logDir string) {
-	// only redirect the daemon which is launched by dfget
-	if viper.GetInt("launcher") == -1 {
-		return
-	}
 	// when console log is enabled, skip redirect stdout
 	if !console {
 		stdoutPath := path.Join(logDir, "daemon", "stdout.log")

--- a/cmd/dfget/cmd/daemon.go
+++ b/cmd/dfget/cmd/daemon.go
@@ -91,14 +91,14 @@ func redirectStdoutAndStderr(console bool, logDir string) {
 	}
 	// when console log is enabled, skip redirect stdout
 	if !console {
-		stdoutPath := path.Join(logDir, "stdout.log")
+		stdoutPath := path.Join(logDir, "daemon", "stdout.log")
 		if stdout, err := os.OpenFile(stdoutPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0644); err != nil {
 			logger.Warnf("open %s error: %s", stdoutPath, err)
 		} else if err := syscall.Dup2(int(stdout.Fd()), 1); err != nil {
 			logger.Warnf("redirect stdout error: %s", err)
 		}
 	}
-	stderrPath := path.Join(logDir, "stderr.log")
+	stderrPath := path.Join(logDir, "daemon", "stderr.log")
 	if stderr, err := os.OpenFile(stderrPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0644); err != nil {
 		logger.Warnf("open %s error: %s", stderrPath, err)
 	} else if err := syscall.Dup2(int(stderr.Fd()), 2); err != nil {

--- a/manager/rpcserver/rpcserver.go
+++ b/manager/rpcserver/rpcserver.go
@@ -43,18 +43,22 @@ import (
 	"d7y.io/dragonfly/v2/pkg/rpc/manager"
 )
 
-var defaultStreamMiddleWares = []grpc.StreamServerInterceptor{
-	grpc_validator.StreamServerInterceptor(),
-	grpc_recovery.StreamServerInterceptor(),
-	grpc_prometheus.StreamServerInterceptor,
-	grpc_zap.StreamServerInterceptor(logger.GrpcLogger.Desugar()),
+func defaultStreamMiddleWares() []grpc.StreamServerInterceptor {
+	return []grpc.StreamServerInterceptor{
+		grpc_validator.StreamServerInterceptor(),
+		grpc_recovery.StreamServerInterceptor(),
+		grpc_prometheus.StreamServerInterceptor,
+		grpc_zap.StreamServerInterceptor(logger.GrpcLogger.Desugar()),
+	}
 }
 
-var defaultUnaryMiddleWares = []grpc.UnaryServerInterceptor{
-	grpc_validator.UnaryServerInterceptor(),
-	grpc_recovery.UnaryServerInterceptor(),
-	grpc_prometheus.UnaryServerInterceptor,
-	grpc_zap.UnaryServerInterceptor(logger.GrpcLogger.Desugar()),
+func defaultUnaryMiddleWares() []grpc.UnaryServerInterceptor {
+	return []grpc.UnaryServerInterceptor{
+		grpc_validator.UnaryServerInterceptor(),
+		grpc_recovery.UnaryServerInterceptor(),
+		grpc_prometheus.UnaryServerInterceptor,
+		grpc_zap.UnaryServerInterceptor(logger.GrpcLogger.Desugar()),
+	}
 }
 
 type Server struct {
@@ -74,8 +78,8 @@ func New(database *database.Database, cache *cache.Cache, searcher searcher.Sear
 	}
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
-		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(defaultStreamMiddleWares...)),
-		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(defaultUnaryMiddleWares...)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(defaultStreamMiddleWares()...)),
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(defaultUnaryMiddleWares()...)),
 	}, opts...)...)
 
 	// Register servers on grpc server

--- a/pkg/rpc/cdnsystem/server/server.go
+++ b/pkg/rpc/cdnsystem/server/server.go
@@ -53,7 +53,7 @@ type proxy struct {
 }
 
 func New(seederServer SeederServer, opts ...grpc.ServerOption) *grpc.Server {
-	grpcServer := grpc.NewServer(append(rpc.DefaultServerOptions, opts...)...)
+	grpcServer := grpc.NewServer(append(rpc.DefaultServerOptions(), opts...)...)
 
 	// Register servers on grpc server
 	cdnsystem.RegisterSeederServer(grpcServer, &proxy{server: seederServer})

--- a/pkg/rpc/dfdaemon/server/server.go
+++ b/pkg/rpc/dfdaemon/server/server.go
@@ -51,7 +51,7 @@ type proxy struct {
 }
 
 func New(daemonServer DaemonServer, opts ...grpc.ServerOption) *grpc.Server {
-	grpcServer := grpc.NewServer(append(rpc.DefaultServerOptions, opts...)...)
+	grpcServer := grpc.NewServer(append(rpc.DefaultServerOptions(), opts...)...)
 	dfdaemon.RegisterDaemonServer(grpcServer, &proxy{server: daemonServer})
 	return grpcServer
 }

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -35,28 +35,30 @@ import (
 	"d7y.io/dragonfly/v2/pkg/rpc/base/common"
 )
 
-var DefaultServerOptions = []grpc.ServerOption{
-	grpc.ConnectionTimeout(10 * time.Second),
-	grpc.InitialConnWindowSize(8 * 1024 * 1024),
-	grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-		MinTime: 1 * time.Minute,
-	}),
-	grpc.KeepaliveParams(keepalive.ServerParameters{
-		MaxConnectionIdle: 5 * time.Minute,
-	}),
-	grpc.MaxConcurrentStreams(100),
-	grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
-		streamServerInterceptor,
-		grpc_prometheus.StreamServerInterceptor,
-		grpc_zap.StreamServerInterceptor(logger.GrpcLogger.Desugar()),
-		grpc_validator.StreamServerInterceptor(),
-	)),
-	grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
-		unaryServerInterceptor,
-		grpc_prometheus.UnaryServerInterceptor,
-		grpc_zap.UnaryServerInterceptor(logger.GrpcLogger.Desugar()),
-		grpc_validator.UnaryServerInterceptor(),
-	)),
+func DefaultServerOptions() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.ConnectionTimeout(10 * time.Second),
+		grpc.InitialConnWindowSize(8 * 1024 * 1024),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime: 1 * time.Minute,
+		}),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: 5 * time.Minute,
+		}),
+		grpc.MaxConcurrentStreams(100),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+			streamServerInterceptor,
+			grpc_prometheus.StreamServerInterceptor,
+			grpc_zap.StreamServerInterceptor(logger.GrpcLogger.Desugar()),
+			grpc_validator.StreamServerInterceptor(),
+		)),
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+			unaryServerInterceptor,
+			grpc_prometheus.UnaryServerInterceptor,
+			grpc_zap.UnaryServerInterceptor(logger.GrpcLogger.Desugar()),
+			grpc_validator.UnaryServerInterceptor(),
+		)),
+	}
 }
 
 func streamServerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {

--- a/scheduler/rpcserver/rpcserver.go
+++ b/scheduler/rpcserver/rpcserver.go
@@ -43,7 +43,7 @@ type Server struct {
 // New returns a new transparent scheduler server from the given options
 func New(service *service.Service, opts ...grpc.ServerOption) *grpc.Server {
 	svr := &Server{service: service}
-	grpcServer := grpc.NewServer(append(rpc.DefaultServerOptions, opts...)...)
+	grpcServer := grpc.NewServer(append(rpc.DefaultServerOptions(), opts...)...)
 
 	// Register servers on grpc server
 	scheduler.RegisterSchedulerServer(grpcServer, svr)


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

1. The dfget daemon will be launched by dfget command in backgroud, the stdout and stderr will be lost.
So we need redirect them to log files.
2. Fix zap grpc log is always wrote to stderr.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Code compiles correctly.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
