### PR TITLE
fix: downloadFromSource() doesn't validate response

### DIFF
--- a/client/dfget/dfget.go
+++ b/client/dfget/dfget.go
@@ -165,6 +165,9 @@ func downloadFromSource(ctx context.Context, cfg *config.DfgetConfig, hdr map[st
 		return err
 	}
 	defer response.Body.Close()
+	if err = response.Validate(); err != nil {
+		return err
+	}
 
 	if written, err = io.Copy(target, response.Body); err != nil {
 		return err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In dragonfly v2.0.3, `func (client *httpSourceClient) Download(request *source.Request)` is rewrited, now when status code is not 200/206, it will not directly return error, instead, a status code validation function is assigned to `response.Validate()`.
https://github.com/dragonflyoss/Dragonfly2/blob/b705780a3340fd2f4a15b06483ea77ff7539be77/pkg/source/clients/httpprotocol/http_source_client.go#L185-L198
However, `downloadFromSource()` doesn't call `response.Validate()` to validate, so it will still copy response to target file and report success.

I added validation in `downloadFromSource()`, now it works well (see screenshot below).


<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/Dragonfly2/issues/1397


<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/40566803/174270076-d9cdf8f5-4e1b-4dc9-93cf-bd2c97864df8.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
