### PR TITLE
feat: oss client supports STS access (set security token in header)

### DIFF
--- a/pkg/source/clients/ossprotocol/oss_source_client.go
+++ b/pkg/source/clients/ossprotocol/oss_source_client.go
@@ -41,6 +41,7 @@ const (
 	endpoint        = "endpoint"
 	accessKeyID     = "accessKeyID"
 	accessKeySecret = "accessKeySecret"
+	securityToken   = "securityToken"
 )
 
 var _ source.ResourceClient = (*ossSourceClient)(nil)
@@ -320,11 +321,17 @@ func (osc *ossSourceClient) getClient(header source.Header) (*oss.Client, error)
 	if pkgstrings.IsBlank(accessKeySecret) {
 		return nil, errors.New("accessKeySecret is empty")
 	}
+	securityToken := header.Get(securityToken)
+	if !pkgstrings.IsBlank(securityToken) {
+		return oss.New(endpoint, accessKeyID, accessKeySecret, oss.SecurityToken(securityToken))
+	}
 	clientKey := buildClientKey(endpoint, accessKeyID, accessKeySecret)
 	if client, ok := osc.clientMap.Load(clientKey); ok {
 		return client.(*oss.Client), nil
 	}
+
 	client, err := oss.New(endpoint, accessKeyID, accessKeySecret)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Oss source client for now only supports accessKeyID+accessKeySecret access. To support STS access, one needs to provides security token to init oss Client. 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
To perform sts access, user can set "securityToken" in DfgetConfig.Header in form of "SecurityToken: ******". getClient function of struct ossSourceClient will parsing this header and get "SecurityToken" item. Blank SecurityToken is allowed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
