### PR TITLE
fix: infinite loop in peer.Ancestors()

### DIFF
--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -26,3 +26,18 @@ func Contains[T comparable](s []T, e T) bool {
 
 	return false
 }
+
+// FindDuplicate returns duplicate element in a collection.
+func FindDuplicate[T comparable](s []T) (T, bool) {
+	visited := make(map[T]struct{})
+	for _, v := range s {
+		if _, ok := visited[v]; ok {
+			return v, true
+		}
+
+		visited[v] = struct{}{}
+	}
+
+	var zero T
+	return zero, false
+}

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -29,3 +29,25 @@ func TestContains(t *testing.T) {
 	assert.True(Contains([]string{"a", "b", "c"}, "a"))
 	assert.False(Contains([]string{"a", "b", "c"}, "d"))
 }
+
+func TestFindDuplicate(t *testing.T) {
+	assert := assert.New(t)
+	var (
+		dupi  int
+		dups  string
+		found bool
+	)
+	dupi, found = FindDuplicate([]int{1, 2, 1, 3})
+	assert.True(found)
+	assert.Equal(dupi, 1)
+
+	_, found = FindDuplicate([]int{1, 2, 3})
+	assert.False(found)
+
+	dups, found = FindDuplicate([]string{"a", "b", "c", "b"})
+	assert.True(found)
+	assert.Equal(dups, "b")
+
+	_, found = FindDuplicate([]string{"a", "b", "c"})
+	assert.False(found)
+}

--- a/scheduler/resource/peer_test.go
+++ b/scheduler/resource/peer_test.go
@@ -526,7 +526,7 @@ func TestPeer_Depth(t *testing.T) {
 				peer.StoreParent(peer)
 
 				assert := assert.New(t)
-				assert.Equal(peer.Depth(), 1)
+				assert.Equal(peer.Depth(), 2)
 			},
 		},
 	}
@@ -557,8 +557,8 @@ func TestPeer_Ancestors(t *testing.T) {
 			expect: func(t *testing.T, peer *Peer, mockChildPeer *Peer) {
 				assert := assert.New(t)
 				peer.StoreChild(mockChildPeer)
-				assert.Equal(len(mockChildPeer.Ancestors()), 1)
-				assert.EqualValues(mockChildPeer.Ancestors(), []string{peer.ID})
+				assert.Equal(len(mockChildPeer.Ancestors()), 2)
+				assert.EqualValues(mockChildPeer.Ancestors(), []string{mockChildPeer.ID, peer.ID})
 			},
 		},
 		{
@@ -566,8 +566,8 @@ func TestPeer_Ancestors(t *testing.T) {
 			childID: idgen.PeerID("127.0.0.1"),
 			expect: func(t *testing.T, peer *Peer, mockChildPeer *Peer) {
 				assert := assert.New(t)
-				assert.Equal(len(mockChildPeer.Ancestors()), 0)
-				assert.EqualValues(mockChildPeer.Ancestors(), []string(nil))
+				assert.Equal(len(mockChildPeer.Ancestors()), 1)
+				assert.EqualValues(mockChildPeer.Ancestors(), []string{mockChildPeer.ID})
 			},
 		},
 		{
@@ -576,8 +576,8 @@ func TestPeer_Ancestors(t *testing.T) {
 			expect: func(t *testing.T, peer *Peer, mockChildPeer *Peer) {
 				assert := assert.New(t)
 				peer.StoreChild(peer)
-				assert.Equal(len(peer.Ancestors()), 0)
-				assert.Equal(peer.Ancestors(), []string(nil))
+				assert.Equal(len(peer.Ancestors()), 2)
+				assert.Equal(peer.Ancestors(), []string{peer.ID, peer.ID})
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix infinite loop in `peer.Ancestors()`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
