### PR TITLE
fix: gorm can not update is_default field

### DIFF
--- a/manager/service/scheduler_cluster.go
+++ b/manager/service/scheduler_cluster.go
@@ -109,9 +109,16 @@ func (s *service) UpdateSchedulerCluster(ctx context.Context, id uint, json type
 		Config:       config,
 		ClientConfig: clientConfig,
 		Scopes:       scopes,
-		IsDefault:    json.IsDefault,
 	}).Error; err != nil {
 		return nil, err
+	}
+
+	// Updates does not accept bool as false.
+	// Refer to https://stackoverflow.com/questions/56653423/gorm-doesnt-update-boolean-field-to-false.
+	if json.IsDefault != schedulerCluster.IsDefault {
+		if err := s.db.WithContext(ctx).First(&schedulerCluster, id).Update("is_default", json.IsDefault).Error; err != nil {
+			return nil, err
+		}
 	}
 
 	if json.SeedPeerClusterID > 0 {

--- a/manager/service/seed_peer_cluster.go
+++ b/manager/service/seed_peer_cluster.go
@@ -81,13 +81,20 @@ func (s *service) UpdateSeedPeerCluster(ctx context.Context, id uint, json types
 
 	seedPeerCluster := model.SeedPeerCluster{}
 	if err := s.db.WithContext(ctx).First(&seedPeerCluster, id).Updates(model.SeedPeerCluster{
-		Name:      json.Name,
-		BIO:       json.BIO,
-		Config:    config,
-		Scopes:    scopes,
-		IsDefault: json.IsDefault,
+		Name:   json.Name,
+		BIO:    json.BIO,
+		Config: config,
+		Scopes: scopes,
 	}).Error; err != nil {
 		return nil, err
+	}
+
+	// Updates does not accept bool as false.
+	// Refer to https://stackoverflow.com/questions/56653423/gorm-doesnt-update-boolean-field-to-false.
+	if json.IsDefault != seedPeerCluster.IsDefault {
+		if err := s.db.WithContext(ctx).First(&seedPeerCluster, id).Update("is_default", json.IsDefault).Error; err != nil {
+			return nil, err
+		}
 	}
 
 	return &seedPeerCluster, nil


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fix gorm can not update `is_default` field, refer to https://stackoverflow.com/questions/56653423/gorm-doesnt-update-boolean-field-to-false.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
