### PR TITLE
feat: enable configuration of the tls parameter for the mysql connection. i.e. tls=preferred

### DIFF
--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -87,11 +87,11 @@ type MysqlConfig struct {
 	// Enable migration
 	Migrate bool `yaml:"migrate" mapstructure:"migrate"`
 
-    // TLS setting (can be one of "true", "false", "skip-verify",  or "preferred")
-    TLS string `yaml:"tls" mapstructure:"tls"`
+	// TLS mode (can be one of "true", "false", "skip-verify",  or "preferred")
+	TLSConfig string `yaml:"tlsConfig" mapstructure:"tlsConfig"`
 
-	// TLS configuration (overrides "tls" setting above)
-	TLSConfig *TLSConfig `yaml:"tlsConfig" mapstructure:"tlsConfig"`
+	// Custom TLS configuration (overrides "TLSConfig" setting above)
+	TLS *TLSConfig `yaml:"tls" mapstructure:"tls"`
 }
 
 type TLSConfig struct {
@@ -286,16 +286,16 @@ func (cfg *Config) Validate() error {
 		return errors.New("empty database mysql dbName is not specified")
 	}
 
-	if cfg.Database.Mysql.TLSConfig != nil {
-		if cfg.Database.Mysql.TLSConfig.Cert == "" {
+	if cfg.Database.Mysql.TLS != nil {
+		if cfg.Database.Mysql.TLS.Cert == "" {
 			return errors.New("empty database mysql tls cert is not specified")
 		}
 
-		if cfg.Database.Mysql.TLSConfig.Key == "" {
+		if cfg.Database.Mysql.TLS.Key == "" {
 			return errors.New("empty database mysql tls key is not specified")
 		}
 
-		if cfg.Database.Mysql.TLSConfig.CA == "" {
+		if cfg.Database.Mysql.TLS.CA == "" {
 			return errors.New("empty database mysql tls ca is not specified")
 		}
 	}

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -87,8 +87,11 @@ type MysqlConfig struct {
 	// Enable migration
 	Migrate bool `yaml:"migrate" mapstructure:"migrate"`
 
-	// TLS configuration
-	TLS *TLSConfig `yaml:"tls" mapstructure:"tls"`
+    // TLS setting (can be one of "true", "false", "skip-verify",  or "preferred")
+    TLS string `yaml:"tls" mapstructure:"tls"`
+
+	// TLS configuration (overrides "tls" setting above)
+	TLSConfig *TLSConfig `yaml:"tlsConfig" mapstructure:"tlsConfig"`
 }
 
 type TLSConfig struct {
@@ -283,16 +286,16 @@ func (cfg *Config) Validate() error {
 		return errors.New("empty database mysql dbName is not specified")
 	}
 
-	if cfg.Database.Mysql.TLS != nil {
-		if cfg.Database.Mysql.TLS.Cert == "" {
+	if cfg.Database.Mysql.TLSConfig != nil {
+		if cfg.Database.Mysql.TLSConfig.Cert == "" {
 			return errors.New("empty database mysql tls cert is not specified")
 		}
 
-		if cfg.Database.Mysql.TLS.Key == "" {
+		if cfg.Database.Mysql.TLSConfig.Key == "" {
 			return errors.New("empty database mysql tls key is not specified")
 		}
 
-		if cfg.Database.Mysql.TLS.CA == "" {
+		if cfg.Database.Mysql.TLSConfig.CA == "" {
 			return errors.New("empty database mysql tls ca is not specified")
 		}
 	}

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -46,11 +46,11 @@ func TestManagerConfig_Load(t *testing.T) {
 		},
 		Database: &DatabaseConfig{
 			Mysql: &MysqlConfig{
-				User:     "foo",
-				Password: "foo",
-				Host:     "foo",
-				Port:     3306,
-				DBName:   "foo",
+				User:      "foo",
+				Password:  "foo",
+				Host:      "foo",
+				Port:      3306,
+				DBName:    "foo",
 				TLSConfig: "preferred",
 				TLS: &TLSConfig{
 					Cert:               "foo",

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -51,7 +51,8 @@ func TestManagerConfig_Load(t *testing.T) {
 				Host:     "foo",
 				Port:     3306,
 				DBName:   "foo",
-				TLS: &TLSConfig{
+                TLS: "preferred",
+				TLSConfig: &TLSConfig{
 					Cert:               "foo",
 					Key:                "foo",
 					CA:                 "foo",

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -51,8 +51,8 @@ func TestManagerConfig_Load(t *testing.T) {
 				Host:     "foo",
 				Port:     3306,
 				DBName:   "foo",
-                TLS: "preferred",
-				TLSConfig: &TLSConfig{
+				TLSConfig: "preferred",
+				TLS: &TLSConfig{
 					Cert:               "foo",
 					Key:                "foo",
 					CA:                 "foo",

--- a/manager/config/testdata/manager.yaml
+++ b/manager/config/testdata/manager.yaml
@@ -17,6 +17,7 @@ database:
     host: foo
     port: 3306
     dbname: foo
+    tlsConfig: preferred
     tls:
       cert: foo
       key: foo

--- a/manager/database/mysql.go
+++ b/manager/database/mysql.go
@@ -77,13 +77,12 @@ func formatDSN(cfg *config.MysqlConfig) (string, error) {
 		AllowNativePasswords: true,
 		ParseTime:            true,
 		InterpolateParams:    true,
-		Params:               map[string]string{"tls": "preferred"},
 	}
 
 	// Support TLS connection
-	if cfg.TLS != nil {
+	if cfg.TLSConfig != nil {
 		mysqlCfg.TLSConfig = "custom"
-		tls, err := cfg.TLS.Client()
+		tls, err := cfg.TLSConfig.Client()
 		if err != nil {
 			return "", err
 		}
@@ -91,7 +90,9 @@ func formatDSN(cfg *config.MysqlConfig) (string, error) {
 		if err := mysql.RegisterTLSConfig("custom", tls); err != nil {
 			return "", err
 		}
-	}
+	} else if cfg.TLS != "" { // If no custom config is specified, use tls parameter if it is set
+        mysqlCfg.Params = map[string]string{"tls": cfg.TLS}
+    }
 
 	return mysqlCfg.FormatDSN(), nil
 }

--- a/manager/database/mysql.go
+++ b/manager/database/mysql.go
@@ -80,9 +80,9 @@ func formatDSN(cfg *config.MysqlConfig) (string, error) {
 	}
 
 	// Support TLS connection
-	if cfg.TLSConfig != nil {
+	if cfg.TLS != nil {
 		mysqlCfg.TLSConfig = "custom"
-		tls, err := cfg.TLSConfig.Client()
+		tls, err := cfg.TLS.Client()
 		if err != nil {
 			return "", err
 		}
@@ -90,9 +90,9 @@ func formatDSN(cfg *config.MysqlConfig) (string, error) {
 		if err := mysql.RegisterTLSConfig("custom", tls); err != nil {
 			return "", err
 		}
-	} else if cfg.TLS != "" { // If no custom config is specified, use tls parameter if it is set
-        mysqlCfg.Params = map[string]string{"tls": cfg.TLS}
-    }
+	} else if cfg.TLSConfig != "" { // If no custom config is specified, use tlsConfig parameter if it is set
+		mysqlCfg.Params = map[string]string{"tls": cfg.TLSConfig}
+	}
 
 	return mysqlCfg.FormatDSN(), nil
 }

--- a/manager/database/mysql.go
+++ b/manager/database/mysql.go
@@ -91,7 +91,7 @@ func formatDSN(cfg *config.MysqlConfig) (string, error) {
 			return "", err
 		}
 	} else if cfg.TLSConfig != "" { // If no custom config is specified, use tlsConfig parameter if it is set
-		mysqlCfg.Params = map[string]string{"tls": cfg.TLSConfig}
+		mysqlCfg.TLSConfig = cfg.TLSConfig
 	}
 
 	return mysqlCfg.FormatDSN(), nil

--- a/manager/database/mysql.go
+++ b/manager/database/mysql.go
@@ -77,6 +77,7 @@ func formatDSN(cfg *config.MysqlConfig) (string, error) {
 		AllowNativePasswords: true,
 		ParseTime:            true,
 		InterpolateParams:    true,
+		Params:               map[string]string{"tls": "preferred"},
 	}
 
 	// Support TLS connection


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable configuration of the tls parameter for the mysql connection. An example would be setting tls to "preferred", or "true". This is separate from the tlsConfig (renamed from tls) parameter in manager.yaml, which is used to setup a custom tls config, where tls key/certs are specified. This will fix the case where the manager cannot connect to a server that requires TLS.

See the tls parameter section in the below link:
https://pkg.go.dev/github.com/go-sql-driver/mysql#section-readme

## Related Issue

https://github.com/dragonflyoss/Dragonfly2/issues/1299

## Motivation and Context

Currently Manager cannot connect to a MySQL database that requires TLS, without fully configuring certs/keys (functionality added in https://github.com/dragonflyoss/Dragonfly2/pull/1015). By making this configurable, TLS can be used (even with only password authentication).


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
