### PR TITLE
fix:upload_manager write header immediately when it is ready

### DIFF
--- a/client/daemon/upload/upload_manager.go
+++ b/client/daemon/upload/upload_manager.go
@@ -212,6 +212,9 @@ func (um *uploadManager) getDownload(ctx *gin.Context) {
 	}
 	defer closer.Close()
 
+	// write header immediately, prevent client disconnecting after limiter.Wait() due to response header timeout
+	ctx.Writer.WriteHeaderNow()
+
 	if um.Limiter != nil {
 		if err = um.Limiter.WaitN(ctx, int(rg[0].Length)); err != nil {
 			log.Errorf("get limit failed: %s", err)


### PR DESCRIPTION
Signed-off-by: bigerous <bigerous@qq.com>

<!--- Provide a general summary of your changes in the Title above -->

uploader should write header immediately, prevent client disconnecting after limiter.Wait() due to response header timeout

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
