### PR TITLE
Add multi-arch container images to workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,9 @@ jobs:
         module: ["manager", "scheduler", "dfdaemon"]
         include:
           - module: manager
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
           - module: scheduler
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
           - module: dfdaemon
             platforms: linux/amd64,linux/arm64
     timeout-minutes: 20


### PR DESCRIPTION

Add multiple arch container images resolves #2269 

<!--- Provide a general summary of your changes in the Title above -->

## Description

Manager cannot run on arm64 machine due to non supported architecture.
```
NotFound desc = failed to pull and unpack image "ghcr.io/dragonflyoss/dragonfly2/manager:v2.0.9": no match for platform in manifest: not found
```
## Motivation and Context
Multi-arch capability

## Screenshots (if appropriate)
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/23084355/231517689-a3e351e9-9ea8-4953-a3b1-4599cf8343d0.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
