### PR TITLE
chore: make dfget and dfcache package name follow NVR convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ PKG := "$(PROJECT_NAME)"
 PKG_LIST := $(shell go list ${PKG}/... | grep -v /vendor/ | grep -v '\(/test/\)')
 GIT_COMMIT := $(shell git rev-parse --verify HEAD --short=7)
 GIT_COMMIT_LONG := $(shell git rev-parse --verify HEAD)
-DFGET_ARCHIVE_PREFIX := "$(DFGET_NAME)_$(SEMVER)-$(VERSION_RELEASE)_$(GIT_COMMIT)"
-DFCACHE_ARCHIVE_PREFIX := "$(DFCACHE_NAME)_$(SEMVER)-$(VERSION_RELEASE)_$(GIT_COMMIT)"
+DFGET_ARCHIVE_PREFIX := "$(DFGET_NAME)-$(SEMVER)-$(VERSION_RELEASE).$(GIT_COMMIT)"
+DFCACHE_ARCHIVE_PREFIX := "$(DFCACHE_NAME)-$(SEMVER)-$(VERSION_RELEASE).$(GIT_COMMIT)"
 
 all: help
 
@@ -184,8 +184,8 @@ build-rpm-dfget: build-linux-dfget
 	-e "VERSION_RELEASE=$(VERSION_RELEASE)" \
 	goreleaser/nfpm pkg \
 		--config /root/build/package/nfpm/dfget.yaml \
-		--target /root/bin/$(DFGET_ARCHIVE_PREFIX)_linux_amd64.rpm
-	@echo "Build package output: ./bin/$(DFGET_ARCHIVE_PREFIX)_linux_amd64.rpm"
+		--target /root/bin/$(DFGET_ARCHIVE_PREFIX).linux_amd64.rpm
+	@echo "Build package output: ./bin/$(DFGET_ARCHIVE_PREFIX).linux_amd64.rpm"
 .PHONY: build-rpm-dfget
 
 # Build rpm dfcache
@@ -201,8 +201,8 @@ build-rpm-dfcache: build-linux-dfcache build-dfcache-man-page
 	-e "VERSION_RELEASE=$(VERSION_RELEASE)" \
 	goreleaser/nfpm pkg \
 		--config /root/build/package/nfpm/dfcache.yaml \
-		--target /root/bin/$(DFCACHE_ARCHIVE_PREFIX)_linux_amd64.rpm
-	@echo "Build package output: ./bin/$(DFCACHE_ARCHIVE_PREFIX)_linux_amd64.rpm"
+		--target /root/bin/$(DFCACHE_ARCHIVE_PREFIX).linux_amd64.rpm
+	@echo "Build package output: ./bin/$(DFCACHE_ARCHIVE_PREFIX).linux_amd64.rpm"
 .PHONY: build-rpm-dfcache
 
 # Build deb dfget
@@ -218,8 +218,8 @@ build-deb-dfget: build-linux-dfget
 	-e "VERSION_RELEASE=$(VERSION_RELEASE)" \
 	goreleaser/nfpm pkg \
 		--config /root/build/package/nfpm/dfget.yaml \
-		--target /root/bin/$(DFGET_ARCHIVE_PREFIX)_linux_amd64.deb
-	@echo "Build package output: ./bin/$(DFGET_ARCHIVE_PREFIX)_linux_amd64.deb"
+		--target /root/bin/$(DFGET_ARCHIVE_PREFIX).linux_amd64.deb
+	@echo "Build package output: ./bin/$(DFGET_ARCHIVE_PREFIX).linux_amd64.deb"
 .PHONY: build-deb-dfget
 
 # Build deb dfcache
@@ -235,8 +235,8 @@ build-deb-dfcache: build-linux-dfcache build-dfcache-man-page
 	-e "VERSION_RELEASE=$(VERSION_RELEASE)" \
 	goreleaser/nfpm pkg \
 		--config /root/build/package/nfpm/dfcache.yaml \
-		--target /root/bin/$(DFCACHE_ARCHIVE_PREFIX)_linux_amd64.deb
-	@echo "Build package output: ./bin/$(DFCACHE_ARCHIVE_PREFIX)_linux_amd64.deb"
+		--target /root/bin/$(DFCACHE_ARCHIVE_PREFIX).linux_amd64.deb
+	@echo "Build package output: ./bin/$(DFCACHE_ARCHIVE_PREFIX).linux_amd64.deb"
 .PHONY: build-deb-dfcache
 
 # Generate dfget man page


### PR DESCRIPTION
NVR requires packages to be named as Name-Version-Release format, so
change dfget and dfcache package name to follow NVR convention.

So the name is dfget or dfcache, version is $SEMVER, e.g. "2.0.1",
the following are all release. e.g.

old: dfget_2.0.1-1_<commit>_linux_amd64.rpm
new: dfget-2.0.1-1.<commit>.linux_amd64.rpm

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
