### PR TITLE
fix: find partial completed overflow

### DIFF
--- a/client/daemon/storage/local_storage.go
+++ b/client/daemon/storage/local_storage.go
@@ -605,7 +605,23 @@ func (t *localTaskStore) partialCompleted(rg *clientutil.Range) bool {
 	if t.ContentLength == -1 {
 		return false
 	}
-	start, end := computePiecePosition(t.ContentLength, rg, util.ComputePieceSize)
+
+	realRange := &clientutil.Range{
+		Start:  rg.Start,
+		Length: rg.Length,
+	}
+
+	// handle range like: bytes=1024-
+	if realRange.Start+realRange.Length > t.ContentLength {
+		realRange.Length = t.ContentLength - realRange.Start
+	}
+
+	start, end := computePiecePosition(t.ContentLength, realRange, util.ComputePieceSize)
+	// fix int overflow
+	if start < 0 || end < 0 {
+		t.Warnf("wrong start and end piece num, %d, %d", start, end)
+		return false
+	}
 	for i := start; i <= end; i++ {
 		if _, ok := t.Pieces[i]; !ok {
 			return false


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

For range like: bytes=1024-, func `computePiecePosition` will return a negative end due to overflow, we need check the content length first.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
