### PR TITLE
Compile API group regexp only once

### DIFF
--- a/manager/permission/rbac/rbac.go
+++ b/manager/permission/rbac/rbac.go
@@ -61,6 +61,10 @@ const (
 	ReadAction = "read"
 )
 
+var (
+	apiGroupRegexp = regexp.MustCompile(`^/api/v[0-9]+/([-_a-zA-Z]*)[/.*]*`)
+)
+
 func NewEnforcer(gdb *gorm.DB) (*casbin.Enforcer, error) {
 	adapter, err := gormadapter.NewAdapterByDBWithCustomTable(gdb, &managermodel.CasbinRule{})
 	if err != nil {
@@ -160,7 +164,6 @@ func GetAPIGroupNames(g *gin.Engine) []string {
 }
 
 func GetAPIGroupName(path string) (string, error) {
-	apiGroupRegexp := regexp.MustCompile(`^/api/v[0-9]+/([-_a-zA-Z]*)[/.*]*`)
 	matchs := apiGroupRegexp.FindStringSubmatch(path)
 	if len(matchs) != 2 {
 		return "", errors.New("cannot find group name")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As API group regexp is reused when loading routes and the expression itself doesn't change, should make sense to compile it only once.

<!--- Describe your changes in detail -->

## Related Issue
--

## Motivation and Context
--

## Screenshots (if appropriate)

## Types of changes

Improvement.

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
