### PR TITLE
fix ratelimit

### DIFF
--- a/client/config/dfget.go
+++ b/client/config/dfget.go
@@ -29,8 +29,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/time/rate"
 
+	"d7y.io/dragonfly/v2/client/clientutil"
 	"d7y.io/dragonfly/v2/cmd/dependency/base"
 	"d7y.io/dragonfly/v2/internal/dferrors"
 	logger "d7y.io/dragonfly/v2/internal/dflog"
@@ -103,7 +103,7 @@ type ClientOption struct {
 	// WorkHome is working directory of dfget.
 	WorkHome string `yaml:"workHome,omitempty" mapstructure:"workHome,omitempty"`
 
-	RateLimit rate.Limit `yaml:"rateLimit,omitempty" mapstructure:"rateLimit,omitempty"`
+	RateLimit clientutil.RateLimit `yaml:"rateLimit,omitempty" mapstructure:"rateLimit,omitempty"`
 
 	// Config file paths,
 	// default:["/etc/dragonfly/dfget.yaml","/etc/dragonfly.conf"].

--- a/client/config/dfget_darwin.go
+++ b/client/config/dfget_darwin.go
@@ -19,14 +19,20 @@
 
 package config
 
-import "d7y.io/dragonfly/v2/pkg/unit"
+import (
+	"d7y.io/dragonfly/v2/client/clientutil"
+	"d7y.io/dragonfly/v2/pkg/unit"
+	"golang.org/x/time/rate"
+)
 
 var dfgetConfig = ClientOption{
-	URL:               "",
-	Output:            "",
-	Timeout:           0,
-	BenchmarkRate:     128 * unit.KB,
-	RateLimit:         0,
+	URL:           "",
+	Output:        "",
+	Timeout:       0,
+	BenchmarkRate: 128 * unit.KB,
+	RateLimit: clientutil.RateLimit{
+		Limit: rate.Limit(DefaultTotalDownloadLimit),
+	},
 	Md5:               "",
 	DigestMethod:      "",
 	DigestValue:       "",

--- a/client/config/dfget_linux.go
+++ b/client/config/dfget_linux.go
@@ -19,10 +19,15 @@
 
 package config
 
+import "d7y.io/dragonfly/v2/client/clientutil"
+
 var dfgetConfig = ClientOption{
-	URL:               "",
-	Output:            "",
-	Timeout:           0,
+	URL:     "",
+	Output:  "",
+	Timeout: 0,
+	RateLimit: clientutil.RateLimit{
+		Limit: rate.Limit(DefaultTotalDownloadLimit),
+	},
 	Md5:               "",
 	DigestMethod:      "",
 	DigestValue:       "",

--- a/client/dfget/dfget.go
+++ b/client/dfget/dfget.go
@@ -220,7 +220,7 @@ func newDownRequest(cfg *config.DfgetConfig, hdr map[string]string) *dfdaemon.Do
 		Url:               cfg.URL,
 		Output:            cfg.Output,
 		Timeout:           uint64(cfg.Timeout),
-		Limit:             float64(cfg.RateLimit),
+		Limit:             float64(cfg.RateLimit.Limit),
 		DisableBackSource: cfg.DisableBackSource,
 		UrlMeta: &base.UrlMeta{
 			Digest: cfg.Digest,

--- a/cmd/dfget/cmd/root.go
+++ b/cmd/dfget/cmd/root.go
@@ -139,7 +139,7 @@ func init() {
 
 	flagSet.Duration("timeout", dfgetConfig.Timeout, "Timeout for the downloading task, 0 is infinite")
 
-	flagSet.String("limit", unit.Bytes(dfgetConfig.RateLimit).String(),
+	flagSet.String("ratelimit", unit.Bytes(dfgetConfig.RateLimit.Limit).String(),
 		"The downloading network bandwidth limit per second in format of G(B)/g/M(B)/m/K(B)/k/B, pure number will be parsed as Byte, 0 is infinite")
 
 	flagSet.String("digest", dfgetConfig.Digest,


### PR DESCRIPTION
Signed-off-by: ljx373327 <ljx373327@alibaba-inc.com>

fix dfget limit flag err

## Description

limit flag can't  use because deserialization failed

## Related Issue

#1377

## Motivation and Context

- fix failed to deserialize because of rate limit type error, replace with rate limit wrapper class
- fix flag limit and the keyword ratelimit do not match

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/39621720/174006171-a0a9f5e9-deae-4e53-b2f9-7be04c869848.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
