### PR TITLE
feat: use uid/gid as UserID and UserGroup if current user not found in passwd

### DIFF
--- a/pkg/basic/user.go
+++ b/pkg/basic/user.go
@@ -17,11 +17,14 @@
 package basic
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"strconv"
 	"strings"
+	"syscall"
 
+	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/util/stringutils"
 )
 
@@ -36,17 +39,23 @@ var (
 func init() {
 	u, err := user.Current()
 	if err != nil {
-		panic(err)
-	}
+		logger.Warnf("Failed to get current user: %s", err.Error())
+		logger.Info("Use uid as Username")
 
-	Username = u.Username
-	UserID, _ = strconv.Atoi(u.Uid)
-	UserGroup, _ = strconv.Atoi(u.Gid)
+		UserID = syscall.Getuid()
+		Username = fmt.Sprintf("%d", UserID)
+		UserGroup = syscall.Getgid()
+		HomeDir = "/"
+	} else {
+		Username = u.Username
+		UserID, _ = strconv.Atoi(u.Uid)
+		UserGroup, _ = strconv.Atoi(u.Gid)
 
-	HomeDir = u.HomeDir
-	HomeDir = strings.TrimSpace(HomeDir)
-	if stringutils.IsBlank(HomeDir) {
-		panic("home dir is empty")
+		HomeDir = u.HomeDir
+		HomeDir = strings.TrimSpace(HomeDir)
+		if stringutils.IsBlank(HomeDir) {
+			panic("home dir is empty")
+		}
 	}
 
 	TmpDir = os.TempDir()


### PR DESCRIPTION
If user.Current() failed to parse current user info, e.g. no entry in
passwd file, use uid/gid as UserID and UserGroup, and use "/" as
default HomeDir. So we don't need to panic.

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
