### PR TITLE
feat: add CreatedAt function

### DIFF
--- a/scheduler/networktopology/probes.go
+++ b/scheduler/networktopology/probes.go
@@ -70,7 +70,7 @@ type Probes interface {
 	// Length gets the length of probes.
 	Length() int
 
-	// CreatedAt is the creation time to of probes.
+	// CreatedAt is the creation time of probes.
 	CreatedAt() time.Time
 
 	// UpdatedAt is the updated time to store probe.
@@ -193,7 +193,7 @@ func (p *probes) Length() int {
 	return p.items.Len()
 }
 
-// CreatedAt is the creation time to of probes.
+// CreatedAt is the creation time of probes.
 func (p *probes) CreatedAt() time.Time {
 	return p.createdAt.Load()
 }

--- a/scheduler/networktopology/probes.go
+++ b/scheduler/networktopology/probes.go
@@ -70,7 +70,10 @@ type Probes interface {
 	// Length gets the length of probes.
 	Length() int
 
-	// UpdateAt is the updated time to store probe.
+	// CreatedAt is the creation time to of probes.
+	CreatedAt() time.Time
+
+	// UpdatedAt is the updated time to store probe.
 	UpdatedAt() time.Time
 
 	// AverageRTT is the average round-trip time of probes.
@@ -190,7 +193,12 @@ func (p *probes) Length() int {
 	return p.items.Len()
 }
 
-// UpdateAt is the updated time to store probe.
+// CreatedAt is the creation time to of probes.
+func (p *probes) CreatedAt() time.Time {
+	return p.createdAt.Load()
+}
+
+// UpdatedAt is the updated time to store probe.
 func (p *probes) UpdatedAt() time.Time {
 	return p.updatedAt.Load()
 }

--- a/scheduler/networktopology/probes_test.go
+++ b/scheduler/networktopology/probes_test.go
@@ -18,6 +18,7 @@ package networktopology
 
 import (
 	"container/list"
+	"sync"
 	"testing"
 	"time"
 
@@ -134,6 +135,16 @@ var (
 		Host:      mockHost,
 		RTT:       30 * time.Nanosecond,
 		CreatedAt: time.Now(),
+	}
+
+	mockProbes = &probes{
+		host:       mockHost,
+		limit:      mockQueueLength,
+		items:      list.New(),
+		averageRTT: atomic.NewDuration(0),
+		createdAt:  atomic.NewTime(time.Now()),
+		updatedAt:  atomic.NewTime(time.Time{}),
+		mu:         &sync.RWMutex{},
 	}
 
 	mockQueueLength = 5
@@ -498,6 +509,27 @@ func TestProbes_Length(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mock(tc.probes)
 			tc.expect(t, tc.probes.Length())
+		})
+	}
+}
+
+func TestProbes_CreatedAt(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect func(t *testing.T, updatedAt time.Time)
+	}{
+		{
+			name: "get creation time of probes",
+			expect: func(t *testing.T, createdAt time.Time) {
+				assert := assert.New(t)
+				assert.Equal(createdAt, mockProbes.createdAt)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.expect(t, mockProbes.CreatedAt())
 		})
 	}
 }

--- a/scheduler/networktopology/probes_test.go
+++ b/scheduler/networktopology/probes_test.go
@@ -522,14 +522,15 @@ func TestProbes_CreatedAt(t *testing.T) {
 			name: "get creation time of probes",
 			expect: func(t *testing.T, createdAt time.Time) {
 				assert := assert.New(t)
-				assert.Equal(createdAt, mockProbes.createdAt)
+				assert.Equal(createdAt, mockProbes.createdAt.Load())
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.expect(t, mockProbes.CreatedAt())
+			probes := NewProbes(mockQueueLength, mockHost)
+			tc.expect(t, probes.CreatedAt())
 		})
 	}
 }

--- a/scheduler/networktopology/probes_test.go
+++ b/scheduler/networktopology/probes_test.go
@@ -529,8 +529,7 @@ func TestProbes_CreatedAt(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			probes := NewProbes(mockQueueLength, mockHost)
-			tc.expect(t, probes.CreatedAt())
+			tc.expect(t, mockProbes.CreatedAt())
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

CreatedAt is the function to get creation time of probes. 

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
