### PR TITLE
fix: remove container after generating protoc

### DIFF
--- a/hack/protoc.sh
+++ b/hack/protoc.sh
@@ -9,7 +9,7 @@ proto_modules="base cdnsystem dfdaemon manager scheduler"
 echo "generate protos..."
 
 for module in ${proto_modules}; do
-  if docker run -v $PWD:/defs ${PROTOC_ALL_IMAGE} \
+  if docker run --rm -v $PWD:/defs ${PROTOC_ALL_IMAGE} \
     -d ${PROTO_PATH}/$module -i . \
     -l ${LANGUAGE} -o . \
     --go-source-relative \


### PR DESCRIPTION
Add '--rm' option to docker command, so container will be removed
automatically. Otherwise we'll have many exited but not removed
containers as we run 'make protoc'.

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
