### PR TITLE
fix: dferror not convert

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -47,6 +47,7 @@ import (
 	"d7y.io/dragonfly/v2/pkg/container/ring"
 	"d7y.io/dragonfly/v2/pkg/digest"
 	"d7y.io/dragonfly/v2/pkg/idgen"
+	"d7y.io/dragonfly/v2/pkg/rpc"
 	"d7y.io/dragonfly/v2/pkg/rpc/common"
 	schedulerclient "d7y.io/dragonfly/v2/pkg/rpc/scheduler/client"
 	"d7y.io/dragonfly/v2/pkg/source"
@@ -792,6 +793,8 @@ func (pt *peerTaskConductor) confirmReceivePeerPacketError(err error) (cont bool
 		failedCode   = commonv1.Code_UnknownError
 		failedReason string
 	)
+	// extract DfError for grpc status
+	err = rpc.ConvertToDfError(err)
 	de, ok := err.(*dferrors.DfError)
 	if ok {
 		switch de.Code {

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -47,7 +47,6 @@ import (
 	"d7y.io/dragonfly/v2/pkg/container/ring"
 	"d7y.io/dragonfly/v2/pkg/digest"
 	"d7y.io/dragonfly/v2/pkg/idgen"
-	"d7y.io/dragonfly/v2/pkg/rpc"
 	"d7y.io/dragonfly/v2/pkg/rpc/common"
 	schedulerclient "d7y.io/dragonfly/v2/pkg/rpc/scheduler/client"
 	"d7y.io/dragonfly/v2/pkg/source"
@@ -794,7 +793,7 @@ func (pt *peerTaskConductor) confirmReceivePeerPacketError(err error) (cont bool
 		failedReason string
 	)
 	// extract DfError for grpc status
-	err = rpc.ConvertToDfError(err)
+	err = dferrors.ConvertToDfError(err)
 	de, ok := err.(*dferrors.DfError)
 	if ok {
 		switch de.Code {

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -793,7 +793,7 @@ func (pt *peerTaskConductor) confirmReceivePeerPacketError(err error) (cont bool
 		failedReason string
 	)
 	// extract DfError for grpc status
-	err = dferrors.ConvertToDfError(err)
+	err = dferrors.ConvertGRPCErrorToDfError(err)
 	de, ok := err.(*dferrors.DfError)
 	if ok {
 		switch de.Code {

--- a/internal/dferrors/error.go
+++ b/internal/dferrors/error.go
@@ -20,8 +20,9 @@ import (
 	"errors"
 	"fmt"
 
-	commonv1 "d7y.io/api/pkg/apis/common/v1"
 	"google.golang.org/grpc/status"
+
+	commonv1 "d7y.io/api/pkg/apis/common/v1"
 )
 
 // common and framework errors

--- a/internal/dferrors/error.go
+++ b/internal/dferrors/error.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	commonv1 "d7y.io/api/pkg/apis/common/v1"
+	"google.golang.org/grpc/status"
 )
 
 // common and framework errors
@@ -69,4 +70,19 @@ func CheckError(err error, code commonv1.Code) bool {
 	e, ok := err.(*DfError)
 
 	return ok && e.Code == code
+}
+
+// ConvertToDfError converts grpc error to DfError, if it exists.
+func ConvertToDfError(err error) error {
+	for _, d := range status.Convert(err).Details() {
+		switch internal := d.(type) {
+		case *commonv1.GrpcDfError:
+			return &DfError{
+				Code:    internal.Code,
+				Message: internal.Message,
+			}
+		}
+	}
+
+	return err
 }

--- a/internal/dferrors/error.go
+++ b/internal/dferrors/error.go
@@ -73,8 +73,8 @@ func CheckError(err error, code commonv1.Code) bool {
 	return ok && e.Code == code
 }
 
-// ConvertToDfError converts grpc error to DfError, if it exists.
-func ConvertToDfError(err error) error {
+// ConvertGRPCErrorToDfError converts grpc error to DfError, if it exists.
+func ConvertGRPCErrorToDfError(err error) error {
 	for _, d := range status.Convert(err).Details() {
 		switch internal := d.(type) {
 		case *commonv1.GrpcDfError:
@@ -85,5 +85,20 @@ func ConvertToDfError(err error) error {
 		}
 	}
 
+	return err
+}
+
+// ConvertDfErrorToGRPCError converts DfError to grpc error, if it is.
+func ConvertDfErrorToGRPCError(err error) error {
+	if v, ok := err.(*DfError); ok {
+		s, e := status.Convert(err).WithDetails(
+			&commonv1.GrpcDfError{
+				Code:    v.Code,
+				Message: v.Message,
+			})
+		if e == nil {
+			err = s.Err()
+		}
+	}
 	return err
 }

--- a/pkg/rpc/interceptor.go
+++ b/pkg/rpc/interceptor.go
@@ -24,10 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	commonv1 "d7y.io/api/pkg/apis/common/v1"
-
 	"d7y.io/dragonfly/v2/internal/dferrors"
-	logger "d7y.io/dragonfly/v2/internal/dflog"
 )
 
 // Refresher is the interface for refreshing dynconfig.
@@ -90,7 +87,7 @@ func (r *RateLimiterInterceptor) Limit() bool {
 func ConvertErrorUnaryServerInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	h, err := handler(ctx, req)
 	if err != nil {
-		return h, convertServerError(err)
+		return h, dferrors.ConvertDfErrorToGRPCError(err)
 	}
 
 	return h, nil
@@ -99,34 +96,16 @@ func ConvertErrorUnaryServerInterceptor(ctx context.Context, req any, info *grpc
 // ConvertErrorStreamServerInterceptor returns a new stream server interceptor that convert error when trigger custom error.
 func ConvertErrorStreamServerInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	if err := handler(srv, ss); err != nil {
-		return convertServerError(err)
+		return dferrors.ConvertDfErrorToGRPCError(err)
 	}
 
 	return nil
 }
 
-// convertServerError converts custom error of server.
-func convertServerError(err error) error {
-	if status.Code(err) == codes.InvalidArgument {
-		err = dferrors.New(commonv1.Code_BadRequest, err.Error())
-	}
-
-	if v, ok := err.(*dferrors.DfError); ok {
-		logger.GrpcLogger.Errorf(v.Message)
-		if s, e := status.Convert(err).WithDetails(&commonv1.GrpcDfError{
-			Code:    v.Code,
-			Message: v.Message,
-		}); e == nil {
-			err = s.Err()
-		}
-	}
-	return err
-}
-
 // ConvertErrorUnaryClientInterceptor returns a new unary client interceptor that convert error when trigger custom error.
 func ConvertErrorUnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
-		return dferrors.ConvertToDfError(err)
+		return dferrors.ConvertGRPCErrorToDfError(err)
 	}
 
 	return nil
@@ -136,7 +115,7 @@ func ConvertErrorUnaryClientInterceptor(ctx context.Context, method string, req,
 func ConvertErrorStreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	s, err := streamer(ctx, desc, cc, method, opts...)
 	if err != nil {
-		return nil, dferrors.ConvertToDfError(err)
+		return nil, dferrors.ConvertGRPCErrorToDfError(err)
 	}
 
 	return s, nil

--- a/pkg/rpc/interceptor.go
+++ b/pkg/rpc/interceptor.go
@@ -126,7 +126,7 @@ func convertServerError(err error) error {
 // ConvertErrorUnaryClientInterceptor returns a new unary client interceptor that convert error when trigger custom error.
 func ConvertErrorUnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
-		return convertClientError(err)
+		return ConvertToDfError(err)
 	}
 
 	return nil
@@ -136,14 +136,14 @@ func ConvertErrorUnaryClientInterceptor(ctx context.Context, method string, req,
 func ConvertErrorStreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	s, err := streamer(ctx, desc, cc, method, opts...)
 	if err != nil {
-		return nil, convertClientError(err)
+		return nil, ConvertToDfError(err)
 	}
 
 	return s, nil
 }
 
-// convertClientError converts custom error of client.
-func convertClientError(err error) error {
+// ConvertToDfError converts custom error of client.
+func ConvertToDfError(err error) error {
 	for _, d := range status.Convert(err).Details() {
 		switch internal := d.(type) {
 		case *commonv1.GrpcDfError:

--- a/pkg/rpc/interceptor.go
+++ b/pkg/rpc/interceptor.go
@@ -126,7 +126,7 @@ func convertServerError(err error) error {
 // ConvertErrorUnaryClientInterceptor returns a new unary client interceptor that convert error when trigger custom error.
 func ConvertErrorUnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
-		return ConvertToDfError(err)
+		return dferrors.ConvertToDfError(err)
 	}
 
 	return nil
@@ -136,23 +136,8 @@ func ConvertErrorUnaryClientInterceptor(ctx context.Context, method string, req,
 func ConvertErrorStreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	s, err := streamer(ctx, desc, cc, method, opts...)
 	if err != nil {
-		return nil, ConvertToDfError(err)
+		return nil, dferrors.ConvertToDfError(err)
 	}
 
 	return s, nil
-}
-
-// ConvertToDfError converts custom error of client.
-func ConvertToDfError(err error) error {
-	for _, d := range status.Convert(err).Details() {
-		switch internal := d.(type) {
-		case *commonv1.GrpcDfError:
-			return &dferrors.DfError{
-				Code:    internal.Code,
-				Message: internal.Message,
-			}
-		}
-	}
-
-	return err
 }


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The function `convertClientError ` is only invoked for initializing stream, not `Send` or `Recv`, for parsing `dferrors.DfError`, only call it manually.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
