### PR TITLE
fix: client sync piece panic

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -250,9 +250,9 @@ func (pt *peerTaskConductor) register() error {
 	)
 
 	pt.Infof("step 1: peer %s start to register", pt.request.PeerId)
-	schedulerClient := pt.peerTaskManager.schedulerClient
+	pt.schedulerClient = pt.peerTaskManager.schedulerClient
 
-	result, err := schedulerClient.RegisterPeerTask(regCtx, pt.request)
+	result, err := pt.schedulerClient.RegisterPeerTask(regCtx, pt.request)
 	regSpan.RecordError(err)
 	regSpan.End()
 
@@ -269,7 +269,7 @@ func (pt *peerTaskConductor) register() error {
 		}
 		needBackSource = true
 		// can not detect source or scheduler error, create a new dummy scheduler client
-		schedulerClient = &dummySchedulerClient{}
+		pt.schedulerClient = &dummySchedulerClient{}
 		result = &scheduler.RegisterResult{TaskId: pt.taskID}
 		pt.Warnf("register peer task failed: %s, peer id: %s, try to back source", err, pt.request.PeerId)
 	} else {
@@ -304,7 +304,7 @@ func (pt *peerTaskConductor) register() error {
 		}
 	}
 
-	peerPacketStream, err := schedulerClient.ReportPieceResult(pt.ctx, result.TaskId, pt.request)
+	peerPacketStream, err := pt.schedulerClient.ReportPieceResult(pt.ctx, result.TaskId, pt.request)
 	pt.Infof("step 2: start report piece result")
 	if err != nil {
 		pt.span.RecordError(err)
@@ -313,7 +313,6 @@ func (pt *peerTaskConductor) register() error {
 	}
 
 	pt.peerPacketStream = peerPacketStream
-	pt.schedulerClient = schedulerClient
 	pt.sizeScope = sizeScope
 	pt.singlePiece = singlePiece
 	pt.tinyData = tinyData

--- a/client/daemon/peer/peertask_piecetask_synchronizer.go
+++ b/client/daemon/peer/peertask_piecetask_synchronizer.go
@@ -42,12 +42,12 @@ type pieceTaskSyncManager struct {
 }
 
 type pieceTaskSynchronizer struct {
+	*logger.SugaredLoggerOnWith
+	client            dfdaemon.Daemon_SyncPieceTasksClient
+	dstPeer           *scheduler.PeerPacket_DestPeer
+	error             atomic.Value
 	peerTaskConductor *peerTaskConductor
 	pieceRequestCh    chan *DownloadPieceRequest
-	dstPeer           *scheduler.PeerPacket_DestPeer
-	client            dfdaemon.Daemon_SyncPieceTasksClient
-	error             atomic.Value
-	*logger.SugaredLoggerOnWith
 }
 
 // FIXME for compatibility, sync will be called after the dfclient.GetPieceTasks deprecated and the pieceTaskPoller removed
@@ -227,7 +227,7 @@ func (s *pieceTaskSyncManager) cancel() {
 func (s *pieceTaskSynchronizer) close() {
 	if err := s.client.CloseSend(); err != nil {
 		s.error.Store(err)
-		s.peerTaskConductor.Debugf("close send error: %s, dest peer: %s", err, s.dstPeer.PeerId)
+		s.Debugf("close send error: %s, dest peer: %s", err, s.dstPeer.PeerId)
 	}
 }
 
@@ -235,7 +235,7 @@ func (s *pieceTaskSynchronizer) dispatchPieceRequest(piecePacket *base.PiecePack
 	s.peerTaskConductor.updateMetadata(piecePacket)
 
 	pieceCount := len(piecePacket.PieceInfos)
-	s.peerTaskConductor.Debugf("dispatch piece request, piece count: %d, dest peer: %s", pieceCount, s.dstPeer.PeerId)
+	s.Debugf("dispatch piece request, piece count: %d, dest peer: %s", pieceCount, s.dstPeer.PeerId)
 	// fix cdn return zero piece info, but with total piece count and content length
 	if pieceCount == 0 {
 		finished := s.peerTaskConductor.isCompleted()
@@ -244,7 +244,7 @@ func (s *pieceTaskSynchronizer) dispatchPieceRequest(piecePacket *base.PiecePack
 		}
 	}
 	for _, piece := range piecePacket.PieceInfos {
-		s.peerTaskConductor.Infof("got piece %d from %s/%s, digest: %s, start: %d, size: %d, dest peer: %s",
+		s.Infof("got piece %d from %s/%s, digest: %s, start: %d, size: %d, dest peer: %s",
 			piece.PieceNum, piecePacket.DstAddr, piecePacket.DstPid, piece.PieceMd5, piece.RangeStart, piece.RangeSize, s.dstPeer.PeerId)
 		// FIXME when set total piece but no total digest, fetch again
 		s.peerTaskConductor.requestedPiecesLock.Lock()
@@ -264,9 +264,9 @@ func (s *pieceTaskSynchronizer) dispatchPieceRequest(piecePacket *base.PiecePack
 		select {
 		case s.pieceRequestCh <- req:
 		case <-s.peerTaskConductor.successCh:
-			s.peerTaskConductor.Infof("peer task success, stop dispatch piece request, dest peer: %s", s.dstPeer.PeerId)
+			s.Infof("peer task success, stop dispatch piece request, dest peer: %s", s.dstPeer.PeerId)
 		case <-s.peerTaskConductor.failCh:
-			s.peerTaskConductor.Warnf("peer task fail, stop dispatch piece request, dest peer: %s", s.dstPeer.PeerId)
+			s.Warnf("peer task fail, stop dispatch piece request, dest peer: %s", s.dstPeer.PeerId)
 		}
 	}
 }
@@ -279,17 +279,17 @@ func (s *pieceTaskSynchronizer) receive(piecePacket *base.PiecePacket) {
 	for {
 		piecePacket, err = s.client.Recv()
 		if err == io.EOF {
-			s.peerTaskConductor.Debugf("synchronizer receives io.EOF")
+			s.Debugf("synchronizer receives io.EOF")
 			return
 		}
 		if err != nil {
 			if s.canceled(err) {
-				s.peerTaskConductor.Debugf("synchronizer receives canceled")
+				s.Debugf("synchronizer receives canceled")
 				return
 			}
 			s.error.Store(err)
 			s.reportError()
-			s.peerTaskConductor.Errorf("synchronizer receives with error: %s", err)
+			s.Errorf("synchronizer receives with error: %s", err)
 			return
 		}
 
@@ -301,10 +301,10 @@ func (s *pieceTaskSynchronizer) acquire(request *base.PieceTaskRequest) {
 	err := s.client.Send(request)
 	if err != nil {
 		if s.canceled(err) {
-			s.peerTaskConductor.Debugf("synchronizer sends canceled")
+			s.Debugf("synchronizer sends canceled")
 			return
 		}
-		s.peerTaskConductor.Errorf("synchronizer sends with error: %s", err)
+		s.Errorf("synchronizer sends with error: %s", err)
 		s.error.Store(err)
 		s.reportError()
 		return
@@ -315,18 +315,18 @@ func (s *pieceTaskSynchronizer) reportError() {
 	sendError := s.peerTaskConductor.sendPieceResult(compositePieceResult(s.peerTaskConductor, s.dstPeer))
 	if sendError != nil {
 		s.peerTaskConductor.cancel(base.Code_SchedError, sendError.Error())
-		s.peerTaskConductor.Errorf("sync piece info failed and send piece result with error: %s", sendError)
+		s.Errorf("sync piece info failed and send piece result with error: %s", sendError)
 	}
 }
 
 func (s *pieceTaskSynchronizer) canceled(err error) bool {
 	if err == context.Canceled {
-		s.peerTaskConductor.Debugf("context canceled, dst peer: %s", s.dstPeer.PeerId)
+		s.Debugf("context canceled, dst peer: %s", s.dstPeer.PeerId)
 		return true
 	}
 	if stat, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
 		if stat.GRPCStatus().Code() == codes.Canceled {
-			s.peerTaskConductor.Debugf("grpc canceled, dst peer: %s", s.dstPeer.PeerId)
+			s.Debugf("grpc canceled, dst peer: %s", s.dstPeer.PeerId)
 			return true
 		}
 	}

--- a/client/daemon/rpcserver/subscriber.go
+++ b/client/daemon/rpcserver/subscriber.go
@@ -96,7 +96,8 @@ func (s *subscriber) receiveRemainingPieceTaskRequests() {
 		if err == io.EOF {
 			s.Infof("SyncPieceTasks done, exit receiving")
 			return
-		} else if err != nil {
+		}
+		if err != nil {
 			if stat, ok := status.FromError(err); !ok {
 				s.Errorf("SyncPieceTasks receive error: %s", err)
 			} else if stat.Code() == codes.Canceled {

--- a/client/daemon/rpcserver/subscriber.go
+++ b/client/daemon/rpcserver/subscriber.go
@@ -96,17 +96,15 @@ func (s *subscriber) receiveRemainingPieceTaskRequests() {
 		if err == io.EOF {
 			s.Infof("SyncPieceTasks done, exit receiving")
 			return
-		}
-		if err != nil {
-			stat, ok := status.FromError(err)
-			if !ok {
+		} else if err != nil {
+			if stat, ok := status.FromError(err); !ok {
 				s.Errorf("SyncPieceTasks receive error: %s", err)
-				return
-			}
-			if stat.Code() == codes.Canceled {
+			} else if stat.Code() == codes.Canceled {
 				s.Debugf("SyncPieceTasks canceled, exit receiving")
-				return
+			} else {
+				s.Warnf("SyncPieceTasks receive error code %d/%s", stat.Code(), stat.Message())
 			}
+			return
 		}
 		s.Debugf("receive request: %#v", request)
 		pp, err := s.getPieces(s.sync.Context(), request)
@@ -158,17 +156,17 @@ loop:
 			total, _, err := s.sendExistPieces(uint32(info.Num))
 
 			if err != nil {
-				stat, ok := status.FromError(err)
-				if !ok {
-					s.Unlock()
+				if stat, ok := status.FromError(err); !ok {
+					// not grpc error
 					s.Errorf("sent exist pieces error: %s", err)
-					return err
-				}
-				if stat.Code() == codes.Canceled {
+				} else if stat.Code() == codes.Canceled {
+					err = nil
 					s.Debugf("SyncPieceTasks canceled, exit sending")
-					s.Unlock()
-					return nil
+				} else {
+					s.Warnf("SyncPieceTasks send error code %d/%s", stat.Code(), stat.Message())
 				}
+				s.Unlock()
+				return err
 			}
 			if total > -1 && s.totalPieces == -1 {
 				s.totalPieces = total
@@ -192,17 +190,17 @@ loop:
 			}
 			total, _, err := s.sendExistPieces(nextPieceNum)
 			if err != nil {
-				stat, ok := status.FromError(err)
-				if !ok {
-					s.Unlock()
+				if stat, ok := status.FromError(err); !ok {
+					// not grpc error
 					s.Errorf("sent exist pieces error: %s", err)
-					return err
-				}
-				if stat.Code() == codes.Canceled {
+				} else if stat.Code() == codes.Canceled {
+					err = nil
 					s.Debugf("SyncPieceTasks canceled, exit sending")
-					s.Unlock()
-					return nil
+				} else {
+					s.Warnf("SyncPieceTasks send error code %d/%s", stat.Code(), stat.Message())
 				}
+				s.Unlock()
+				return err
 			}
 			if total > -1 && s.totalPieces == -1 {
 				s.totalPieces = total

--- a/client/daemon/storage/local_storage.go
+++ b/client/daemon/storage/local_storage.go
@@ -380,6 +380,9 @@ func (t *localTaskStore) Store(ctx context.Context, req *StoreRequest) error {
 }
 
 func (t *localTaskStore) GetPieces(ctx context.Context, req *base.PieceTaskRequest) (*base.PiecePacket, error) {
+	if req == nil {
+		return nil, ErrBadRequest
+	}
 	if t.invalid.Load() {
 		t.Errorf("invalid digest, refuse to get pieces")
 		return nil, ErrInvalidDigest

--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -103,6 +103,7 @@ var (
 	ErrPieceCountNotSet = errors.New("total piece count not set")
 	ErrDigestNotSet     = errors.New("digest not set")
 	ErrInvalidDigest    = errors.New("invalid digest")
+	ErrBadRequest       = errors.New("bad request")
 )
 
 const (

--- a/internal/dflog/logger.go
+++ b/internal/dflog/logger.go
@@ -144,6 +144,13 @@ func WithHostnameAndIP(hostname, ip string) *SugaredLoggerOnWith {
 	}
 }
 
+func (log *SugaredLoggerOnWith) With(args ...interface{}) *SugaredLoggerOnWith {
+	args = append(args, log.withArgs...)
+	return &SugaredLoggerOnWith{
+		withArgs: args,
+	}
+}
+
 func (log *SugaredLoggerOnWith) Infof(template string, args ...interface{}) {
 	if !coreLogLevelEnabler.Enabled(zap.InfoLevel) {
 		return

--- a/pkg/safe/safe.go
+++ b/pkg/safe/safe.go
@@ -19,6 +19,8 @@ package safe
 import (
 	"fmt"
 	"runtime/debug"
+
+	logger "d7y.io/dragonfly/v2/internal/dflog"
 )
 
 // safe call function
@@ -26,6 +28,7 @@ func Call(f func()) (err error) {
 	defer func() {
 		if desc := recover(); desc != nil {
 			err = fmt.Errorf("%v", desc)
+			logger.Errorf("panic stack: %s", string(debug.Stack()))
 			debug.PrintStack()
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

1. https://github.com/dragonflyoss/Dragonfly2/blob/v2.0.2/client/daemon/rpcserver/subscriber.go#L100
When `err != ni`l, `request == nil`, and `stat.Code() != codes.Canceled`, `s.getPieces` will panic.
2. https://github.com/dragonflyoss/Dragonfly2/blob/v2.0.2/client/daemon/peer/peertask_conductor.go#L267
When register fail, `pt.cancel` will report peer result with `pt.schedulerClient`, while `pt.schedulerClient` is nil.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
