### PR TITLE
feat: refresh dynconfig addresses when grpc requests unavailable

### DIFF
--- a/client/daemon/daemon.go
+++ b/client/daemon/daemon.go
@@ -162,8 +162,14 @@ func New(opt *config.DaemonOption, d dfpath.Dfpath) (Daemon, error) {
 	var schedulerClientOptions []grpc.DialOption
 	if opt.Options.Telemetry.Jaeger != "" {
 		schedulerClientOptions = append(schedulerClientOptions,
-			grpc.WithChainUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-			grpc.WithChainStreamInterceptor(otelgrpc.StreamClientInterceptor()),
+			grpc.WithChainUnaryInterceptor(
+				otelgrpc.UnaryClientInterceptor(),
+				rpc.RefresherUnaryClientInterceptor(dynconfig),
+			),
+			grpc.WithChainStreamInterceptor(
+				otelgrpc.StreamClientInterceptor(),
+				rpc.RefresherStreamClientInterceptor(dynconfig),
+			),
 		)
 	}
 

--- a/pkg/rpc/interceptor.go
+++ b/pkg/rpc/interceptor.go
@@ -1,0 +1,59 @@
+/*
+ *     Copyright 2022 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Refresher is the interface for refreshing dynconfig.
+type Refresher interface {
+	Refresh() error
+}
+
+// UnaryClientInterceptor returns a new unary client interceptor that refresh dynconfig addresses when calling error.
+func RefresherUnaryClientInterceptor(r Refresher) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if s, ok := status.FromError(err); ok {
+			if s.Code() == codes.ResourceExhausted || s.Code() == codes.Unavailable {
+				// nolint
+				r.Refresh()
+			}
+		}
+
+		return err
+	}
+}
+
+// StreamClientInterceptor returns a new stream client interceptor that refresh dynconfig addresses when calling error.
+func RefresherStreamClientInterceptor(r Refresher) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		if s, ok := status.FromError(err); ok {
+			if s.Code() == codes.ResourceExhausted || s.Code() == codes.Unavailable {
+				// nolint
+				r.Refresh()
+			}
+		}
+		return clientStream, err
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -34,6 +34,7 @@ import (
 	"d7y.io/dragonfly/v2/pkg/dfpath"
 	"d7y.io/dragonfly/v2/pkg/gc"
 	"d7y.io/dragonfly/v2/pkg/resolver"
+	"d7y.io/dragonfly/v2/pkg/rpc"
 	managerclient "d7y.io/dragonfly/v2/pkg/rpc/manager/client"
 	"d7y.io/dragonfly/v2/scheduler/config"
 	"d7y.io/dragonfly/v2/scheduler/job"
@@ -127,8 +128,14 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath) (*Server, err
 	if s.config.Options.Telemetry.Jaeger != "" {
 		seedPeerDialOptions = append(
 			seedPeerDialOptions,
-			grpc.WithChainUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-			grpc.WithChainStreamInterceptor(otelgrpc.StreamClientInterceptor()),
+			grpc.WithChainUnaryInterceptor(
+				otelgrpc.UnaryClientInterceptor(),
+				rpc.RefresherUnaryClientInterceptor(dynconfig),
+			),
+			grpc.WithChainStreamInterceptor(
+				otelgrpc.StreamClientInterceptor(),
+				rpc.RefresherStreamClientInterceptor(dynconfig),
+			),
 		)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Refresh dynconfig addresses when grpc requests unavailable.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
