### PR TITLE
refactor: support reload scheduler addresses for local Dynconfig in client

### DIFF
--- a/client/config/dynconfig.go
+++ b/client/config/dynconfig.go
@@ -61,14 +61,8 @@ type Dynconfig interface {
 	// Get the dynamic config.
 	Get() (*DynconfigData, error)
 
-	// Get the dynamic config source type.
-	GetSourceType() SourceType
-
 	// Refresh refreshes dynconfig in cache.
 	Refresh() error
-
-	// SetConfig updates DaemonOption in dynconfig.
-	SetConfig(*DaemonOption)
 
 	// Register allows an instance to register itself to listen/observe events.
 	Register(Observer)
@@ -78,6 +72,10 @@ type Dynconfig interface {
 
 	// Notify publishes new events to listeners.
 	Notify() error
+
+	// OnNotify allows an event to be published to the dynconfig.
+	// Used for listening changes of the local configuration.
+	OnNotify(*DaemonOption)
 
 	// Serve the dynconfig listening service.
 	Serve() error

--- a/client/config/dynconfig_local.go
+++ b/client/config/dynconfig_local.go
@@ -19,6 +19,7 @@ package config
 import (
 	"errors"
 	"net"
+	"reflect"
 	"time"
 
 	"google.golang.org/grpc/resolver"
@@ -100,19 +101,9 @@ func (d *dynconfigLocal) Get() (*DynconfigData, error) {
 	return nil, ErrUnimplemented
 }
 
-// Get the dynamic config source type.
-func (d *dynconfigLocal) GetSourceType() SourceType {
-	return LocalSourceType
-}
-
 // Refresh refreshes dynconfig in cache.
 func (d *dynconfigLocal) Refresh() error {
 	return nil
-}
-
-// SetConfig updates DaemonOption in dynconfig.
-func (d *dynconfigLocal) SetConfig(newcfg *DaemonOption) {
-	d.config = newcfg
 }
 
 // Register allows an instance to register itself to listen/observe events.
@@ -132,6 +123,16 @@ func (d *dynconfigLocal) Notify() error {
 	}
 
 	return nil
+}
+
+// OnNotify allows an event to be published to the dynconfig.
+// Used for listening changes of the local configuration.
+func (d *dynconfigLocal) OnNotify(cfg *DaemonOption) {
+	if reflect.DeepEqual(d.config, cfg) {
+		return
+	}
+
+	d.config = cfg
 }
 
 // Serve the dynconfig listening service.

--- a/client/config/dynconfig_local_test.go
+++ b/client/config/dynconfig_local_test.go
@@ -36,8 +36,7 @@ func TestDynconfigGetResolveSchedulerAddrs_LocalSourceType(t *testing.T) {
 	tests := []struct {
 		name   string
 		config *DaemonOption
-		newcfg *DaemonOption
-		expect func(t *testing.T, dynconfig Dynconfig, config, newcfg *DaemonOption)
+		expect func(t *testing.T, dynconfig Dynconfig, config *DaemonOption)
 	}{
 		{
 			name: "get scheduler addrs",
@@ -50,8 +49,7 @@ func TestDynconfigGetResolveSchedulerAddrs_LocalSourceType(t *testing.T) {
 					},
 				},
 			},
-			newcfg: nil,
-			expect: func(t *testing.T, dynconfig Dynconfig, config, _newcfg *DaemonOption) {
+			expect: func(t *testing.T, dynconfig Dynconfig, config *DaemonOption) {
 				assert := assert.New(t)
 				result, err := dynconfig.GetResolveSchedulerAddrs()
 				assert.NoError(err)
@@ -69,8 +67,7 @@ func TestDynconfigGetResolveSchedulerAddrs_LocalSourceType(t *testing.T) {
 					},
 				},
 			},
-			newcfg: nil,
-			expect: func(t *testing.T, dynconfig Dynconfig, config, _newcfg *DaemonOption) {
+			expect: func(t *testing.T, dynconfig Dynconfig, config *DaemonOption) {
 				assert := assert.New(t)
 				_, err := dynconfig.GetResolveSchedulerAddrs()
 				assert.EqualError(err, "can not found available scheduler addresses")
@@ -90,8 +87,7 @@ func TestDynconfigGetResolveSchedulerAddrs_LocalSourceType(t *testing.T) {
 					},
 				},
 			},
-			newcfg: nil,
-			expect: func(t *testing.T, dynconfig Dynconfig, config, _newcfg *DaemonOption) {
+			expect: func(t *testing.T, dynconfig Dynconfig, config *DaemonOption) {
 				assert := assert.New(t)
 				result, err := dynconfig.GetResolveSchedulerAddrs()
 				assert.NoError(err)
@@ -99,7 +95,7 @@ func TestDynconfigGetResolveSchedulerAddrs_LocalSourceType(t *testing.T) {
 			},
 		},
 		{
-			name: "get scheduler addrs after update config",
+			name: "get scheduler addrs with OnNotify",
 			config: &DaemonOption{
 				Scheduler: SchedulerOption{
 					NetAddrs: []dfnet.NetAddr{
@@ -109,21 +105,20 @@ func TestDynconfigGetResolveSchedulerAddrs_LocalSourceType(t *testing.T) {
 					},
 				},
 			},
-			newcfg: &DaemonOption{
-				Scheduler: SchedulerOption{
-					NetAddrs: []dfnet.NetAddr{
-						{
-							Addr: "127.0.0.1:3000",
-						},
-					},
-				},
-			},
-			expect: func(t *testing.T, dynconfig Dynconfig, config, newcfg *DaemonOption) {
+			expect: func(t *testing.T, dynconfig Dynconfig, config *DaemonOption) {
 				assert := assert.New(t)
 				_, err := dynconfig.GetResolveSchedulerAddrs()
 				assert.EqualError(err, "can not found available scheduler addresses")
 
-				dynconfig.SetConfig(newcfg)
+				dynconfig.OnNotify(&DaemonOption{
+					Scheduler: SchedulerOption{
+						NetAddrs: []dfnet.NetAddr{
+							{
+								Addr: "127.0.0.1:3000",
+							},
+						},
+					},
+				})
 				result, err := dynconfig.GetResolveSchedulerAddrs()
 				assert.NoError(err)
 				assert.EqualValues(result, []resolver.Address{{ServerName: "127.0.0.1", Addr: "127.0.0.1:3000"}})
@@ -138,7 +133,7 @@ func TestDynconfigGetResolveSchedulerAddrs_LocalSourceType(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tc.expect(t, dynconfig, tc.config, tc.newcfg)
+			tc.expect(t, dynconfig, tc.config)
 		})
 	}
 }

--- a/client/daemon/daemon.go
+++ b/client/daemon/daemon.go
@@ -718,9 +718,14 @@ func (cd *clientDaemon) Serve() error {
 			logger.Errorf("dynconfig start failed %v", err)
 			return err
 		}
+
 		logger.Info("dynconfig start successfully")
 		return nil
 	})
+
+	if cd.managerClient == nil {
+		watchers = append(watchers, cd.dynconfig.OnNotify)
+	}
 
 	if cd.Option.Metrics != "" {
 		metricsServer := metrics.New(cd.Option.Metrics)
@@ -759,10 +764,6 @@ func (cd *clientDaemon) Serve() error {
 				logger.Errorf("health http server error: %v", err)
 			}
 		}()
-	}
-
-	if cd.dynconfig.GetSourceType() == config.LocalSourceType {
-		watchers = append(watchers, cd.dynconfig.SetConfig)
 	}
 
 	if len(watchers) > 0 && interval > 0 {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add OnNotify to client dynconfig, it will listen changes of the local configuration.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
