### PR TITLE
fix: client synchronizer report error lock and dial grpc timeout

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -399,6 +399,7 @@ func (pt *peerTaskConductor) cancel(code base.Code, reason string) {
 	})
 }
 
+// only use when receive back source code from scheduler
 func (pt *peerTaskConductor) markBackSource() {
 	pt.needBackSource.Store(true)
 	// when close peerPacketReady, pullPiecesFromPeers will invoke backSource
@@ -420,7 +421,7 @@ func (pt *peerTaskConductor) markBackSource() {
 	})
 }
 
-// only use when schedule timeout
+// only use when legacy get piece from peers schedule timeout
 func (pt *peerTaskConductor) forceBackSource() {
 	pt.needBackSource.Store(true)
 	pt.backSource()

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -926,8 +926,8 @@ func (pt *peerTaskConductor) waitFirstPeerPacket() (done bool, backSource bool) 
 	case _, ok := <-pt.peerPacketReady:
 		if ok {
 			// preparePieceTasksByPeer func already send piece result with error
-			pt.Infof("new peer client ready, scheduler time cost: %dus, main peer: %s",
-				time.Since(pt.startTime).Microseconds(), pt.peerPacket.Load().(*scheduler.PeerPacket).MainPeer)
+			pt.Infof("new peer client ready, scheduler time cost: %dus, peer count: %d",
+				time.Since(pt.startTime).Microseconds(), len(pt.peerPacket.Load().(*scheduler.PeerPacket).StealPeers))
 			return true, false
 		}
 		// when scheduler says base.Code_SchedNeedBackSource, receivePeerPacket will close pt.peerPacketReady
@@ -962,7 +962,7 @@ func (pt *peerTaskConductor) waitAvailablePeerPacket() (int32, bool) {
 	case _, ok := <-pt.peerPacketReady:
 		if ok {
 			// preparePieceTasksByPeer func already send piece result with error
-			pt.Infof("new peer client ready, main peer: %s", pt.peerPacket.Load().(*scheduler.PeerPacket).MainPeer)
+			pt.Infof("new peer client ready, peer count: %d", len(pt.peerPacket.Load().(*scheduler.PeerPacket).StealPeers))
 			// research from piece 0
 			return 0, true
 		}

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -119,7 +119,6 @@ type peerTaskConductor struct {
 
 	// same actions must be done only once, like close done channel and so on
 	statusOnce sync.Once
-	cancelOnce sync.Once
 	// done channel will be closed when peer task success
 	successCh chan struct{}
 	// fail channel will be closed after peer task fail
@@ -392,10 +391,10 @@ func (pt *peerTaskConductor) Log() *logger.SugaredLoggerOnWith {
 }
 
 func (pt *peerTaskConductor) cancel(code base.Code, reason string) {
-	pt.cancelOnce.Do(func() {
+	pt.statusOnce.Do(func() {
 		pt.failedCode = code
 		pt.failedReason = reason
-		pt.Fail()
+		pt.fail()
 	})
 }
 

--- a/client/daemon/peer/peertask_piecetask_synchronizer.go
+++ b/client/daemon/peer/peertask_piecetask_synchronizer.go
@@ -183,6 +183,10 @@ func (s *pieceTaskSyncManager) newMultiPieceTaskSynchronizer(
 			s.peerTaskConductor.Infof("connected to peer: %s", peer.PeerId)
 			continue
 		}
+		if err == context.DeadlineExceeded {
+			s.peerTaskConductor.Infof("connect to peer %s with error: %s, peer is invalid, skip legacy grpc", peer.PeerId, err)
+			continue
+		}
 		legacyPeers = append(legacyPeers, peer)
 		// when err is codes.Unimplemented, fallback to legacy get piece grpc
 		stat, ok := status.FromError(err)

--- a/client/daemon/peer/peertask_piecetask_synchronizer.go
+++ b/client/daemon/peer/peertask_piecetask_synchronizer.go
@@ -213,8 +213,8 @@ func compositePieceResult(peerTaskConductor *peerTaskConductor, destPeer *schedu
 func (s *pieceTaskSyncManager) reportError(destPeer *scheduler.PeerPacket_DestPeer) {
 	sendError := s.peerTaskConductor.sendPieceResult(compositePieceResult(s.peerTaskConductor, destPeer))
 	if sendError != nil {
-		s.peerTaskConductor.cancel(base.Code_SchedError, sendError.Error())
 		s.peerTaskConductor.Errorf("connect peer %s failed and send piece result with error: %s", destPeer.PeerId, sendError)
+		go s.peerTaskConductor.cancel(base.Code_SchedError, sendError.Error())
 	}
 }
 
@@ -302,12 +302,12 @@ func (s *pieceTaskSynchronizer) receive(piecePacket *base.PiecePacket) {
 	if err == io.EOF {
 		s.Debugf("synchronizer receives io.EOF")
 	} else if s.canceled(err) {
-		s.error.Store(&pieceTaskSynchronizerError{err})
 		s.Debugf("synchronizer receives canceled")
+		s.error.Store(&pieceTaskSynchronizerError{err})
 	} else {
+		s.Errorf("synchronizer receives with error: %s", err)
 		s.error.Store(&pieceTaskSynchronizerError{err})
 		s.reportError()
-		s.Errorf("synchronizer receives with error: %s", err)
 	}
 }
 
@@ -333,8 +333,8 @@ func (s *pieceTaskSynchronizer) acquire(request *base.PieceTaskRequest) error {
 func (s *pieceTaskSynchronizer) reportError() {
 	sendError := s.peerTaskConductor.sendPieceResult(compositePieceResult(s.peerTaskConductor, s.dstPeer))
 	if sendError != nil {
-		s.peerTaskConductor.cancel(base.Code_SchedError, sendError.Error())
 		s.Errorf("sync piece info failed and send piece result with error: %s", sendError)
+		go s.peerTaskConductor.cancel(base.Code_SchedError, sendError.Error())
 	}
 }
 

--- a/client/daemon/peer/peertask_piecetask_synchronizer.go
+++ b/client/daemon/peer/peertask_piecetask_synchronizer.go
@@ -139,6 +139,11 @@ func (s *pieceTaskSyncManager) newPieceTaskSynchronizer(
 
 	request.DstPid = dstPeer.PeerId
 	client, err := dfclient.SyncPieceTasks(ctx, dstPeer, request)
+	// Refer: https://github.com/grpc/grpc-go/blob/v1.44.0/stream.go#L104
+	// When receive io.EOF, the real error should be discovered using RecvMsg, here is client.Recv() here
+	if err == io.EOF && client != nil {
+		_, err = client.Recv()
+	}
 	if err != nil {
 		s.peerTaskConductor.Errorf("call SyncPieceTasks error: %s, dest peer: %s", err, dstPeer.PeerId)
 		return err

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -269,7 +269,6 @@ type candidateClient struct {
 }
 
 func (conn *Connection) createClient(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	// should not retry
 	ctx, cancel := context.WithTimeout(context.Background(), conn.dialTimeout)
 	defer cancel()
 	return grpc.DialContext(ctx, target, opts...)

--- a/pkg/rpc/manager/client/client.go
+++ b/pkg/rpc/manager/client/client.go
@@ -102,10 +102,10 @@ func NewWithAddrs(netAddrs []dfnet.NetAddr) (Client, error) {
 			logger.Infof("use %s address for manager grpc client", netAddr.Addr)
 			return New(netAddr.Addr)
 		}
-		logger.Warnf("%s address can not reachable", netAddr.Addr)
+		logger.Warnf("%s manager address can not reachable", netAddr.Addr)
 	}
 
-	return nil, errors.New("can not find available addresses")
+	return nil, errors.New("can not find available manager addresses")
 }
 
 func (c *client) GetScheduler(req *manager.GetSchedulerRequest) (*manager.Scheduler, error) {

--- a/test/e2e/dfget_test.go
+++ b/test/e2e/dfget_test.go
@@ -99,7 +99,8 @@ func singleDfgetTest(name, ns, label, podNamePrefix, container string, fileDetai
 		pod := e2eutil.NewPodExec(ns, podName, container)
 
 		// install curl
-		_, err = pod.Command("apk", "add", "-U", "curl").CombinedOutput()
+		out, err = pod.Command("apk", "add", "-U", "curl").CombinedOutput()
+		fmt.Println("apk output: " + string(out))
 		Expect(err).NotTo(HaveOccurred())
 
 		for path, size := range fileDetails {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Cancel the peer task in background when encounter report to scheduler err in sync manager
2. Remove superfluous retry to sync and get pieces from other peers to make sync pieces quickly.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
