### PR TITLE
fix:scheduler's health client not close

### DIFF
--- a/client/config/dynconfig_manager.go
+++ b/client/config/dynconfig_manager.go
@@ -109,6 +109,7 @@ func (d *dynconfigManager) GetResolveSchedulerAddrs() ([]resolver.Address, error
 			logger.Errorf("get health client %s failed: %s", addr, err.Error())
 			continue
 		}
+		defer healthClient.Close()
 
 		if err := healthClient.Check(context.Background(), &healthpb.HealthCheckRequest{}); err != nil {
 			logger.Errorf("scheduler address %s is unreachable: %s", addr, err.Error())

--- a/scheduler/config/dynconfig.go
+++ b/scheduler/config/dynconfig.go
@@ -192,8 +192,10 @@ func (d *dynconfig) GetResolveSeedPeerAddrs() ([]resolver.Address, error) {
 
 		if err := healthClient.Check(context.Background(), &healthpb.HealthCheckRequest{}); err != nil {
 			logger.Errorf("seed peer address %s is unreachable: %s", addr, err.Error())
+			healthClient.Close()
 			continue
 		}
+		healthClient.Close()
 
 		if addrs[addr] {
 			continue

--- a/scheduler/config/dynconfig.go
+++ b/scheduler/config/dynconfig.go
@@ -189,13 +189,12 @@ func (d *dynconfig) GetResolveSeedPeerAddrs() ([]resolver.Address, error) {
 			logger.Errorf("get health client %s failed: %s", addr, err.Error())
 			continue
 		}
+		defer healthClient.Close()
 
 		if err := healthClient.Check(context.Background(), &healthpb.HealthCheckRequest{}); err != nil {
 			logger.Errorf("seed peer address %s is unreachable: %s", addr, err.Error())
-			healthClient.Close()
 			continue
 		}
-		healthClient.Close()
 
 		if addrs[addr] {
 			continue


### PR DESCRIPTION
Signed-off-by: bigerous <cuidajun.cdj@alibaba-inc.com>

health client not close will cause go routines leak:
![image](https://user-images.githubusercontent.com/56508337/210927316-cdf2c762-1e19-49b7-9fbd-f9dfe0853838.png)


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
