### PR TITLE
feat: add authinfo injector

### DIFF
--- a/pkg/source/clients/orasprotocol/oras_source_client.go
+++ b/pkg/source/clients/orasprotocol/oras_source_client.go
@@ -21,12 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
 
+	commonv1 "d7y.io/api/pkg/apis/common/v1"
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/source"
 )
@@ -35,7 +36,9 @@ const (
 	ociAcceptHeader  = "application/vnd.oci.image.manifest.v1+json"
 	jsonAcceptHeader = "application/json"
 	scheme           = "oras"
-	authFilePath     = "/.singularity/docker-config.json"
+	configFilePath   = "/.singularity/docker-config.json"
+
+	authHeader = "X-Dragonfly-Oras-Authorization"
 )
 
 var _ source.ResourceClient = (*orasSourceClient)(nil)
@@ -49,7 +52,9 @@ type Manifest struct {
 }
 
 func init() {
-	source.RegisterBuilder(scheme, source.NewPlainResourceClientBuilder(Builder))
+	source.RegisterBuilder(scheme,
+		source.NewPlainResourceClientBuilder(Builder),
+		source.WithAuthInfoInjector(source.NewPlainAuthInfoInjector(AuthInfoInjector)))
 }
 
 func Builder(optionYaml []byte) (source.ResourceClient, source.RequestAdapter, []source.Hook, error) {
@@ -62,6 +67,21 @@ func Builder(optionYaml []byte) (source.ResourceClient, source.RequestAdapter, [
 		httpClient: httpClient,
 	}
 	return client, client.adaptor, nil, nil
+}
+
+func AuthInfoInjector(_url string, urlMeta *commonv1.UrlMeta) error {
+	u, err := url.Parse(_url)
+	if err != nil {
+		return err
+	}
+
+	auth, err := fetchAuthInfo(u.Host, false)
+	if err != nil {
+		return err
+	}
+
+	urlMeta.Header[authHeader] = "Basic " + auth
+	return nil
 }
 
 func (client *orasSourceClient) adaptor(request *source.Request) *source.Request {
@@ -108,30 +128,48 @@ func (client *orasSourceClient) Download(request *source.Request) (*source.Respo
 	return imageFetchResponse, nil
 }
 
+func fetchAuthInfo(host string, skipCheckExist bool) (string, error) {
+	configFile := os.Getenv("HOME") + configFilePath
+	if !skipCheckExist && !fileExists(configFile) {
+		return "", nil
+	}
+
+	var auth string
+	databytes, err := os.ReadFile(configFile)
+	if err != nil {
+		return "", err
+	}
+
+	var jsonData map[string]interface{}
+	if err = json.Unmarshal(databytes, &jsonData); err != nil {
+		return "", err
+	}
+
+	for _, v := range jsonData {
+		for registry, v1 := range (v).(map[string]interface{}) {
+			for _, credentials := range (v1).(map[string]interface{}) {
+				if registry == host {
+					auth = credentials.(string)
+				}
+			}
+		}
+	}
+	return auth, nil
+}
+
 func (client *orasSourceClient) fetchToken(request *source.Request, path string) (string, error) {
 	var response *http.Response
 	var err error
 	tokenFetchURL := fmt.Sprintf("https://%s/service/token/?scope=repository:%s:pull&service=harbor-registry", request.URL.Host, path)
-	if fileExists(os.Getenv("HOME") + authFilePath) {
-		var auth string
-		databytes, err := os.ReadFile(os.Getenv("HOME") + authFilePath)
+	if authHeaderVal := request.Header.Get(authHeader); authHeaderVal != "" {
+		response, err = client.doRequest(request, jsonAcceptHeader, authHeaderVal, tokenFetchURL)
 		if err != nil {
 			return "", err
 		}
-		var jsonData map[string]interface{}
-		if err := json.Unmarshal(databytes, &jsonData); err != nil {
-			return "", err
-		}
-		for _, v := range jsonData {
-			for registry, v1 := range (v).(map[string]interface{}) {
-				for _, credentials := range (v1).(map[string]interface{}) {
-					if registry == request.URL.Host {
-						auth = credentials.(string)
-					}
-				}
-			}
-		}
-		authHeaderVal := "Basic " + auth
+	} else if fileExists(os.Getenv("HOME") + configFilePath) {
+		var auth string
+		auth, err = fetchAuthInfo(request.URL.Host, true)
+		authHeaderVal = "Basic " + auth
 		response, err = client.doRequest(request, jsonAcceptHeader, authHeaderVal, tokenFetchURL)
 		if err != nil {
 			return "", err
@@ -142,13 +180,13 @@ func (client *orasSourceClient) fetchToken(request *source.Request, path string)
 			return "", err
 		}
 	}
-	token, err := ioutil.ReadAll(response.Body)
+	token, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}
 	defer response.Body.Close()
 	var tokenData map[string]interface{}
-	if err := json.Unmarshal(token, &tokenData); err != nil {
+	if err = json.Unmarshal(token, &tokenData); err != nil {
 		return "", err
 	}
 	logger.Info(fmt.Sprintf("fetching token for %s  successful", request.URL))

--- a/pkg/source/source_client_builder.go
+++ b/pkg/source/source_client_builder.go
@@ -20,11 +20,14 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v3"
+
+	commonv1 "d7y.io/api/pkg/apis/common/v1"
 )
 
 var (
 	resourceClientBuilder = map[string]ResourceClientBuilder{}
 	resourceClientOptions = map[string]interface{}{}
+	resourceAuthInjector  = map[string]AuthInfoInjector{}
 )
 
 // ResourceClientBuilder is used to build resource client with custom option
@@ -33,12 +36,35 @@ type ResourceClientBuilder interface {
 	Build(optionYaml []byte) (resourceClient ResourceClient, adaptor RequestAdapter, hooks []Hook, err error)
 }
 
+// AuthInfoInjector will inject auth information for target url and metadata, eg: fetch docker config for different users
+type AuthInfoInjector interface {
+	Inject(url string, urlMeta *commonv1.UrlMeta) error
+}
+
+// RegisterOption is used for extra options when registering, like mark target scheme protocol should inject auth information
+type RegisterOption func(scheme string)
+
 // RegisterBuilder register ResourceClientBuilder into global resourceClientBuilder, the InitSourceClients will use it.
-func RegisterBuilder(scheme string, builder ResourceClientBuilder) {
+func RegisterBuilder(scheme string, builder ResourceClientBuilder, opts ...RegisterOption) {
 	if _, ok := resourceClientBuilder[scheme]; ok {
 		panic(fmt.Sprintf("duplicate ResourceClientBuilder: %s", scheme))
 	}
 	resourceClientBuilder[scheme] = builder
+
+	for _, opt := range opts {
+		opt(scheme)
+	}
+}
+
+func WithAuthInfoInjector(inj AuthInfoInjector) RegisterOption {
+	return func(scheme string) {
+		resourceAuthInjector[scheme] = inj
+	}
+}
+
+func ShouldInjectAuthInfo(scheme string) (AuthInfoInjector, bool) {
+	inj, ok := resourceAuthInjector[scheme]
+	return inj, ok
 }
 
 func UnRegisterBuilder(scheme string) {
@@ -87,4 +113,17 @@ func (b *plainResourceClientBuilder) Build(optionYaml []byte) (resourceClient Re
 func NewPlainResourceClientBuilder(
 	build func(optionYaml []byte) (resourceClient ResourceClient, adaptor RequestAdapter, hooks []Hook, err error)) ResourceClientBuilder {
 	return &plainResourceClientBuilder{build: build}
+}
+
+type plainAuthInfoInjector struct {
+	inject func(url string, urlMeta *commonv1.UrlMeta) error
+}
+
+func (a *plainAuthInfoInjector) Inject(url string, urlMeta *commonv1.UrlMeta) error {
+	return a.inject(url, urlMeta)
+}
+
+func NewPlainAuthInfoInjector(
+	inject func(url string, urlMeta *commonv1.UrlMeta) error) AuthInfoInjector {
+	return &plainAuthInfoInjector{inject: inject}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When download with dfget, some config like docker config is in special user home directory. 
For more flexible to fetch auth information, we introduce a new interface `AuthInfoInjector`.

Source client can register `AuthInfoInjector` optional. `AuthInfoInjector` will be invoked before dfget send the download grpc request to daemon. `AuthInfoInjector` injects auth information into the urlMeta or others.

## Related Issue

#2146

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
