### PR TITLE
feat: add default networkTopology configuration

### DIFF
--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -303,7 +303,7 @@ type NetworkConfig struct {
 }
 
 type NetworkTopologyConfig struct {
-	// Enable networkTopology service.
+	// Enable networkTopology services, including probe, network topology collection and synchronization service.
 	Enable bool `yaml:"enable" mapstructure:"enable"`
 
 	// SyncInterval is the interval of synchronizing network topology between schedulers.

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -303,7 +303,7 @@ type NetworkConfig struct {
 }
 
 type NetworkTopologyConfig struct {
-	// Enable networkTopology services, including probe, network topology collection and synchronization service.
+	// Enable network topology service, including probe, network topology collection and synchronization service.
 	Enable bool `yaml:"enable" mapstructure:"enable"`
 
 	// SyncInterval is the interval of synchronizing network topology between schedulers.

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -65,6 +65,9 @@ type Config struct {
 
 	// Network configuration.
 	Network NetworkConfig `yaml:"network" mapstructure:"network"`
+
+	// Probe configuration.
+	Probe ProbeConfig `yaml:"probe" mapstructure:"probe"`
 }
 
 type ServerConfig struct {
@@ -299,6 +302,26 @@ type NetworkConfig struct {
 	EnableIPv6 bool `mapstructure:"enableIPv6" yaml:"enableIPv6"`
 }
 
+type ProbeConfig struct {
+	// ProbeQueueLength is the number of probes that an edge stores.
+	ProbeQueueLength int `mapstructure:"probeQueueLength" yaml:"probeQueueLength"`
+
+	// GetProbesInterval is the interval at which the host get the probe list.
+	GetProbesInterval time.Duration `mapstructure:"getProbesInterval" yaml:"getProbesInterval"`
+
+	// AOIPriorityInterval is the priority effect of the information of age for host.
+	AOIPriorityInterval time.Duration `mapstructure:"AOIPriorityInterval" yaml:"AOIPriorityInterval"`
+
+	// GetProbeCount is the number of targets that the scheduler sends to the host for probing.
+	GetProbeCount int `mapstructure:"getProbeCount" yaml:"getProbeCount"`
+
+	// SyncNetworkTopologyInterval is the interval at which network topologies are synchronized between schedulers.
+	SyncNetworkTopologyInterval time.Duration `mapstructure:"syncNetworkTopologyInterval" yaml:"syncNetworkTopologyInterval"`
+
+	// StoreNetworkTopologyInterval is the interval at which the network topology is stored locally.
+	StoreNetworkTopologyInterval time.Duration `mapstructure:"storeNetworkTopologyInterval" yaml:"storeNetworkTopologyInterval"`
+}
+
 // New default configuration.
 func New() *Config {
 	return &Config{
@@ -371,6 +394,14 @@ func New() *Config {
 		},
 		Network: NetworkConfig{
 			EnableIPv6: DefaultNetworkEnableIPv6,
+		},
+		Probe: ProbeConfig{
+			ProbeQueueLength:             DefaultProbeQueueLength,
+			GetProbesInterval:            DefaultGetProbesInterval,
+			AOIPriorityInterval:          DefaultAOIPriorityInterval,
+			GetProbeCount:                DefaultGetProbeCount,
+			SyncNetworkTopologyInterval:  DefaultSyncNetworkTopologyInterval,
+			StoreNetworkTopologyInterval: DefaultStoreNetworkTopologyInterval,
 		},
 	}
 }
@@ -521,6 +552,30 @@ func (cfg *Config) Validate() error {
 		if cfg.Security.CertSpec.ValidityPeriod <= 0 {
 			return errors.New("certSpec requires parameter validityPeriod")
 		}
+	}
+
+	if cfg.Probe.ProbeQueueLength <= 0 {
+		return errors.New("probe requires parameter probeQueueLength")
+	}
+
+	if cfg.Probe.GetProbesInterval <= 0 {
+		return errors.New("probe requires parameter getProbeListInterval")
+	}
+
+	if cfg.Probe.AOIPriorityInterval <= 0 {
+		return errors.New("probe requires parameter AOIPriorityInterval")
+	}
+
+	if cfg.Probe.GetProbeCount <= 0 {
+		return errors.New("probe requires parameter getProbeCount")
+	}
+
+	if cfg.Probe.SyncNetworkTopologyInterval <= 0 {
+		return errors.New("probe requires parameter syncNetworkTopologyInterval")
+	}
+
+	if cfg.Probe.StoreNetworkTopologyInterval <= 0 {
+		return errors.New("probe requires parameter storeNetworkTopologyInterval")
 	}
 
 	return nil

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -66,8 +66,8 @@ type Config struct {
 	// Network configuration.
 	Network NetworkConfig `yaml:"network" mapstructure:"network"`
 
-	// Probe configuration.
-	Probe ProbeConfig `yaml:"probe" mapstructure:"probe"`
+	// NetworkTopology configuration.
+	NetworkTopology NetworkTopologyConfig `yaml:"networkTopology" mapstructure:"networkTopology"`
 }
 
 type ServerConfig struct {
@@ -302,6 +302,20 @@ type NetworkConfig struct {
 	EnableIPv6 bool `mapstructure:"enableIPv6" yaml:"enableIPv6"`
 }
 
+type NetworkTopologyConfig struct {
+	// AOIPriorityInterval is the priority effect of the information of age for host.
+	AOIPriorityInterval time.Duration `mapstructure:"AOIPriorityInterval" yaml:"AOIPriorityInterval"`
+
+	// SyncNetworkTopologyInterval is the interval at which network topologies are synchronized between schedulers.
+	SyncNetworkTopologyInterval time.Duration `mapstructure:"syncNetworkTopologyInterval" yaml:"syncNetworkTopologyInterval"`
+
+	// StoreNetworkTopologyInterval is the interval at which the network topology is stored locally.
+	StoreNetworkTopologyInterval time.Duration `mapstructure:"storeNetworkTopologyInterval" yaml:"storeNetworkTopologyInterval"`
+
+	//Probe is the configuration of probe
+	Probe ProbeConfig `yaml:"probe" mapstructure:"probe"`
+}
+
 type ProbeConfig struct {
 	// ProbeQueueLength is the number of probes that an edge stores.
 	ProbeQueueLength int `mapstructure:"probeQueueLength" yaml:"probeQueueLength"`
@@ -309,17 +323,8 @@ type ProbeConfig struct {
 	// GetProbesInterval is the interval at which the host get the probe list.
 	GetProbesInterval time.Duration `mapstructure:"getProbesInterval" yaml:"getProbesInterval"`
 
-	// AOIPriorityInterval is the priority effect of the information of age for host.
-	AOIPriorityInterval time.Duration `mapstructure:"AOIPriorityInterval" yaml:"AOIPriorityInterval"`
-
 	// GetProbeCount is the number of targets that the scheduler sends to the host for probing.
 	GetProbeCount int `mapstructure:"getProbeCount" yaml:"getProbeCount"`
-
-	// SyncNetworkTopologyInterval is the interval at which network topologies are synchronized between schedulers.
-	SyncNetworkTopologyInterval time.Duration `mapstructure:"syncNetworkTopologyInterval" yaml:"syncNetworkTopologyInterval"`
-
-	// StoreNetworkTopologyInterval is the interval at which the network topology is stored locally.
-	StoreNetworkTopologyInterval time.Duration `mapstructure:"storeNetworkTopologyInterval" yaml:"storeNetworkTopologyInterval"`
 }
 
 // New default configuration.
@@ -395,13 +400,15 @@ func New() *Config {
 		Network: NetworkConfig{
 			EnableIPv6: DefaultNetworkEnableIPv6,
 		},
-		Probe: ProbeConfig{
-			ProbeQueueLength:             DefaultProbeQueueLength,
-			GetProbesInterval:            DefaultGetProbesInterval,
+		NetworkTopology: NetworkTopologyConfig{
 			AOIPriorityInterval:          DefaultAOIPriorityInterval,
-			GetProbeCount:                DefaultGetProbeCount,
 			SyncNetworkTopologyInterval:  DefaultSyncNetworkTopologyInterval,
 			StoreNetworkTopologyInterval: DefaultStoreNetworkTopologyInterval,
+			Probe: ProbeConfig{
+				ProbeQueueLength:  DefaultProbeQueueLength,
+				GetProbesInterval: DefaultGetProbesInterval,
+				GetProbeCount:     DefaultGetProbeCount,
+			},
 		},
 	}
 }
@@ -554,28 +561,28 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	if cfg.Probe.ProbeQueueLength <= 0 {
-		return errors.New("probe requires parameter probeQueueLength")
-	}
-
-	if cfg.Probe.GetProbesInterval <= 0 {
-		return errors.New("probe requires parameter getProbeListInterval")
-	}
-
-	if cfg.Probe.AOIPriorityInterval <= 0 {
+	if cfg.NetworkTopology.AOIPriorityInterval <= 0 {
 		return errors.New("probe requires parameter AOIPriorityInterval")
 	}
 
-	if cfg.Probe.GetProbeCount <= 0 {
-		return errors.New("probe requires parameter getProbeCount")
-	}
-
-	if cfg.Probe.SyncNetworkTopologyInterval <= 0 {
+	if cfg.NetworkTopology.SyncNetworkTopologyInterval <= 0 {
 		return errors.New("probe requires parameter syncNetworkTopologyInterval")
 	}
 
-	if cfg.Probe.StoreNetworkTopologyInterval <= 0 {
+	if cfg.NetworkTopology.StoreNetworkTopologyInterval <= 0 {
 		return errors.New("probe requires parameter storeNetworkTopologyInterval")
+	}
+
+	if cfg.NetworkTopology.Probe.ProbeQueueLength <= 0 {
+		return errors.New("probe requires parameter probeQueueLength")
+	}
+
+	if cfg.NetworkTopology.Probe.GetProbesInterval <= 0 {
+		return errors.New("probe requires parameter getProbeListInterval")
+	}
+
+	if cfg.NetworkTopology.Probe.GetProbeCount <= 0 {
+		return errors.New("probe requires parameter getProbeCount")
 	}
 
 	return nil

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -303,24 +303,27 @@ type NetworkConfig struct {
 }
 
 type NetworkTopologyConfig struct {
-	// SyncInterval is the interval at which network topologies are synchronized between schedulers.
+	// Enable networkTopology service.
+	Enable bool `yaml:"enable" mapstructure:"enable"`
+
+	// SyncInterval is the interval of synchronizing network topology between schedulers.
 	SyncInterval time.Duration `mapstructure:"syncInterval" yaml:"syncInterval"`
 
-	// CollectInterval is the interval at which the network topology is collected locally.
+	// CollectInterval is the interval of collecting network topology.
 	CollectInterval time.Duration `mapstructure:"collectInterval" yaml:"collectInterval"`
 
-	//Probe is the configuration of probe
+	// Probe is the configuration of probe.
 	Probe ProbeConfig `yaml:"probe" mapstructure:"probe"`
 }
 
 type ProbeConfig struct {
-	// QueueLength is the maximum number of probes that an edge stores.
+	// QueueLength is the length of probe queue in directed graph.
 	QueueLength int `mapstructure:"queueLength" yaml:"queueLength"`
 
-	// SyncInterval is the interval at which network topology synchronizes the probes of host.
+	// SyncInterval is the interval of synchronizing host's probes.
 	SyncInterval time.Duration `mapstructure:"syncInterval" yaml:"syncInterval"`
 
-	// SyncCount is the number of targets that the scheduler sends to the host for probing.
+	// SyncCount is the number of probing hosts.
 	SyncCount int `mapstructure:"syncCount" yaml:"syncCount"`
 }
 
@@ -398,12 +401,13 @@ func New() *Config {
 			EnableIPv6: DefaultNetworkEnableIPv6,
 		},
 		NetworkTopology: NetworkTopologyConfig{
-			SyncInterval:    DefaultSyncProbesInterval,
-			CollectInterval: DefaultCollectInterval,
+			Enable:          true,
+			SyncInterval:    DefaultNetworkTopologySyncInterval,
+			CollectInterval: DefaultNetworkTopologyCollectInterval,
 			Probe: ProbeConfig{
-				QueueLength:  DefaultQueueLength,
-				SyncInterval: DefaultSyncNetworkTopologyInterval,
-				SyncCount:    DefaultSyncCount,
+				QueueLength:  DefaultProbeQueueLength,
+				SyncInterval: DefaultProbeSyncInterval,
+				SyncCount:    DefaultProbeSyncCount,
 			},
 		},
 	}

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -303,28 +303,25 @@ type NetworkConfig struct {
 }
 
 type NetworkTopologyConfig struct {
-	// AOIPriorityInterval is the priority effect of the information of age for host.
-	AOIPriorityInterval time.Duration `mapstructure:"AOIPriorityInterval" yaml:"AOIPriorityInterval"`
+	// SyncInterval is the interval at which network topologies are synchronized between schedulers.
+	SyncInterval time.Duration `mapstructure:"syncInterval" yaml:"syncInterval"`
 
-	// SyncNetworkTopologyInterval is the interval at which network topologies are synchronized between schedulers.
-	SyncNetworkTopologyInterval time.Duration `mapstructure:"syncNetworkTopologyInterval" yaml:"syncNetworkTopologyInterval"`
-
-	// StoreNetworkTopologyInterval is the interval at which the network topology is stored locally.
-	StoreNetworkTopologyInterval time.Duration `mapstructure:"storeNetworkTopologyInterval" yaml:"storeNetworkTopologyInterval"`
+	// CollectInterval is the interval at which the network topology is collected locally.
+	CollectInterval time.Duration `mapstructure:"collectInterval" yaml:"collectInterval"`
 
 	//Probe is the configuration of probe
 	Probe ProbeConfig `yaml:"probe" mapstructure:"probe"`
 }
 
 type ProbeConfig struct {
-	// ProbeQueueLength is the number of probes that an edge stores.
-	ProbeQueueLength int `mapstructure:"probeQueueLength" yaml:"probeQueueLength"`
+	// QueueLength is the maximum number of probes that an edge stores.
+	QueueLength int `mapstructure:"queueLength" yaml:"queueLength"`
 
-	// GetProbesInterval is the interval at which the host get the probe list.
-	GetProbesInterval time.Duration `mapstructure:"getProbesInterval" yaml:"getProbesInterval"`
+	// SyncInterval is the interval at which network topology synchronizes the probes of host.
+	SyncInterval time.Duration `mapstructure:"syncInterval" yaml:"syncInterval"`
 
-	// GetProbeCount is the number of targets that the scheduler sends to the host for probing.
-	GetProbeCount int `mapstructure:"getProbeCount" yaml:"getProbeCount"`
+	// SyncCount is the number of targets that the scheduler sends to the host for probing.
+	SyncCount int `mapstructure:"syncCount" yaml:"syncCount"`
 }
 
 // New default configuration.
@@ -401,13 +398,12 @@ func New() *Config {
 			EnableIPv6: DefaultNetworkEnableIPv6,
 		},
 		NetworkTopology: NetworkTopologyConfig{
-			AOIPriorityInterval:          DefaultAOIPriorityInterval,
-			SyncNetworkTopologyInterval:  DefaultSyncNetworkTopologyInterval,
-			StoreNetworkTopologyInterval: DefaultStoreNetworkTopologyInterval,
+			SyncInterval:    DefaultSyncProbesInterval,
+			CollectInterval: DefaultCollectInterval,
 			Probe: ProbeConfig{
-				ProbeQueueLength:  DefaultProbeQueueLength,
-				GetProbesInterval: DefaultGetProbesInterval,
-				GetProbeCount:     DefaultGetProbeCount,
+				QueueLength:  DefaultQueueLength,
+				SyncInterval: DefaultSyncNetworkTopologyInterval,
+				SyncCount:    DefaultSyncCount,
 			},
 		},
 	}
@@ -561,28 +557,24 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	if cfg.NetworkTopology.AOIPriorityInterval <= 0 {
-		return errors.New("probe requires parameter AOIPriorityInterval")
+	if cfg.NetworkTopology.SyncInterval <= 0 {
+		return errors.New("networkTopology requires parameter SyncInterval")
 	}
 
-	if cfg.NetworkTopology.SyncNetworkTopologyInterval <= 0 {
-		return errors.New("probe requires parameter syncNetworkTopologyInterval")
+	if cfg.NetworkTopology.CollectInterval <= 0 {
+		return errors.New("networkTopology requires parameter CollectInterval")
 	}
 
-	if cfg.NetworkTopology.StoreNetworkTopologyInterval <= 0 {
-		return errors.New("probe requires parameter storeNetworkTopologyInterval")
+	if cfg.NetworkTopology.Probe.QueueLength <= 0 {
+		return errors.New("probe requires parameter QueueLength")
 	}
 
-	if cfg.NetworkTopology.Probe.ProbeQueueLength <= 0 {
-		return errors.New("probe requires parameter probeQueueLength")
+	if cfg.NetworkTopology.Probe.SyncInterval <= 0 {
+		return errors.New("probe requires parameter SyncInterval")
 	}
 
-	if cfg.NetworkTopology.Probe.GetProbesInterval <= 0 {
-		return errors.New("probe requires parameter getProbeListInterval")
-	}
-
-	if cfg.NetworkTopology.Probe.GetProbeCount <= 0 {
-		return errors.New("probe requires parameter getProbeCount")
+	if cfg.NetworkTopology.Probe.SyncCount <= 0 {
+		return errors.New("probe requires parameter SyncCount")
 	}
 
 	return nil

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -117,6 +117,14 @@ func TestConfig_Load(t *testing.T) {
 		Network: NetworkConfig{
 			EnableIPv6: true,
 		},
+		Probe: ProbeConfig{
+			ProbeQueueLength:             5,
+			GetProbesInterval:            30 * time.Second,
+			AOIPriorityInterval:          10 * time.Second,
+			GetProbeCount:                50,
+			SyncNetworkTopologyInterval:  30 * time.Second,
+			StoreNetworkTopologyInterval: 60 * time.Second,
+		},
 	}
 
 	schedulerConfigYAML := &Config{}

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -118,6 +118,7 @@ func TestConfig_Load(t *testing.T) {
 			EnableIPv6: true,
 		},
 		NetworkTopology: NetworkTopologyConfig{
+			Enable:          true,
 			SyncInterval:    30 * time.Second,
 			CollectInterval: 60 * time.Second,
 			Probe: ProbeConfig{

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -117,13 +117,15 @@ func TestConfig_Load(t *testing.T) {
 		Network: NetworkConfig{
 			EnableIPv6: true,
 		},
-		Probe: ProbeConfig{
-			ProbeQueueLength:             5,
-			GetProbesInterval:            30 * time.Second,
+		NetworkTopology: NetworkTopologyConfig{
 			AOIPriorityInterval:          10 * time.Second,
-			GetProbeCount:                50,
 			SyncNetworkTopologyInterval:  30 * time.Second,
 			StoreNetworkTopologyInterval: 60 * time.Second,
+			Probe: ProbeConfig{
+				ProbeQueueLength:  5,
+				GetProbesInterval: 30 * time.Second,
+				GetProbeCount:     50,
+			},
 		},
 	}
 

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -118,13 +118,12 @@ func TestConfig_Load(t *testing.T) {
 			EnableIPv6: true,
 		},
 		NetworkTopology: NetworkTopologyConfig{
-			AOIPriorityInterval:          10 * time.Second,
-			SyncNetworkTopologyInterval:  30 * time.Second,
-			StoreNetworkTopologyInterval: 60 * time.Second,
+			SyncInterval:    30 * time.Second,
+			CollectInterval: 60 * time.Second,
 			Probe: ProbeConfig{
-				ProbeQueueLength:  5,
-				GetProbesInterval: 30 * time.Second,
-				GetProbeCount:     50,
+				QueueLength:  5,
+				SyncInterval: 30 * time.Second,
+				SyncCount:    50,
 			},
 		},
 	}

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -146,21 +146,18 @@ const (
 )
 
 const (
-	// DefaultProbeQueueLength is the default number of probes that an edge stores.
-	DefaultProbeQueueLength = 5
-
-	// DefaultGetProbesInterval is the default interval at which the host get the probe list.
-	DefaultGetProbesInterval = 30 * time.Second
-
-	// DefaultAOIPriorityInterval is the default priority effect of the information of age for host.
-	DefaultAOIPriorityInterval = 10 * time.Second
-
-	// DefaultGetProbeCount is the default number of targets that the scheduler sends to the host for probing.
-	DefaultGetProbeCount = 50
-
 	// DefaultSyncNetworkTopologyInterval is the default interval at which network topologies are synchronized between schedulers.
 	DefaultSyncNetworkTopologyInterval = 30 * time.Second
 
-	// DefaultStoreNetworkTopologyInterval is the default interval at which the network topology is stored locally.
-	DefaultStoreNetworkTopologyInterval = 60 * time.Second
+	// DefaultCollectInterval is the default interval at which the network topology is collected locally.
+	DefaultCollectInterval = 60 * time.Second
+
+	// DefaultQueueLength is the default maximum number of probes that an edge stores.
+	DefaultQueueLength = 5
+
+	// DefaultSyncProbesInterval is the default interval at which network topology synchronizes the probes of host.
+	DefaultSyncProbesInterval = 30 * time.Second
+
+	// DefaultSyncCount is the default number of targets that the scheduler sends to the host for probing.
+	DefaultSyncCount = 50
 )

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -144,3 +144,23 @@ const (
 	// DefaultStorageBufferSize is the default size of buffer container.
 	DefaultStorageBufferSize = 100
 )
+
+const (
+	// DefaultProbeQueueLength is the default number of probes that an edge stores.
+	DefaultProbeQueueLength = 5
+
+	// DefaultGetProbesInterval is the default interval at which the host get the probe list.
+	DefaultGetProbesInterval = 30 * time.Second
+
+	// DefaultAOIPriorityInterval is the default priority effect of the information of age for host.
+	DefaultAOIPriorityInterval = 10 * time.Second
+
+	// DefaultGetProbeCount is the default number of targets that the scheduler sends to the host for probing.
+	DefaultGetProbeCount = 50
+
+	// DefaultSyncNetworkTopologyInterval is the default interval at which network topologies are synchronized between schedulers.
+	DefaultSyncNetworkTopologyInterval = 30 * time.Second
+
+	// DefaultStoreNetworkTopologyInterval is the default interval at which the network topology is stored locally.
+	DefaultStoreNetworkTopologyInterval = 60 * time.Second
+)

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -146,18 +146,22 @@ const (
 )
 
 const (
-	// DefaultSyncNetworkTopologyInterval is the default interval at which network topologies are synchronized between schedulers.
-	DefaultSyncNetworkTopologyInterval = 30 * time.Second
+	// TODO(XZ): The default setting needs to be changed after testing.
+	// DefaultNetworkTopologySyncInterval is the default interval of synchronizing network topology between schedulers.
+	DefaultNetworkTopologySyncInterval = 30 * time.Second
 
-	// DefaultCollectInterval is the default interval at which the network topology is collected locally.
-	DefaultCollectInterval = 60 * time.Second
+	// TODO(XZ): The default setting needs to be changed after testing.
+	// DefaultNetworkTopologyCollectInterval is the default interval of collecting network topology.
+	DefaultNetworkTopologyCollectInterval = 60 * time.Second
 
-	// DefaultQueueLength is the default maximum number of probes that an edge stores.
-	DefaultQueueLength = 5
+	// DefaultProbeQueueLength is the default length of probe queue in directed graph.
+	DefaultProbeQueueLength = 5
 
-	// DefaultSyncProbesInterval is the default interval at which network topology synchronizes the probes of host.
-	DefaultSyncProbesInterval = 30 * time.Second
+	// TODO(XZ): The default setting needs to be changed after testing.
+	// DefaultProbeSyncInterval is the default interval of synchronizing host's probes.
+	DefaultProbeSyncInterval = 30 * time.Second
 
-	// DefaultSyncCount is the default number of targets that the scheduler sends to the host for probing.
-	DefaultSyncCount = 50
+	// TODO(XZ): The default setting needs to be changed after testing.
+	// DefaultProbeSyncCount is the default number of probing hosts.
+	DefaultProbeSyncCount = 50
 )

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -82,10 +82,11 @@ security:
 network:
   enableIPv6: true
 
-probe:
-  probeQueueLength: 5
-  getProbesInterval: 30s
+networkTopology:
   AOIPriorityInterval: 10s
-  getProbeCount: 50
   syncNetworkTopologyInterval: 30s
   storeNetworkTopologyInterval: 60s
+  probe:
+    probeQueueLength: 5
+    getProbesInterval: 30s
+    getProbeCount: 50

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -83,6 +83,7 @@ network:
   enableIPv6: true
 
 networkTopology:
+  enable: true
   syncInterval: 30s
   collectInterval: 60s
   probe:

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -49,7 +49,7 @@ job:
   schedulerWorkerNum: 1
   localWorkerNum: 5
   redis:
-    addrs: ["foo", "bar"]
+    addrs: [ "foo", "bar" ]
     masterName: "baz"
     host: 127.0.0.1
     port: 6379
@@ -83,10 +83,9 @@ network:
   enableIPv6: true
 
 networkTopology:
-  AOIPriorityInterval: 10s
-  syncNetworkTopologyInterval: 30s
-  storeNetworkTopologyInterval: 60s
+  syncInterval: 30s
+  collectInterval: 60s
   probe:
-    probeQueueLength: 5
-    getProbesInterval: 30s
-    getProbeCount: 50
+    queueLength: 5
+    syncInterval: 30s
+    syncCount: 50

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -81,3 +81,11 @@ security:
 
 network:
   enableIPv6: true
+
+probe:
+  probeQueueLength: 5
+  getProbesInterval: 30s
+  AOIPriorityInterval: 10s
+  getProbeCount: 50
+  syncNetworkTopologyInterval: 30s
+  storeNetworkTopologyInterval: 60s


### PR DESCRIPTION
Signed-off-by: XZ <834756128@qq.com>

<!--- Provide a general summary of your changes in the Title above -->
## Description

Add default networkTopology configuration.

Struct networkTopology includes parameters: Enable, SyncInterval, CollectInterval, Probe. 
Enable networkTopology services, including probe, network topology collection and synchronization service.
SyncInterval is the interval of synchronizing network topology between schedulers.
CollectInterval is the interval of collecting network topology.
Probe is the configuration of probe.

Struct Probe includes parameters: QueueLength, SyncInterval, SyncCount.
QueueLength is the length of probe queue in directed graph.
SyncInterval is the interval of synchronizing host's probes.
SyncCount is the number of probing hosts.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
