### PR TITLE
fix: legacy cdn peer

### DIFF
--- a/scheduler/service/service_test.go
+++ b/scheduler/service/service_test.go
@@ -2583,7 +2583,7 @@ func TestService_handlePieceFail(t *testing.T) {
 
 				svc.handlePieceFail(context.Background(), peer, piece)
 				assert := assert.New(t)
-				assert.True(parent.FSM.Is(resource.PeerStateFailed))
+				assert.True(parent.FSM.Is(resource.PeerStateLeave))
 			},
 		},
 		{
@@ -2613,7 +2613,7 @@ func TestService_handlePieceFail(t *testing.T) {
 				svc.handlePieceFail(context.Background(), peer, piece)
 				assert := assert.New(t)
 				assert.True(peer.FSM.Is(resource.PeerStateRunning))
-				assert.True(parent.FSM.Is(resource.PeerStateFailed))
+				assert.True(parent.FSM.Is(resource.PeerStateLeave))
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- If cdn server's task has left and did not notify the schduler to leave the task, scheduler sets cdn peer state to `PeerStateLeave`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
