### PR TITLE
feat: support reload scheduler addresses for local Dynconfig

### DIFF
--- a/client/config/dynconfig.go
+++ b/client/config/dynconfig.go
@@ -61,8 +61,14 @@ type Dynconfig interface {
 	// Get the dynamic config.
 	Get() (*DynconfigData, error)
 
+	// Get the dynamic config source type.
+	GetSourceType() SourceType
+
 	// Refresh refreshes dynconfig in cache.
 	Refresh() error
+
+	// SetConfig updates DaemonOption in dynconfig.
+	SetConfig(*DaemonOption)
 
 	// Register allows an instance to register itself to listen/observe events.
 	Register(Observer)

--- a/client/config/dynconfig_local.go
+++ b/client/config/dynconfig_local.go
@@ -100,9 +100,19 @@ func (d *dynconfigLocal) Get() (*DynconfigData, error) {
 	return nil, ErrUnimplemented
 }
 
+// Get the dynamic config source type.
+func (d *dynconfigLocal) GetSourceType() SourceType {
+	return LocalSourceType
+}
+
 // Refresh refreshes dynconfig in cache.
 func (d *dynconfigLocal) Refresh() error {
 	return nil
+}
+
+// SetConfig updates DaemonOption in dynconfig.
+func (d *dynconfigLocal) SetConfig(newcfg *DaemonOption) {
+	d.config = newcfg
 }
 
 // Register allows an instance to register itself to listen/observe events.

--- a/client/config/dynconfig_manager.go
+++ b/client/config/dynconfig_manager.go
@@ -167,6 +167,11 @@ func (d *dynconfigManager) GetObjectStorage() (*managerv1.ObjectStorage, error) 
 	return data.ObjectStorage, nil
 }
 
+// Get the dynamic config source type.
+func (d *dynconfigManager) GetSourceType() SourceType {
+	return ManagerSourceType
+}
+
 // Refresh refreshes dynconfig in cache.
 func (d *dynconfigManager) Refresh() error {
 	if err := d.Dynconfig.Refresh(); err != nil {
@@ -178,6 +183,11 @@ func (d *dynconfigManager) Refresh() error {
 	}
 
 	return nil
+}
+
+// SetConfig updates DaemonOption in dynconfig. This is only useful for local dynconfig.
+func (d *dynconfigManager) SetConfig(_cfg *DaemonOption) {
+	return
 }
 
 // Register allows an instance to register itself to listen/observe events.

--- a/client/daemon/daemon.go
+++ b/client/daemon/daemon.go
@@ -761,6 +761,10 @@ func (cd *clientDaemon) Serve() error {
 		}()
 	}
 
+	if cd.dynconfig.GetSourceType() == config.LocalSourceType {
+		watchers = append(watchers, cd.dynconfig.SetConfig)
+	}
+
 	if len(watchers) > 0 && interval > 0 {
 		go func() {
 			dependency.WatchConfig(interval, func() any {


### PR DESCRIPTION
Dynconfig only supports refresh new configs from manager, but local dynconfig is unable to reload scheduler addresses when local config file is updated.

Now we introduce new Dynconfig method 'SetConfig()', which sets the given DaemonOption to struct dynconfigLocal, and register it as a watcher of WatchConfig(), which will reload config file periodically. So that dynconfigLocal.GetResolveSchedulerAddrs() will get new scheduler addresses.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
