### PR TITLE
fix: remove advertiseIP config in e2e

### DIFF
--- a/test/testdata/charts/config-cache-list-metadata.yaml
+++ b/test/testdata/charts/config-cache-list-metadata.yaml
@@ -89,7 +89,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/charts/config-concurent-back-source.yaml
+++ b/test/testdata/charts/config-concurent-back-source.yaml
@@ -94,7 +94,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/charts/config-disable-seed-peer.yaml
+++ b/test/testdata/charts/config-disable-seed-peer.yaml
@@ -65,7 +65,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/charts/config-grpc-tls-ipv6.yaml
+++ b/test/testdata/charts/config-grpc-tls-ipv6.yaml
@@ -172,7 +172,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/charts/config-grpc-tls.yaml
+++ b/test/testdata/charts/config-grpc-tls.yaml
@@ -168,7 +168,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/charts/config-ipv6.yaml
+++ b/test/testdata/charts/config-ipv6.yaml
@@ -90,7 +90,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/charts/config-split-running-tasks.yaml
+++ b/test/testdata/charts/config-split-running-tasks.yaml
@@ -87,7 +87,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/charts/config.yaml
+++ b/test/testdata/charts/config.yaml
@@ -86,7 +86,6 @@ dfdaemon:
         insecure: true
       tcpListen:
         namespace: /run/dragonfly/net
-        listen: 0.0.0.0
         # if you want to change port, please update hostPort in $.Values.dfdaemon.hostPort
         # port in configmap is generated from $.Values.dfdaemon.hostPort
         # port: 65001

--- a/test/testdata/k8s/proxy.yaml
+++ b/test/testdata/k8s/proxy.yaml
@@ -20,13 +20,6 @@ data:
         refreshInterval: 5m
       scheduleTimeout: 30s
       disableAutoBackSource: true
-    host:
-      advertiseIP: 0.0.0.0
-      idc: ""
-      listenIP: 0.0.0.0
-      location: ""
-      netTopology: ""
-      securityDomain: ""
     download:
       prefetch: true
       calculateDigest: true


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove `advertiseIP` config in e2e.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
