### PR TITLE
feat: peer will back-to-source when task switch state failed

### DIFF
--- a/scheduler/service/service_test.go
+++ b/scheduler/service/service_test.go
@@ -1749,9 +1749,8 @@ func TestService_registerTask(t *testing.T) {
 					mt.Load(gomock.Any()).Return(mockTask, true).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -1777,9 +1776,8 @@ func TestService_registerTask(t *testing.T) {
 					mt.Load(gomock.Any()).Return(mockTask, true).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -1805,9 +1803,8 @@ func TestService_registerTask(t *testing.T) {
 					mt.Load(gomock.Any()).Return(mockTask, true).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -1844,9 +1841,8 @@ func TestService_registerTask(t *testing.T) {
 					mc.TriggerTask(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, task *resource.Task) { wg.Done() }).Return(mockPeer, &schedulerv1.PeerResult{}, nil).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTaskURL, task.URL)
 				assert.EqualValues(mockTaskURLMeta, task.URLMeta)
@@ -1882,9 +1878,8 @@ func TestService_registerTask(t *testing.T) {
 					mc.TriggerTask(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, task *resource.Task) { wg.Done() }).Return(mockPeer, &schedulerv1.PeerResult{}, nil).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -1919,9 +1914,8 @@ func TestService_registerTask(t *testing.T) {
 					mc.TriggerTask(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, task *resource.Task) { wg.Done() }).Return(mockPeer, &schedulerv1.PeerResult{}, nil).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -1956,9 +1950,8 @@ func TestService_registerTask(t *testing.T) {
 					mc.TriggerTask(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, task *resource.Task) { wg.Done() }).Return(mockPeer, &schedulerv1.PeerResult{}, nil).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -1988,9 +1981,8 @@ func TestService_registerTask(t *testing.T) {
 					mh.Load(gomock.Any()).Return(mockHost, true).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.True(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -2027,9 +2019,8 @@ func TestService_registerTask(t *testing.T) {
 					mc.TriggerTask(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, task *resource.Task) { wg.Done() }).Return(mockPeer, &schedulerv1.PeerResult{}, errors.New("foo")).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTaskURL, task.URL)
 				assert.EqualValues(mockTaskURLMeta, task.URLMeta)
@@ -2065,9 +2056,8 @@ func TestService_registerTask(t *testing.T) {
 					mc.TriggerTask(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, task *resource.Task) { wg.Done() }).Return(mockPeer, &schedulerv1.PeerResult{}, errors.New("foo")).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.False(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},
@@ -2098,9 +2088,8 @@ func TestService_registerTask(t *testing.T) {
 					mh.Load(gomock.Any()).Return(nil, false).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.True(needBackToSource)
 				assert.EqualValues(mockTaskURL, task.URL)
 				assert.EqualValues(mockTaskURLMeta, task.URLMeta)
@@ -2130,9 +2119,8 @@ func TestService_registerTask(t *testing.T) {
 					mh.Load(gomock.Any()).Return(nil, false).Times(1),
 				)
 
-				task, needBackToSource, err := svc.registerTask(context.Background(), req)
+				task, needBackToSource := svc.registerTask(context.Background(), req)
 				assert := assert.New(t)
-				assert.NoError(err)
 				assert.True(needBackToSource)
 				assert.EqualValues(mockTask, task)
 			},


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Peer will back-to-source when task switch state failed.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
