### PR TITLE
[WIP] chore: remove unused MarkInvalid in daemon

### DIFF
--- a/client/daemon/storage/local_storage.go
+++ b/client/daemon/storage/local_storage.go
@@ -505,10 +505,6 @@ func (t *localTaskStore) CanReclaim() bool {
 	return false
 }
 
-func (t *localTaskStore) MarkInvalid() {
-	t.invalid.Store(true)
-}
-
 // MarkReclaim will try to invoke gcCallback (normal leave peer task)
 func (t *localTaskStore) MarkReclaim() {
 	if t.reclaimMarked.Load() {

--- a/client/daemon/storage/local_storage_subtask.go
+++ b/client/daemon/storage/local_storage_subtask.go
@@ -392,15 +392,12 @@ func (t *localSubTaskStore) CanReclaim() bool {
 }
 
 func (t *localSubTaskStore) MarkReclaim() {
-	// gc this subtask
+	// gc this subtask with gcCallback from parent
 	t.parent.gcCallback(CommonTaskRequest{
 		PeerID: t.PeerID,
 		TaskID: t.TaskID,
 	})
 	t.Infof("sub task %s/%s will be reclaimed, marked", t.TaskID, t.PeerID)
-
-	// mark parent invalid
-	t.parent.invalid.Store(true)
 
 	t.parent.Lock()
 	// remove subtask from parent

--- a/client/daemon/storage/local_storage_subtask.go
+++ b/client/daemon/storage/local_storage_subtask.go
@@ -391,20 +391,19 @@ func (t *localSubTaskStore) CanReclaim() bool {
 	return false
 }
 
-func (t *localSubTaskStore) MarkInvalid() {
-	if t.parent.Done || t.invalid.Load() {
-		return
-	}
-	t.parent.MarkInvalid()
-}
-
 func (t *localSubTaskStore) MarkReclaim() {
+	// gc this subtask
 	t.parent.gcCallback(CommonTaskRequest{
 		PeerID: t.PeerID,
 		TaskID: t.TaskID,
 	})
 	t.Infof("sub task %s/%s will be reclaimed, marked", t.TaskID, t.PeerID)
+
+	// mark parent invalid
+	t.parent.invalid.Store(true)
+
 	t.parent.Lock()
+	// remove subtask from parent
 	delete(t.parent.subtasks, PeerTaskMetadata{
 		PeerID: t.PeerID,
 		TaskID: t.TaskID,

--- a/client/daemon/storage/mocks/stroage_manager_mock.go
+++ b/client/daemon/storage/mocks/stroage_manager_mock.go
@@ -224,18 +224,6 @@ func (mr *MockReclaimerMockRecorder) CanReclaim() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanReclaim", reflect.TypeOf((*MockReclaimer)(nil).CanReclaim))
 }
 
-// MarkInvalid mocks base method.
-func (m *MockReclaimer) MarkInvalid() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "MarkInvalid")
-}
-
-// MarkInvalid indicates an expected call of MarkInvalid.
-func (mr *MockReclaimerMockRecorder) MarkInvalid() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkInvalid", reflect.TypeOf((*MockReclaimer)(nil).MarkInvalid))
-}
-
 // MarkReclaim mocks base method.
 func (m *MockReclaimer) MarkReclaim() {
 	m.ctrl.T.Helper()

--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -83,9 +83,6 @@ type Reclaimer interface {
 	// MarkReclaim marks the storage which will be reclaimed
 	MarkReclaim()
 
-	// marks the special storage invalid, that will reclaim next gc round
-	MarkInvalid()
-
 	// Reclaim reclaims the storage
 	Reclaim() error
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When delete task force(like delete failed task) in daemon, call MarkReclaim is enough, so remove unused MarkInvalid.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
