### PR TITLE
fix: expire header timezone

### DIFF
--- a/client/daemon/rpcserver/rpcserver.go
+++ b/client/daemon/rpcserver/rpcserver.go
@@ -435,7 +435,8 @@ func (s *server) recursiveDownloadWithP2PMetadata(
 	// update url scheme
 	purl.Scheme = source.ListMetadataScheme
 	// update cache expire time
-	urlMeta.Header[source.ListMetadataExpire] = time.Now().Add(s.cacheRecursiveMetadata).Format(source.ExpireLayout)
+	// The target format is GMT time, need convert to UTC time first
+	urlMeta.Header[source.ListMetadataExpire] = time.Now().Add(s.cacheRecursiveMetadata).UTC().Format(source.ExpireLayout)
 
 	rc, _, err := s.peerTaskManager.StartStreamTask(ctx, &peer.StreamTaskRequest{
 		URL:     purl.String(),

--- a/pkg/source/header.go
+++ b/pkg/source/header.go
@@ -16,7 +16,10 @@
 
 package source
 
-import "net/textproto"
+import (
+	"net/http"
+	"net/textproto"
+)
 
 const (
 	// Range is different with HTTP Range, it's without "bytes=" prefix
@@ -24,8 +27,8 @@ const (
 )
 
 const (
-	LastModifiedLayout = "Mon, 02 Jan 2006 15:04:05 GMT"
-	ExpireLayout       = "Mon, 02 Jan 2006 15:04:05 GMT"
+	LastModifiedLayout = http.TimeFormat
+	ExpireLayout       = http.TimeFormat
 )
 
 type ExpireInfo struct {


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

The Expire header target format is GMT time, need convert local time to UTC time first before format.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
