### PR TITLE
fix: backsource first piece timeout

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -717,6 +717,10 @@ loop:
 		pt.Debugf("receive peerPacket %v", peerPacket)
 		if peerPacket.Code != commonv1.Code_Success {
 			if peerPacket.Code == commonv1.Code_SchedNeedBackSource {
+				// fix back source directly, then waitFirstPeerPacket timeout
+				if !firstPacketReceived {
+					close(firstPacketDone)
+				}
 				pt.forceBackSource()
 				pt.Infof("receive back source code")
 				return
@@ -760,6 +764,11 @@ loop:
 			firstPacketReceived = true
 			close(firstPacketDone)
 		}
+	}
+
+	// double check to avoid waitFirstPeerPacket timeout
+	if !firstPacketReceived {
+		close(firstPacketDone)
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When there is no seed peer cluster in a scheduler cluster, the first peers will back source, if the source is slow and reach schedule timeout, will cause first piece timeout error.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
