### PR TITLE
fix: peer GC clear all peers when peer's count large than PeerCountLimitForTask

### DIFF
--- a/scheduler/resource/peer_manager.go
+++ b/scheduler/resource/peer_manager.go
@@ -211,6 +211,8 @@ func (p *peerManager) RunGC() error {
 				return true
 			}
 
+			p.Delete(peer.ID)
+			peer.Log.Info("peer has been reclaimed")
 			return true
 		}
 

--- a/scheduler/resource/peer_manager_test.go
+++ b/scheduler/resource/peer_manager_test.go
@@ -497,9 +497,8 @@ func TestPeerManager_RunGC(t *testing.T) {
 				err := peerManager.RunGC()
 				assert.NoError(err)
 
-				peer, loaded := peerManager.Load(mockPeer.ID)
-				assert.Equal(loaded, true)
-				assert.Equal(peer.FSM.Current(), PeerStateLeave)
+				_, loaded := peerManager.Load(mockPeer.ID)
+				assert.Equal(loaded, false)
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fix peer GC clear all peers when peer's count large than PeerCountLimitForTask, refer to https://github.com/dragonflyoss/Dragonfly2/pull/2060.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
