### PR TITLE
fix: unregister task from scheduler in storage.deleteTask

### DIFF
--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -886,6 +886,7 @@ func (s *storageManager) TryGC() (bool, error) {
 	return true, nil
 }
 
+// delete the given task from local storage and unregister it from scheduler.
 func (s *storageManager) deleteTask(meta PeerTaskMetadata) error {
 	task, ok := s.LoadAndDeleteTask(meta)
 	if !ok {
@@ -899,7 +900,8 @@ func (s *storageManager) deleteTask(meta PeerTaskMetadata) error {
 	} else {
 		s.cleanSubIndex(meta.TaskID, meta.PeerID)
 	}
-	task.(Reclaimer).MarkInvalid()
+	// MarkReclaim() will call gcCallback, which will unregister task from scheduler
+	task.(Reclaimer).MarkReclaim()
 	return task.(Reclaimer).Reclaim()
 }
 


### PR DESCRIPTION
On graceful shutdown we will call forceGC() to delete all cached tasks if 'keepStorage' is false. And we rely on deleteTask() to delete the given task from both local storage and scheduler.

But commit 86a6030c8f10 ("feat: unregister failed task storage (#1717)") changed MarkReclaim() to MarkInvalid() in deleteTask(), and resulted in task leak in scheduler.

Fix it by calling MarkReclaim() in deleteTask().

Fixes: 86a6030c8f10 ("feat: unregister failed task storage (#1717)")

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
