### PR TITLE
feat: if the scheduler cannot find the peer, then return Code_SchedReregister to dfdaemon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module d7y.io/dragonfly/v2
 go 1.19
 
 require (
-	d7y.io/api v1.2.8
+	d7y.io/api v1.2.9
 	github.com/RichardKnop/machinery v1.10.6
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
-d7y.io/api v1.2.8 h1:NknL+9NnuS2ro7/ip+vV5V/tlpIdenCrFu2F9hUETdw=
-d7y.io/api v1.2.8/go.mod h1:HERD+sbavL0vJXkd37RZxJvpu+nXZ6ipffm4EFUbF2w=
+d7y.io/api v1.2.9 h1:mdMu9nYIcZueIpCF1cTr0YlIEIW9bK5oEN2Lg6yV7pk=
+d7y.io/api v1.2.9/go.mod h1:HERD+sbavL0vJXkd37RZxJvpu+nXZ6ipffm4EFUbF2w=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=

--- a/scheduler/service/service.go
+++ b/scheduler/service/service.go
@@ -197,9 +197,11 @@ func (s *Service) ReportPieceResult(stream schedulerv1.Scheduler_ReportPieceResu
 			// Get peer from peer manager.
 			peer, loaded = s.resource.PeerManager().Load(piece.SrcPid)
 			if !loaded {
+				// If the scheduler cannot find the peer,
+				// then the peer has not been registered in this scheduler.
 				msg := fmt.Sprintf("peer %s not found", piece.SrcPid)
 				logger.Error(msg)
-				return dferrors.New(commonv1.Code_SchedPeerNotFound, msg)
+				return dferrors.New(commonv1.Code_SchedReregister, msg)
 			}
 
 			// Peer setting stream.

--- a/scheduler/service/service_test.go
+++ b/scheduler/service/service_test.go
@@ -864,7 +864,7 @@ func TestService_ReportPieceResult(t *testing.T) {
 				assert := assert.New(t)
 				dferr, ok := err.(*dferrors.DfError)
 				assert.True(ok)
-				assert.Equal(dferr.Code, commonv1.Code_SchedPeerNotFound)
+				assert.Equal(dferr.Code, commonv1.Code_SchedReregister)
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- If the scheduler cannot find the peer, then return `Code_SchedReregister` to dfdaemon.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
