### PR TITLE
feat: when dfdaemon disable object storage, dynconfig can't fetch manager

### DIFF
--- a/client/config/dynconfig_manager_test.go
+++ b/client/config/dynconfig_manager_test.go
@@ -61,6 +61,9 @@ func TestDynconfigGetResolveSchedulerAddrs_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -102,6 +105,9 @@ func TestDynconfigGetResolveSchedulerAddrs_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -149,6 +155,9 @@ func TestDynconfigGetResolveSchedulerAddrs_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -193,6 +202,9 @@ func TestDynconfigGetResolveSchedulerAddrs_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -244,6 +256,9 @@ func TestDynconfigGetResolveSchedulerAddrs_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -288,6 +303,9 @@ func TestDynconfigGetResolveSchedulerAddrs_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -361,6 +379,9 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -406,6 +427,9 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -449,11 +473,59 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 			},
 		},
 		{
+			name:   "disable object storage",
+			expire: 10 * time.Millisecond,
+			config: &DaemonOption{
+				Host: HostOption{
+					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: false,
+				},
+			},
+			data: &DynconfigData{
+				Schedulers: []*managerv1.Scheduler{
+					{
+						HostName: "foo",
+					},
+				},
+			},
+			sleep: func() {
+				time.Sleep(100 * time.Millisecond)
+			},
+			cleanFileCache: func(t *testing.T) {
+				if err := os.Remove(mockCachePath); err != nil {
+					t.Fatal(err)
+				}
+			},
+			mock: func(m *mocks.MockClientMockRecorder, data *DynconfigData) {
+				gomock.InOrder(
+					m.ListSchedulers(gomock.Any(), gomock.Any()).Return(&managerv1.ListSchedulersResponse{}, nil).Times(1),
+					m.ListSchedulers(gomock.Any(), gomock.Any()).Return(&managerv1.ListSchedulersResponse{
+						Schedulers: []*managerv1.Scheduler{
+							{
+								HostName: data.Schedulers[0].HostName,
+							},
+						},
+					}, nil).Times(1),
+				)
+			},
+			expect: func(t *testing.T, dynconfig Dynconfig, data *DynconfigData) {
+				assert := assert.New(t)
+				result, err := dynconfig.Get()
+				assert.NoError(err)
+				assert.EqualValues(result, data)
+			},
+		},
+		{
 			name:   "list schedulers error",
 			expire: 10 * time.Millisecond,
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -503,6 +575,9 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -551,6 +626,9 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -603,6 +681,9 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 							HostName: data.Schedulers[0].HostName,
 						},
 					},
+					ObjectStorage: &managerv1.ObjectStorage{
+						Name: data.ObjectStorage.Name,
+					},
 				})
 			},
 		},
@@ -612,6 +693,9 @@ func TestDynconfigGet_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -687,6 +771,9 @@ func TestDynconfigGetSchedulers_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -726,6 +813,9 @@ func TestDynconfigGetSchedulers_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -771,6 +861,9 @@ func TestDynconfigGetSchedulers_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				Schedulers: []*managerv1.Scheduler{
@@ -813,6 +906,9 @@ func TestDynconfigGetSchedulers_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -887,6 +983,9 @@ func TestDynconfigGetObjectStorage_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				ObjectStorage: &managerv1.ObjectStorage{
@@ -920,6 +1019,9 @@ func TestDynconfigGetObjectStorage_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{
@@ -959,6 +1061,9 @@ func TestDynconfigGetObjectStorage_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				ObjectStorage: &managerv1.ObjectStorage{
@@ -997,6 +1102,9 @@ func TestDynconfigGetObjectStorage_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			data: &DynconfigData{
 				ObjectStorage: &managerv1.ObjectStorage{
@@ -1025,7 +1133,9 @@ func TestDynconfigGetObjectStorage_ManagerSourceType(t *testing.T) {
 				assert := assert.New(t)
 				result, err := dynconfig.GetObjectStorage()
 				assert.NoError(err)
-				assert.EqualValues(result, (*managerv1.ObjectStorage)(nil))
+				assert.EqualValues(result, &managerv1.ObjectStorage{
+					Name: data.ObjectStorage.Name,
+				})
 			},
 		},
 		{
@@ -1034,6 +1144,9 @@ func TestDynconfigGetObjectStorage_ManagerSourceType(t *testing.T) {
 			config: &DaemonOption{
 				Host: HostOption{
 					Hostname: "foo",
+				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
 				},
 			},
 			data: &DynconfigData{

--- a/client/config/dynconfig_test.go
+++ b/client/config/dynconfig_test.go
@@ -51,6 +51,9 @@ func TestDynconfigNewDynconfig_ManagerSourceType(t *testing.T) {
 				Host: HostOption{
 					Hostname: "foo",
 				},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			cleanFileCache: func(t *testing.T) {
 				if err := os.Remove(mockCachePath); err != nil {
@@ -73,6 +76,9 @@ func TestDynconfigNewDynconfig_ManagerSourceType(t *testing.T) {
 			expire: 10 * time.Millisecond,
 			config: &DaemonOption{
 				Host: HostOption{},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			cleanFileCache: func(t *testing.T) {
 				if err := os.Remove(mockCachePath); err != nil {
@@ -95,6 +101,9 @@ func TestDynconfigNewDynconfig_ManagerSourceType(t *testing.T) {
 			expire: 10 * time.Millisecond,
 			config: &DaemonOption{
 				Host: HostOption{},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			cleanFileCache: func(t *testing.T) {},
 			mock: func(m *mocks.MockClientMockRecorder) {
@@ -110,6 +119,9 @@ func TestDynconfigNewDynconfig_ManagerSourceType(t *testing.T) {
 			expire: 10 * time.Millisecond,
 			config: &DaemonOption{
 				Host: HostOption{},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
 			cleanFileCache: func(t *testing.T) {},
 			mock: func(m *mocks.MockClientMockRecorder) {
@@ -128,12 +140,11 @@ func TestDynconfigNewDynconfig_ManagerSourceType(t *testing.T) {
 			expire: 10 * time.Millisecond,
 			config: &DaemonOption{
 				Host: HostOption{},
+				ObjectStorage: ObjectStorageOption{
+					Enable: true,
+				},
 			},
-			cleanFileCache: func(t *testing.T) {
-				if err := os.Remove(mockCachePath); err != nil {
-					t.Fatal(err)
-				}
-			},
+			cleanFileCache: func(t *testing.T) {},
 			mock: func(m *mocks.MockClientMockRecorder) {
 				gomock.InOrder(
 					m.ListSchedulers(gomock.Any(), gomock.Any()).Return(&managerv1.ListSchedulersResponse{}, nil).Times(1),
@@ -142,7 +153,7 @@ func TestDynconfigNewDynconfig_ManagerSourceType(t *testing.T) {
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.NoError(err)
+				assert.Error(err)
 			},
 		},
 	}

--- a/manager/rpcserver/rpcserver.go
+++ b/manager/rpcserver/rpcserver.go
@@ -607,12 +607,8 @@ func (s *Server) ListSchedulers(ctx context.Context, req *managerv1.ListSchedule
 
 // Get object storage configuration.
 func (s *Server) GetObjectStorage(ctx context.Context, req *managerv1.GetObjectStorageRequest) (*managerv1.ObjectStorage, error) {
-	log := logger.WithHostnameAndIP(req.HostName, req.Ip)
-
 	if !s.objectStorageConfig.Enable {
-		msg := "object storage is disabled"
-		log.Debug(msg)
-		return nil, status.Error(codes.NotFound, msg)
+		return nil, status.Error(codes.NotFound, "object storage is disabled")
 	}
 
 	return &managerv1.ObjectStorage{


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- when dfdaemon disable object storage, dynconfig can't fetch manager.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
