### PR TITLE
fix: reuse seed panic

### DIFF
--- a/client/daemon/peer/peertask_reuse.go
+++ b/client/daemon/peer/peertask_reuse.go
@@ -339,7 +339,7 @@ func (ptm *peerTaskManager) tryReuseSeedPeerTask(ctx context.Context,
 		Span:    span,
 		TaskID:  taskID,
 		SubscribeResponse: SubscribeResponse{
-			Storage:          nil,
+			Storage:          reuse.Storage,
 			PieceInfoChannel: nil,
 			Success:          successCh,
 			Fail:             nil,

--- a/client/daemon/rpcserver/seeder.go
+++ b/client/daemon/rpcserver/seeder.go
@@ -90,6 +90,18 @@ func (s *seeder) ObtainSeeds(seedRequest *cdnsystem.SeedRequest, seedsServer cdn
 		return err
 	}
 
+	if resp.SubscribeResponse.Storage == nil {
+		err = fmt.Errorf("invalid SubscribeResponse.Storage")
+		log.Errorf("%s", err.Error())
+		return err
+	}
+
+	if resp.SubscribeResponse.Success == nil && resp.SubscribeResponse.Fail == nil {
+		err = fmt.Errorf("both of SubscribeResponse.Success and SubscribeResponse.Fail is nil")
+		log.Errorf("%s", err.Error())
+		return err
+	}
+
 	log.Infof("start seed task")
 
 	err = seedsServer.Send(

--- a/client/daemon/storage/metadata.go
+++ b/client/daemon/storage/metadata.go
@@ -110,4 +110,11 @@ type UpdateTaskRequest struct {
 	Header        *source.Header
 }
 
-type ReusePeerTask = UpdateTaskRequest
+type ReusePeerTask struct {
+	PeerTaskMetadata
+	ContentLength int64
+	TotalPieces   int32
+	PieceMd5Sign  string
+	Header        *source.Header
+	Storage       TaskStorageDriver
+}

--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -500,12 +500,14 @@ func (s *storageManager) FindCompletedTask(taskID string) *ReusePeerTask {
 
 		if t.Done {
 			return &ReusePeerTask{
+				Storage: t,
 				PeerTaskMetadata: PeerTaskMetadata{
 					PeerID: t.PeerID,
 					TaskID: taskID,
 				},
 				ContentLength: t.ContentLength,
 				TotalPieces:   t.TotalPieces,
+				Header:        t.Header,
 			}
 		}
 	}
@@ -532,12 +534,14 @@ func (s *storageManager) FindPartialCompletedTask(taskID string, rg *clientutil.
 
 		if t.Done || t.partialCompleted(rg) {
 			return &ReusePeerTask{
+				Storage: t,
 				PeerTaskMetadata: PeerTaskMetadata{
 					PeerID: t.PeerID,
 					TaskID: taskID,
 				},
 				ContentLength: t.ContentLength,
 				TotalPieces:   t.TotalPieces,
+				Header:        t.Header,
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xd2ebae]

goroutine 447 [running]:
d7y.io/dragonfly/v2/client/daemon/rpcserver.(*seedSynchronizer).sendRemindingPieceSeeds(0xc000a41730, 0x1094bd9)
	/go/src/d7y.io/dragonfly/v2/client/daemon/rpcserver/seeder.go:178 +0x8e
d7y.io/dragonfly/v2/client/daemon/rpcserver.(*seedSynchronizer).sendPieceSeeds(0xc000a41730)
	/go/src/d7y.io/dragonfly/v2/client/daemon/rpcserver/seeder.go:146 +0x78c
d7y.io/dragonfly/v2/client/daemon/rpcserver.(*seeder).ObtainSeeds(0xc00000e528, 0xc000c52500, {0x12d6c10, 0xc0006a4380})
	/go/src/d7y.io/dragonfly/v2/client/daemon/rpcserver/seeder.go:119 +0x753
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
