### PR TITLE
feat: use 127.0.0.1 as IPv4 if there's no external IPv4 addr

### DIFF
--- a/pkg/util/net/iputils/ip_utils.go
+++ b/pkg/util/net/iputils/ip_utils.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 )
 

--- a/pkg/util/net/iputils/ip_utils.go
+++ b/pkg/util/net/iputils/ip_utils.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
-	
+
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 )
 

--- a/pkg/util/net/iputils/ip_utils.go
+++ b/pkg/util/net/iputils/ip_utils.go
@@ -22,17 +22,22 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	logger "d7y.io/dragonfly/v2/internal/dflog"
 )
 
 var IPv4 string
 
+const internalIPv4 string = "127.0.0.1"
+
 func init() {
 	ip, err := externalIPv4()
 	if err != nil {
-		panic(err)
+		logger.Warnf("Failed to get IPv4 address: %s", err.Error())
+		logger.Infof("Use %s as IPv4 addr", internalIPv4)
+		IPv4 = internalIPv4
+	} else {
+		IPv4 = ip
 	}
-
-	IPv4 = ip
 }
 
 // IsIPv4 returns whether the ip is a valid IPv4 Address.


### PR DESCRIPTION
Since commit 0bc0d3b7ead8 ("feat: add vsock network type support
(#1303)") we have vsock support, which means we could run dfget in a
constrained VM env that only has loopback net interface, and connect to
dfdaemon on host via vsock connection. So it's a valid setup to have no
external IPv4 addr.

Don't panic in this case and use "127.0.0.1" as IPv4.

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
