### PR TITLE
feat: enable oss client download object concurrently.

### DIFF
--- a/pkg/source/clients/ossprotocol/oss_source_client.go
+++ b/pkg/source/clients/ossprotocol/oss_source_client.go
@@ -216,6 +216,12 @@ func (osc *ossSourceClient) Download(request *source.Request) (*source.Response,
 				ETag:         objectResult.Response.Headers.Get(headers.ETag),
 			},
 		))
+	contentLength := objectResult.Response.Headers.Get(oss.HTTPHeaderContentLength)
+	if !pkgstrings.IsBlank(contentLength) {
+		if len, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
+			response.ContentLength = len
+		}
+	}
 	return response, nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make oss source downloads oss object concurrently by setting the "ContentLength" value of Source.Response.

## Description
df2 struct pieceManager calls DownloadSource() to download source objects. DownloadSource() firstly connect to source and get the response from source. Then, DownloadSource() checks the "ContentLength" value of the response. If it larger than 0, pieceManager will download the object by multiple threads. Unfortunately, oss client doesn't set ContentLength value, even thought ContentLength can be set by the oss.GetObjectResult.Response.Headers. So this patch add a line to set response a ContentLength value.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
