### PR TITLE
feat: searcher can not found candidate scheduler clusters, return all scheduler clusters

### DIFF
--- a/manager/metrics/metrics.go
+++ b/manager/metrics/metrics.go
@@ -39,6 +39,13 @@ var (
 		Help:      "Gauge of the number of peer.",
 	}, []string{"version", "commit"})
 
+	SearchSchedulerClusterFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.SchedulerMetricsName,
+		Name:      "search_scheduler_cluster_failure_total",
+		Help:      "Counter of the number of failed of searching scheduler cluster.",
+	}, []string{"version", "commit"})
+
 	VersionGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: types.MetricsNamespace,
 		Subsystem: types.ManagerMetricsName,

--- a/manager/rpcserver/rpcserver.go
+++ b/manager/rpcserver/rpcserver.go
@@ -544,20 +544,28 @@ func (s *Server) ListSchedulers(ctx context.Context, req *managerv1.ListSchedule
 	if err := s.db.WithContext(ctx).Preload("SecurityGroup.SecurityRules").Preload("SeedPeerClusters.SeedPeers", "state = ?", "active").Preload("Schedulers", "state = ?", "active").Find(&schedulerClusters).Error; err != nil {
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
+	log.Debugf("list scheduler clusters %v with hostInfo %#v", getSchedulerClusterNames(schedulerClusters), req.HostInfo)
 
 	// Search optimal scheduler clusters.
-	log.Debugf("list scheduler clusters %v with hostInfo %#v", getSchedulerClusterNames(schedulerClusters), req.HostInfo)
-	schedulerClusters, err := s.searcher.FindSchedulerClusters(ctx, schedulerClusters, req)
+	// If searcher can not found candidate scheduler cluster,
+	// return all scheduler clusters.
+	var (
+		candidateSchedulerClusters []model.SchedulerCluster
+		err                        error
+	)
+	candidateSchedulerClusters, err = s.searcher.FindSchedulerClusters(ctx, schedulerClusters, req)
 	if err != nil {
+		candidateSchedulerClusters = schedulerClusters
+
 		log.Error(err)
-		return nil, status.Error(codes.NotFound, "scheduler cluster not found")
+		metrics.SearchSchedulerClusterFailureCount.WithLabelValues(req.Version, req.Commit).Inc()
 	}
 	log.Debugf("find matching scheduler cluster %v", getSchedulerClusterNames(schedulerClusters))
 
 	schedulers := []model.Scheduler{}
-	for _, schedulerCluster := range schedulerClusters {
-		for _, scheduler := range schedulerCluster.Schedulers {
-			scheduler.SchedulerCluster = schedulerCluster
+	for _, candidateSchedulerCluster := range candidateSchedulerClusters {
+		for _, scheduler := range candidateSchedulerCluster.Schedulers {
+			scheduler.SchedulerCluster = candidateSchedulerCluster
 			schedulers = append(schedulers, scheduler)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Searcher can not found candidate scheduler clusters, return all scheduler clusters.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
