### PR TITLE
cache: avoid checking dir existence before MkdirAll

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -290,10 +290,8 @@ func (c *cache) Save(w io.Writer) (err error) {
 // documentation for NewFrom().)
 func (c *cache) SaveFile(fname string) error {
 	dir := filepath.Dir(fname)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
 	}
 
 	fp, err := os.Create(fname)
@@ -301,12 +299,9 @@ func (c *cache) SaveFile(fname string) error {
 		return err
 	}
 
-	err = c.Save(fp)
-	if err != nil {
-		fp.Close()
-		return err
-	}
-	return fp.Close()
+	defer fp.Close()
+
+	return c.Save(fp)
 }
 
 // Add (Gob-serialized) cache items from an io.Reader, excluding any items with


### PR DESCRIPTION
So we can save a syscall stat(2) thus reducing a little overhead. The function MkdirAll will do nothing it the target dir is already existed.
Besides, Close() can only fail if it is ever called. We can safely simplify the code by `defer Close()`

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
