### PR TITLE
feat: unregister failed task storage

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -1641,7 +1641,7 @@ func (pt *peerTaskConductor) fail() {
 			pt.pieceTaskSyncManager.cancel()
 		}
 		// mark storage to reclaim
-		pt.StorageManager.UnregisterTask(
+		_ = pt.StorageManager.UnregisterTask(
 			pt.ctx,
 			storage.CommonTaskRequest{
 				PeerID: pt.peerID,

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -1640,6 +1640,13 @@ func (pt *peerTaskConductor) fail() {
 		if pt.pieceTaskSyncManager != nil {
 			pt.pieceTaskSyncManager.cancel()
 		}
+		// mark storage to reclaim
+		pt.StorageManager.UnregisterTask(
+			pt.ctx,
+			storage.CommonTaskRequest{
+				PeerID: pt.peerID,
+				TaskID: pt.taskID,
+			})
 	}()
 	pt.peerTaskManager.PeerTaskDone(pt.taskID)
 	var end = time.Now()

--- a/client/daemon/storage/local_storage.go
+++ b/client/daemon/storage/local_storage.go
@@ -486,6 +486,10 @@ func (t *localTaskStore) CanReclaim() bool {
 	return reclaim
 }
 
+func (t *localTaskStore) MarkInvalid() {
+	t.invalid.Store(true)
+}
+
 // MarkReclaim will try to invoke gcCallback (normal leave peer task)
 func (t *localTaskStore) MarkReclaim() {
 	if t.reclaimMarked.Load() {

--- a/client/daemon/storage/local_storage_subtask.go
+++ b/client/daemon/storage/local_storage_subtask.go
@@ -391,6 +391,13 @@ func (t *localSubTaskStore) CanReclaim() bool {
 	return false
 }
 
+func (t *localSubTaskStore) MarkInvalid() {
+	if t.parent.Done || t.invalid.Load() {
+		return
+	}
+	t.parent.MarkInvalid()
+}
+
 func (t *localSubTaskStore) MarkReclaim() {
 	t.parent.gcCallback(CommonTaskRequest{
 		PeerID: t.PeerID,

--- a/client/daemon/storage/mocks/stroage_manager_mock.go
+++ b/client/daemon/storage/mocks/stroage_manager_mock.go
@@ -224,6 +224,18 @@ func (mr *MockReclaimerMockRecorder) CanReclaim() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanReclaim", reflect.TypeOf((*MockReclaimer)(nil).CanReclaim))
 }
 
+// MarkInvalid mocks base method.
+func (m *MockReclaimer) MarkInvalid() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkInvalid")
+}
+
+// MarkInvalid indicates an expected call of MarkInvalid.
+func (mr *MockReclaimerMockRecorder) MarkInvalid() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkInvalid", reflect.TypeOf((*MockReclaimer)(nil).MarkInvalid))
+}
+
 // MarkReclaim mocks base method.
 func (m *MockReclaimer) MarkReclaim() {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

The gc did not known which task is failed and mark it reclaim, we need unregister failed task storage first.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
