### PR TITLE
fix: open end range in concurrent back source

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,13 +93,12 @@ jobs:
 
       - name: Run E2E test
         run: |
+          set -x
           make build-e2e-sha256sum
           # generate an empty file
           docker exec kind-control-plane touch /tmp/empty-file
           ginkgo -v -r --race --fail-fast --cover --trace --progress --skip=${{ matrix.skip }} test/e2e -- \
-              --feature-gates=dfget-range=true \
-              --feature-gates=dfget-open-range=true \
-              --feature-gates=dfget-empty-file=true
+              --feature-gates=dfget-range=true,dfget-open-range=true,dfget-empty-file=true
           cat coverprofile.out >> coverage.txt
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,7 +96,10 @@ jobs:
           make build-e2e-sha256sum
           # generate an empty file
           docker exec kind-control-plane touch /tmp/empty-file
-          ginkgo -v -r --race --fail-fast --cover --trace --progress --skip=${{ matrix.skip }} test/e2e -- --feature-gates=dfget-range=true --feature-gates=dfget-empty-file=true
+          ginkgo -v -r --race --fail-fast --cover --trace --progress --skip=${{ matrix.skip }} test/e2e -- \
+              --feature-gates=dfget-range=true \
+              --feature-gates=dfget-open-range=true \
+              --feature-gates=dfget-empty-file=true
           cat coverprofile.out >> coverage.txt
 
       - name: Upload coverage to Codecov

--- a/client/daemon/objectstorage/objectstorage.go
+++ b/client/daemon/objectstorage/objectstorage.go
@@ -643,7 +643,7 @@ func (o *objectStorage) client() (objectstorage.ObjectStorage, error) {
 
 // parseRangeHeader uses to parse range http header for dragonfly.
 func (o *objectStorage) parseRangeHeader(rangeHeader string) ([]util.Range, error) {
-	ranges, err := util.ParseRange(rangeHeader, math.MaxInt)
+	ranges, err := util.ParseRange(rangeHeader, math.MaxInt64)
 	if err != nil {
 		return nil, err
 	}

--- a/client/daemon/peer/peertask_manager_test.go
+++ b/client/daemon/peer/peertask_manager_test.go
@@ -477,7 +477,7 @@ func TestPeerTaskManager_TaskSuite(t *testing.T) {
 					func(request *source.Request) (int64, error) {
 						assert := testifyassert.New(t)
 						if rg != nil {
-							rgs, err := util.ParseRange(request.Header.Get(headers.Range), math.MaxInt)
+							rgs, err := util.ParseRange(request.Header.Get(headers.Range), math.MaxInt64)
 							assert.Nil(err)
 							assert.Equal(1, len(rgs))
 							assert.Equal(rg.String(), rgs[0].String())
@@ -488,7 +488,7 @@ func TestPeerTaskManager_TaskSuite(t *testing.T) {
 					func(request *source.Request) (*source.Response, error) {
 						assert := testifyassert.New(t)
 						if rg != nil {
-							rgs, err := util.ParseRange(request.Header.Get(headers.Range), math.MaxInt)
+							rgs, err := util.ParseRange(request.Header.Get(headers.Range), math.MaxInt64)
 							assert.Nil(err)
 							assert.Equal(1, len(rgs))
 							assert.Equal(rg.String(), rgs[0].String())

--- a/client/daemon/peer/peertask_reuse.go
+++ b/client/daemon/peer/peertask_reuse.go
@@ -227,7 +227,7 @@ func (ptm *peerTaskManager) tryReuseStreamPeerTask(ctx context.Context,
 			reuse.PeerID, reuse.ContentLength, request.URLMeta.Range)
 
 		// correct range like: bytes=1024-
-		if reuseRange.Start+reuseRange.Length > reuse.ContentLength {
+		if reuseRange.Length > reuse.ContentLength-reuseRange.Start {
 			reuseRange.Length = reuse.ContentLength - reuseRange.Start
 			if reuseRange.Length < 0 {
 				return nil, nil, false

--- a/client/daemon/peer/piece_manager.go
+++ b/client/daemon/peer/piece_manager.go
@@ -452,10 +452,10 @@ singleDownload:
 		log.Infof("update range length: %d", parsedRange.Length)
 	}
 
-	return pm.downloadKnownLengthSource(ctx, pt, contentLength, pieceSize, reader, response, peerTaskRequest, parsedRange, metadata, supportConcurrent)
+	return pm.downloadKnownLengthSource(ctx, pt, contentLength, pieceSize, reader, response, peerTaskRequest, parsedRange, supportConcurrent)
 }
 
-func (pm *pieceManager) downloadKnownLengthSource(ctx context.Context, pt Task, contentLength int64, pieceSize uint32, reader io.Reader, response *source.Response, peerTaskRequest *schedulerv1.PeerTaskRequest, parsedRange *clientutil.Range, metadata *source.Metadata, supportConcurrent bool) error {
+func (pm *pieceManager) downloadKnownLengthSource(ctx context.Context, pt Task, contentLength int64, pieceSize uint32, reader io.Reader, response *source.Response, peerTaskRequest *schedulerv1.PeerTaskRequest, parsedRange *clientutil.Range, supportConcurrent bool) error {
 	log := pt.Log()
 	maxPieceNum := pt.GetTotalPieces()
 	for pieceNum := int32(0); pieceNum < maxPieceNum; pieceNum++ {

--- a/client/daemon/rpcserver/rpcserver.go
+++ b/client/daemon/rpcserver/rpcserver.go
@@ -56,7 +56,6 @@ import (
 	"d7y.io/dragonfly/v2/internal/dferrors"
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/idgen"
-	"d7y.io/dragonfly/v2/pkg/net/http"
 	"d7y.io/dragonfly/v2/pkg/os/user"
 	dfdaemonserver "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/server"
 	"d7y.io/dragonfly/v2/pkg/safe"
@@ -516,15 +515,12 @@ func (s *server) doDownload(ctx context.Context, req *dfdaemonv1.DownRequest, st
 		KeepOriginalOffset: req.KeepOriginalOffset,
 	}
 	if len(req.UrlMeta.Range) > 0 {
-		r, err := http.ParseRange(req.UrlMeta.Range, math.MaxInt)
+		r, err := util.ParseOneRange(req.UrlMeta.Range, math.MaxInt64)
 		if err != nil {
 			err = fmt.Errorf("parse range %s error: %s", req.UrlMeta.Range, err)
 			return err
 		}
-		peerTask.Range = &util.Range{
-			Start:  int64(r.StartIndex),
-			Length: int64(r.Length()),
-		}
+		peerTask.Range = &r
 	}
 	log := logger.With("peer", peerTask.PeerId, "component", "downloadService")
 

--- a/client/daemon/rpcserver/rpcserver.go
+++ b/client/daemon/rpcserver/rpcserver.go
@@ -56,6 +56,7 @@ import (
 	"d7y.io/dragonfly/v2/internal/dferrors"
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/idgen"
+	"d7y.io/dragonfly/v2/pkg/net/http"
 	"d7y.io/dragonfly/v2/pkg/os/user"
 	dfdaemonserver "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/server"
 	"d7y.io/dragonfly/v2/pkg/safe"
@@ -515,12 +516,15 @@ func (s *server) doDownload(ctx context.Context, req *dfdaemonv1.DownRequest, st
 		KeepOriginalOffset: req.KeepOriginalOffset,
 	}
 	if len(req.UrlMeta.Range) > 0 {
-		r, err := util.ParseOneRange(req.UrlMeta.Range, math.MaxInt64)
+		r, err := http.ParseRange(req.UrlMeta.Range, math.MaxInt64)
 		if err != nil {
 			err = fmt.Errorf("parse range %s error: %s", req.UrlMeta.Range, err)
 			return err
 		}
-		peerTask.Range = &r
+		peerTask.Range = &util.Range{
+			Start:  int64(r.StartIndex),
+			Length: int64(r.Length()),
+		}
 	}
 	log := logger.With("peer", peerTask.PeerId, "component", "downloadService")
 

--- a/client/daemon/rpcserver/seeder.go
+++ b/client/daemon/rpcserver/seeder.go
@@ -81,7 +81,7 @@ func (s *seeder) ObtainSeeds(seedRequest *cdnsystemv1.SeedRequest, seedsServer c
 	log := logger.With("peer", req.PeerId, "task", seedRequest.TaskId, "component", "seedService")
 
 	if len(req.UrlMeta.Range) > 0 {
-		r, err := clientutil.ParseOneRange(req.UrlMeta.Range, math.MaxUint64)
+		r, err := clientutil.ParseOneRange(req.UrlMeta.Range, math.MaxInt64)
 		if err != nil {
 			metrics.SeedPeerDownloadFailureCount.Add(1)
 			err = fmt.Errorf("parse range %s error: %s", req.UrlMeta.Range, err)

--- a/client/daemon/rpcserver/seeder.go
+++ b/client/daemon/rpcserver/seeder.go
@@ -32,10 +32,9 @@ import (
 	"d7y.io/dragonfly/v2/client/config"
 	"d7y.io/dragonfly/v2/client/daemon/metrics"
 	"d7y.io/dragonfly/v2/client/daemon/peer"
-	"d7y.io/dragonfly/v2/client/util"
+	clientutil "d7y.io/dragonfly/v2/client/util"
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/idgen"
-	"d7y.io/dragonfly/v2/pkg/net/http"
 	"d7y.io/dragonfly/v2/pkg/rpc/common"
 )
 
@@ -82,17 +81,14 @@ func (s *seeder) ObtainSeeds(seedRequest *cdnsystemv1.SeedRequest, seedsServer c
 	log := logger.With("peer", req.PeerId, "task", seedRequest.TaskId, "component", "seedService")
 
 	if len(req.UrlMeta.Range) > 0 {
-		r, err := http.ParseRange(req.UrlMeta.Range, math.MaxInt)
+		r, err := clientutil.ParseOneRange(req.UrlMeta.Range, math.MaxUint64)
 		if err != nil {
 			metrics.SeedPeerDownloadFailureCount.Add(1)
 			err = fmt.Errorf("parse range %s error: %s", req.UrlMeta.Range, err)
 			log.Errorf(err.Error())
 			return err
 		}
-		req.Range = &util.Range{
-			Start:  int64(r.StartIndex),
-			Length: int64(r.Length()),
-		}
+		req.Range = &r
 	}
 
 	resp, reuse, err := s.server.peerTaskManager.StartSeedTask(seedsServer.Context(), &req)

--- a/client/daemon/transport/transport.go
+++ b/client/daemon/transport/transport.go
@@ -230,7 +230,7 @@ func (rt *transport) download(ctx context.Context, req *http.Request) (*http.Res
 
 	// Set meta range's value
 	if rangeHeader := req.Header.Get("Range"); len(rangeHeader) > 0 {
-		rgs, err := util.ParseRange(rangeHeader, math.MaxInt)
+		rgs, err := util.ParseRange(rangeHeader, math.MaxInt64)
 		if err != nil {
 			return badRequest(req, err.Error())
 		}

--- a/client/util/range.go
+++ b/client/util/range.go
@@ -40,10 +40,11 @@ var ErrNoOverlap = errors.New("invalid range: failed to overlap")
 // ParseRange parses a Range header string as per RFC 7233.
 // ErrNoOverlap is returned if none of the ranges overlap.
 // Example:
-//   "Range": "bytes=100-200"
-//   "Range": "bytes=-50"
-//   "Range": "bytes=150-"
-//   "Range": "bytes=0-0,-1"
+//
+//	"Range": "bytes=100-200"
+//	"Range": "bytes=-50"
+//	"Range": "bytes=150-"
+//	"Range": "bytes=0-0,-1"
 //
 // copy from go/1.15.2 net/http/fs.go ParseRange
 func ParseRange(s string, size int64) ([]Range, error) {
@@ -115,8 +116,9 @@ func ParseRange(s string, size int64) ([]Range, error) {
 }
 
 // Example:
-//   "Content-Range": "bytes 100-200/1000"
-//   "Content-Range": "bytes 100-200/*"
+//
+//	"Content-Range": "bytes 100-200/1000"
+//	"Content-Range": "bytes 100-200/*"
 func GetContentRange(start, end, total int64) string {
 	// unknown total: -1
 	if total == -1 {
@@ -135,4 +137,15 @@ func MustParseRange(s string, size int64) Range {
 		panic(fmt.Sprintf("parse range length must be 1"))
 	}
 	return rs[0]
+}
+
+func ParseOneRange(s string, size int64) (Range, error) {
+	rs, err := ParseRange(s, size)
+	if err != nil {
+		return Range{}, err
+	}
+	if len(rs) != 1 {
+		return Range{}, fmt.Errorf("parse range length must be 1")
+	}
+	return rs[0], nil
 }

--- a/test/e2e/dfget_test.go
+++ b/test/e2e/dfget_test.go
@@ -124,14 +124,24 @@ func singleDfgetTest(name, ns, label, podNamePrefix, container string) {
 			// make ranged requests to invoke prefetch feature
 			if featureGates.Enabled(featureGateRange) {
 				rg1, rg2 := getRandomRange(size), getRandomRange(size)
+				rg1Range, rg2Range := rg1.String(), rg2.String()
 
-				downloadSingleFile(ns, pod, path, url1, size, rg1, rg1.String())
+				// avoid "Range: bytes=0--1" for empty file
+				if rg1.Length == 0 {
+					rg1Range = "bytes=0-0"
+				}
+				if rg2.Length == 0 {
+					rg2Range = "bytes=0-0"
+				}
+
+				downloadSingleFile(ns, pod, path, url1, size, rg1, rg1Range)
 				if featureGates.Enabled(featureGateNoLength) {
-					downloadSingleFile(ns, pod, path, url2, size, rg2, rg2.String())
+					downloadSingleFile(ns, pod, path, url2, size, rg2, rg2Range)
 				}
 
 				if featureGates.Enabled(featureGateOpenRange) {
 					rg3, rg4 := getRandomRange(size), getRandomRange(size)
+					// set target length
 					rg3.Length = int64(size) - rg3.Start
 					rg4.Length = int64(size) - rg4.Start
 

--- a/test/e2e/dfget_test.go
+++ b/test/e2e/dfget_test.go
@@ -118,25 +118,19 @@ func singleDfgetTest(name, ns, label, podNamePrefix, container string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		for path, size := range fileDetails {
+			// skip empty file
+			if size == 0 {
+				continue
+			}
 			url1 := e2eutil.GetFileURL(path)
 			url2 := e2eutil.GetNoContentLengthFileURL(path)
 
 			// make ranged requests to invoke prefetch feature
 			if featureGates.Enabled(featureGateRange) {
 				rg1, rg2 := getRandomRange(size), getRandomRange(size)
-				rg1Range, rg2Range := rg1.String(), rg2.String()
-
-				// avoid "Range: bytes=0--1" for empty file
-				if rg1.Length == 0 {
-					rg1Range = "bytes=0-0"
-				}
-				if rg2.Length == 0 {
-					rg2Range = "bytes=0-0"
-				}
-
-				downloadSingleFile(ns, pod, path, url1, size, rg1, rg1Range)
+				downloadSingleFile(ns, pod, path, url1, size, rg1, rg1.String())
 				if featureGates.Enabled(featureGateNoLength) {
-					downloadSingleFile(ns, pod, path, url2, size, rg2, rg2Range)
+					downloadSingleFile(ns, pod, path, url2, size, rg2, rg2.String())
 				}
 
 				if featureGates.Enabled(featureGateOpenRange) {

--- a/test/e2e/dfget_test.go
+++ b/test/e2e/dfget_test.go
@@ -124,22 +124,34 @@ func singleDfgetTest(name, ns, label, podNamePrefix, container string) {
 			// make ranged requests to invoke prefetch feature
 			if featureGates.Enabled(featureGateRange) {
 				rg1, rg2 := getRandomRange(size), getRandomRange(size)
-				downloadSingleFile(ns, pod, path, url1, size, rg1)
-				downloadSingleFile(ns, pod, path, url1, size, rg2)
-				// FIXME no content length cases are always failed.
-				// downloadSingleFile(ns, pod, path, url2, size, rg)
+
+				downloadSingleFile(ns, pod, path, url1, size, rg1, rg1.String())
+				if featureGates.Enabled(featureGateNoLength) {
+					downloadSingleFile(ns, pod, path, url2, size, rg2, rg2.String())
+				}
+
+				if featureGates.Enabled(featureGateOpenRange) {
+					rg3, rg4 := getRandomRange(size), getRandomRange(size)
+					rg3.Length = int64(size) - rg3.Start
+					rg4.Length = int64(size) - rg4.Start
+
+					downloadSingleFile(ns, pod, path, url1, size, rg3, fmt.Sprintf("bytes=%d-", rg3.Start))
+					if featureGates.Enabled(featureGateNoLength) {
+						downloadSingleFile(ns, pod, path, url2, size, rg4, fmt.Sprintf("bytes=%d-", rg4.Start))
+					}
+				}
 			}
 
-			downloadSingleFile(ns, pod, path, url1, size, nil)
+			downloadSingleFile(ns, pod, path, url1, size, nil, "")
 
 			if featureGates.Enabled(featureGateNoLength) {
-				downloadSingleFile(ns, pod, path, url2, size, nil)
+				downloadSingleFile(ns, pod, path, url2, size, nil, "")
 			}
 		}
 	})
 }
 
-func downloadSingleFile(ns string, pod *e2eutil.PodExec, path, url string, size int, rg *util.Range) {
+func downloadSingleFile(ns string, pod *e2eutil.PodExec, path, url string, size int, rg *util.Range, rawRg string) {
 	var (
 		sha256sum []string
 		dfget     []string
@@ -158,23 +170,23 @@ func downloadSingleFile(ns string, pod *e2eutil.PodExec, path, url string, size 
 			fmt.Sprintf("/bin/sha256sum-offset -file %s -offset %d -length %d", path, rg.Start, rg.Length))
 
 		dfget = append(dfget, "/opt/dragonfly/bin/dfget", "--disable-back-source", "-O", "/tmp/d7y.out", "-H",
-			fmt.Sprintf("Range: bytes=%d-%d", rg.Start, rg.Start+rg.Length-1), url)
+			fmt.Sprintf("Range: %s", rawRg), url)
 		curl = append(curl, "/usr/bin/curl", "-x", "http://127.0.0.1:65001", "-s", "--dump-header", "-", "-o", "/tmp/curl.out",
-			"--header", fmt.Sprintf("Range: bytes=%d-%d", rg.Start, rg.Start+rg.Length-1), url)
+			"--header", fmt.Sprintf("Range: %s", rawRg), url)
 
 		sha256sumOffset = append(sha256sumOffset, "sh", "-c",
 			fmt.Sprintf("/bin/sha256sum-offset -file %s -offset %d -length %d",
 				"/var/lib/dragonfly/d7y.offset.out", rg.Start, rg.Length))
 		dfgetOffset = append(dfgetOffset, "/opt/dragonfly/bin/dfget", "--disable-back-source", "--original-offset", "-O", "/var/lib/dragonfly/d7y.offset.out", "-H",
-			fmt.Sprintf("Range: bytes=%d-%d", rg.Start, rg.Start+rg.Length-1), url)
+			fmt.Sprintf("Range: %s", rawRg), url)
 	}
 
 	fmt.Printf("--------------------------------------------------------------------------------\n\n")
 	if rg == nil {
 		fmt.Printf("download %s, size %d\n", url, size)
 	} else {
-		fmt.Printf("download %s, size %d, range: bytes=%d-%d/%d, target length: %d\n",
-			url, size, rg.Start, rg.Start+rg.Length-1, size, rg.Length)
+		fmt.Printf("download %s, size %d, range: %s/%d, target length: %d\n",
+			url, size, rawRg, size, rg.Length)
 	}
 	// get original file digest
 	out, err := e2eutil.DockerCommand(sha256sum...).CombinedOutput()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,6 +37,7 @@ var (
 	featureGatesFlag string
 
 	featureGateRange     featuregate.Feature = "dfget-range"
+	featureGateOpenRange featuregate.Feature = "dfget-open-range"
 	featureGateCommit    featuregate.Feature = "dfget-commit"
 	featureGateNoLength  featuregate.Feature = "dfget-no-length"
 	featureGateEmptyFile featuregate.Feature = "dfget-empty-file"
@@ -53,6 +54,11 @@ var (
 			PreRelease:    featuregate.Alpha,
 		},
 		featureGateRange: {
+			Default:       false,
+			LockToDefault: false,
+			PreRelease:    featuregate.Alpha,
+		},
+		featureGateOpenRange: {
 			Default:       false,
 			LockToDefault: false,
 			PreRelease:    featuregate.Alpha,


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

In open end range in concurrent back source like: `bytes=1-`, `parsedRange.Length` is not updated after got metadata.
This PR will fix it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
