### PR TITLE
feat: add probe default configuration

### DIFF
--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -306,8 +306,8 @@ type ProbeConfig struct {
 	// ProbeQueueLength is the number of probes that an edge stores.
 	ProbeQueueLength int `mapstructure:"probeQueueLength" yaml:"probeQueueLength"`
 
-	// GetProbeListInterval is the interval at which the host get the probe list.
-	GetProbeListInterval time.Duration `mapstructure:"getProbeListInterval" yaml:"getProbeListInterval"`
+	// GetProbesInterval is the interval at which the host get the probe list.
+	GetProbesInterval time.Duration `mapstructure:"getProbesInterval" yaml:"getProbesInterval"`
 
 	// AOIPriorityInterval is the priority effect of the information of age for host.
 	AOIPriorityInterval time.Duration `mapstructure:"AOIPriorityInterval" yaml:"AOIPriorityInterval"`
@@ -397,7 +397,7 @@ func New() *Config {
 		},
 		Probe: ProbeConfig{
 			ProbeQueueLength:             DefaultProbeQueueLength,
-			GetProbeListInterval:         DefaultGetProbeListInterval,
+			GetProbesInterval:            DefaultGetProbesInterval,
 			AOIPriorityInterval:          DefaultAOIPriorityInterval,
 			GetProbeCount:                DefaultGetProbeCount,
 			SyncNetworkTopologyInterval:  DefaultSyncNetworkTopologyInterval,
@@ -557,27 +557,27 @@ func (cfg *Config) Validate() error {
 	if cfg.Probe.ProbeQueueLength <= 0 {
 		return errors.New("probe requires parameter probeQueueLength")
 	}
-	
-	if cfg.Probe.GetProbeListInterval <= 0 {
-		return errors.New("probe requires parameter getProbeListInterval")
+
+	if cfg.Probe.GetProbesInterval <= 0 {
+		return errors.New("probe requires parameter getProbesInterval")
 	}
-	
+
 	if cfg.Probe.AOIPriorityInterval <= 0 {
 		return errors.New("probe requires parameter AOIPriorityInterval")
 	}
-	
+
 	if cfg.Probe.GetProbeCount <= 0 {
 		return errors.New("probe requires parameter getProbeCount")
 	}
-	
+
 	if cfg.Probe.SyncNetworkTopologyInterval <= 0 {
 		return errors.New("probe requires parameter syncNetworkTopologyInterval")
 	}
-	
+
 	if cfg.Probe.StoreNetworkTopologyInterval <= 0 {
 		return errors.New("probe requires parameter storeNetworkTopologyInterval")
 	}
-	
+
 	return nil
 }
 

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -557,21 +557,27 @@ func (cfg *Config) Validate() error {
 	if cfg.Probe.ProbeQueueLength <= 0 {
 		return errors.New("probe requires parameter probeQueueLength")
 	}
+	
 	if cfg.Probe.GetProbeListInterval <= 0 {
 		return errors.New("probe requires parameter getProbeListInterval")
 	}
+	
 	if cfg.Probe.AOIPriorityInterval <= 0 {
 		return errors.New("probe requires parameter AOIPriorityInterval")
 	}
+	
 	if cfg.Probe.GetProbeCount <= 0 {
 		return errors.New("probe requires parameter getProbeCount")
 	}
+	
 	if cfg.Probe.SyncNetworkTopologyInterval <= 0 {
 		return errors.New("probe requires parameter syncNetworkTopologyInterval")
 	}
+	
 	if cfg.Probe.StoreNetworkTopologyInterval <= 0 {
 		return errors.New("probe requires parameter storeNetworkTopologyInterval")
 	}
+	
 	return nil
 }
 

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -65,6 +65,9 @@ type Config struct {
 
 	// Network configuration.
 	Network NetworkConfig `yaml:"network" mapstructure:"network"`
+
+	// Probe configuration.
+	Probe ProbeConfig `yaml:"probe" mapstructure:"probe"`
 }
 
 type ServerConfig struct {
@@ -299,6 +302,26 @@ type NetworkConfig struct {
 	EnableIPv6 bool `mapstructure:"enableIPv6" yaml:"enableIPv6"`
 }
 
+type ProbeConfig struct {
+	// ProbeQueueLength is the number of probes that an edge stores.
+	ProbeQueueLength int `mapstructure:"probeQueueLength" yaml:"probeQueueLength"`
+
+	// GetProbeListInterval is the interval at which the host get the probe list.
+	GetProbeListInterval time.Duration `mapstructure:"getProbeListInterval" yaml:"getProbeListInterval"`
+
+	// AOIPriorityInterval is the priority effect of the information of age for host.
+	AOIPriorityInterval time.Duration `mapstructure:"AOIPriorityInterval" yaml:"AOIPriorityInterval"`
+
+	// GetProbeCount is the number of targets that the scheduler sends to the host for probing.
+	GetProbeCount int `mapstructure:"getProbeCount" yaml:"getProbeCount"`
+
+	// SyncNetworkTopologyInterval is the interval at which network topologies are synchronized between schedulers.
+	SyncNetworkTopologyInterval time.Duration `mapstructure:"syncNetworkTopologyInterval" yaml:"syncNetworkTopologyInterval"`
+
+	// StoreNetworkTopologyInterval is the interval at which the network topology is stored locally.
+	StoreNetworkTopologyInterval time.Duration `mapstructure:"storeNetworkTopologyInterval" yaml:"storeNetworkTopologyInterval"`
+}
+
 // New default configuration.
 func New() *Config {
 	return &Config{
@@ -371,6 +394,14 @@ func New() *Config {
 		},
 		Network: NetworkConfig{
 			EnableIPv6: DefaultNetworkEnableIPv6,
+		},
+		Probe: ProbeConfig{
+			ProbeQueueLength:             DefaultProbeQueueLength,
+			GetProbeListInterval:         DefaultGetProbeListInterval,
+			AOIPriorityInterval:          DefaultAOIPriorityInterval,
+			GetProbeCount:                DefaultGetProbeCount,
+			SyncNetworkTopologyInterval:  DefaultSyncNetworkTopologyInterval,
+			StoreNetworkTopologyInterval: DefaultStoreNetworkTopologyInterval,
 		},
 	}
 }
@@ -523,6 +554,24 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
+	if cfg.Probe.ProbeQueueLength <= 0 {
+		return errors.New("probe requires parameter probeQueueLength")
+	}
+	if cfg.Probe.GetProbeListInterval <= 0 {
+		return errors.New("probe requires parameter getProbeListInterval")
+	}
+	if cfg.Probe.AOIPriorityInterval <= 0 {
+		return errors.New("probe requires parameter AOIPriorityInterval")
+	}
+	if cfg.Probe.GetProbeCount <= 0 {
+		return errors.New("probe requires parameter getProbeCount")
+	}
+	if cfg.Probe.SyncNetworkTopologyInterval <= 0 {
+		return errors.New("probe requires parameter syncNetworkTopologyInterval")
+	}
+	if cfg.Probe.StoreNetworkTopologyInterval <= 0 {
+		return errors.New("probe requires parameter storeNetworkTopologyInterval")
+	}
 	return nil
 }
 

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -117,6 +117,14 @@ func TestConfig_Load(t *testing.T) {
 		Network: NetworkConfig{
 			EnableIPv6: true,
 		},
+		Probe: ProbeConfig{
+			ProbeQueueLength:             5,
+			GetProbeListInterval:         30 * time.Second,
+			AOIPriorityInterval:          10 * time.Second,
+			GetProbeCount:                50,
+			SyncNetworkTopologyInterval:  30 * time.Second,
+			StoreNetworkTopologyInterval: 60 * time.Second,
+		},
 	}
 
 	schedulerConfigYAML := &Config{}

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -119,7 +119,7 @@ func TestConfig_Load(t *testing.T) {
 		},
 		Probe: ProbeConfig{
 			ProbeQueueLength:             5,
-			GetProbeListInterval:         30 * time.Second,
+			GetProbesInterval:            30 * time.Second,
 			AOIPriorityInterval:          10 * time.Second,
 			GetProbeCount:                50,
 			SyncNetworkTopologyInterval:  30 * time.Second,

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -149,8 +149,8 @@ const (
 	// DefaultProbeQueueLength is the default number of probes that an edge stores.
 	DefaultProbeQueueLength = 5
 
-	// DefaultGetProbeListInterval is the default interval at which the host get the probe list.
-	DefaultGetProbeListInterval = 30 * time.Second
+	// DefaultGetProbesInterval is the default interval at which the host get the probe list.
+	DefaultGetProbesInterval = 30 * time.Second
 
 	// DefaultAOIPriorityInterval is the default priority effect of the information of age for host.
 	DefaultAOIPriorityInterval = 10 * time.Second

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -144,3 +144,23 @@ const (
 	// DefaultStorageBufferSize is the default size of buffer container.
 	DefaultStorageBufferSize = 100
 )
+
+const (
+	// DefaultProbeQueueLength is the default number of probes that an edge stores.
+	DefaultProbeQueueLength = 5
+
+	// DefaultGetProbeListInterval is the default interval at which the host get the probe list.
+	DefaultGetProbeListInterval = 30 * time.Second
+
+	// DefaultAOIPriorityInterval is the default priority effect of the information of age for host.
+	DefaultAOIPriorityInterval = 10 * time.Second
+
+	// DefaultGetProbeCount is the default number of targets that the scheduler sends to the host for probing.
+	DefaultGetProbeCount = 50
+
+	// DefaultSyncNetworkTopologyInterval is the default interval at which network topologies are synchronized between schedulers.
+	DefaultSyncNetworkTopologyInterval = 30 * time.Second
+
+	// DefaultStoreNetworkTopologyInterval is the default interval at which the network topology is stored locally.
+	DefaultStoreNetworkTopologyInterval = 60 * time.Second
+)

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -81,3 +81,12 @@ security:
 
 network:
   enableIPv6: true
+
+probe:
+  probeQueueLength: 5
+  getProbesInterval: 30s
+  AOIPriorityInterval: 10s
+  getProbeCount: 50
+  syncNetworkTopologyInterval: 30s
+  storeNetworkTopologyInterval: 60s
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add probe default configuration:
ProbeQueueLength is the number of probes that an edge stores.
GetProbesInterval is the interval at which the host get the probe list.
AOIPriorityInterval is the priority effect of the information of age for host.
GetProbeCount is the number of targets that the scheduler sends to the host for probing.
SyncNetworkTopologyInterval is the interval at which network topologies are synchronized between schedulers.
StoreNetworkTopologyInterval is the interval at which the network topology is stored locally.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
