### PR TITLE
fix: validate daemon gcInterval config

### DIFF
--- a/client/config/peerhost.go
+++ b/client/config/peerhost.go
@@ -192,6 +192,10 @@ func (p *DaemonOption) Validate() error {
 		return errors.New("reload interval too short, must great than 1 second")
 	}
 
+	if p.GCInterval.Duration <= 0 {
+		return errors.New("gcInterval must be greater than 0")
+	}
+
 	if p.Security.AutoIssueCert {
 		if p.Security.CACert == "" {
 			return errors.New("security requires parameter caCert")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

    If gcInterval is set to 0s or negative value, dfdaemon will panic as

      panic: non-positive interval for NewTicker

      goroutine 132 [running]:
      time.NewTicker(0x0?)

    Fix it by validating it as well.

    Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
