### PR TITLE
feat: add MaxConnectionIdle to grpc keepalive

### DIFF
--- a/pkg/rpc/cdnsystem/server/server.go
+++ b/pkg/rpc/cdnsystem/server/server.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"time"
+
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpc_ratelimit "github.com/grpc-ecosystem/go-grpc-middleware/ratelimit"
@@ -27,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 
 	cdnsystemv1 "d7y.io/api/pkg/apis/cdnsystem/v1"
 
@@ -40,6 +43,15 @@ const (
 
 	// DefaultBurst is default burst of grpc server.
 	DefaultBurst = 20 * 1000
+
+	// DefaultMaxConnectionIdle is default max connection idle of grpc keepalive.
+	DefaultMaxConnectionIdle = 10 * time.Minute
+
+	// DefaultMaxConnectionAge is default max connection age of grpc keepalive.
+	DefaultMaxConnectionAge = 12 * time.Hour
+
+	// DefaultMaxConnectionAgeGrace is default max connection age grace of grpc keepalive.
+	DefaultMaxConnectionAgeGrace = 5 * time.Minute
 )
 
 // New returns a grpc server instance and register service on grpc server.
@@ -47,6 +59,11 @@ func New(svr cdnsystemv1.SeederServer, opts ...grpc.ServerOption) *grpc.Server {
 	limiter := rpc.NewRateLimiterInterceptor(DefaultQPS, DefaultBurst)
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle:     DefaultMaxConnectionIdle,
+			MaxConnectionAge:      DefaultMaxConnectionAge,
+			MaxConnectionAgeGrace: DefaultMaxConnectionAgeGrace,
+		}),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_ratelimit.UnaryServerInterceptor(limiter),
 			rpc.ConvertErrorUnaryServerInterceptor,

--- a/pkg/rpc/dfdaemon/server/server.go
+++ b/pkg/rpc/dfdaemon/server/server.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"time"
+
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpc_ratelimit "github.com/grpc-ecosystem/go-grpc-middleware/ratelimit"
@@ -27,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 
 	dfdaemonv1 "d7y.io/api/pkg/apis/dfdaemon/v1"
 
@@ -40,6 +43,15 @@ const (
 
 	// DefaultBurst is default burst of grpc server.
 	DefaultBurst = 20 * 1000
+
+	// DefaultMaxConnectionIdle is default max connection idle of grpc keepalive.
+	DefaultMaxConnectionIdle = 10 * time.Minute
+
+	// DefaultMaxConnectionAge is default max connection age of grpc keepalive.
+	DefaultMaxConnectionAge = 12 * time.Hour
+
+	// DefaultMaxConnectionAgeGrace is default max connection age grace of grpc keepalive.
+	DefaultMaxConnectionAgeGrace = 5 * time.Minute
 )
 
 // New returns a grpc server instance and register service on grpc server.
@@ -47,6 +59,11 @@ func New(svr dfdaemonv1.DaemonServer, opts ...grpc.ServerOption) *grpc.Server {
 	limiter := rpc.NewRateLimiterInterceptor(DefaultQPS, DefaultBurst)
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle:     DefaultMaxConnectionIdle,
+			MaxConnectionAge:      DefaultMaxConnectionAge,
+			MaxConnectionAgeGrace: DefaultMaxConnectionAgeGrace,
+		}),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_ratelimit.UnaryServerInterceptor(limiter),
 			rpc.ConvertErrorUnaryServerInterceptor,

--- a/pkg/rpc/scheduler/server/server.go
+++ b/pkg/rpc/scheduler/server/server.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"time"
+
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpc_ratelimit "github.com/grpc-ecosystem/go-grpc-middleware/ratelimit"
@@ -27,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 
 	schedulerv1 "d7y.io/api/pkg/apis/scheduler/v1"
 
@@ -40,6 +43,15 @@ const (
 
 	// DefaultBurst is default burst of grpc server.
 	DefaultBurst = 20 * 1000
+
+	// DefaultMaxConnectionIdle is default max connection idle of grpc keepalive.
+	DefaultMaxConnectionIdle = 10 * time.Minute
+
+	// DefaultMaxConnectionAge is default max connection age of grpc keepalive.
+	DefaultMaxConnectionAge = 12 * time.Hour
+
+	// DefaultMaxConnectionAgeGrace is default max connection age grace of grpc keepalive.
+	DefaultMaxConnectionAgeGrace = 5 * time.Minute
 )
 
 // New returns a grpc server instance and register service on grpc server.
@@ -47,6 +59,11 @@ func New(svr schedulerv1.SchedulerServer, opts ...grpc.ServerOption) *grpc.Serve
 	limiter := rpc.NewRateLimiterInterceptor(DefaultQPS, DefaultBurst)
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle:     DefaultMaxConnectionIdle,
+			MaxConnectionAge:      DefaultMaxConnectionAge,
+			MaxConnectionAgeGrace: DefaultMaxConnectionAgeGrace,
+		}),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_ratelimit.UnaryServerInterceptor(limiter),
 			rpc.ConvertErrorUnaryServerInterceptor,


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add `MaxConnectionIdle`, `MaxConnectionAge` and `MaxConnectionAgeGrace` to grpc keepalive.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
