### PR TITLE
Github docker workflow timeouts while building manager image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
             platforms: linux/amd64,linux/arm64
           - module: dfdaemon
             platforms: linux/amd64,linux/arm64
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,9 @@ jobs:
         module: ["manager", "scheduler", "dfdaemon"]
         include:
           - module: manager
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
           - module: scheduler
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
           - module: dfdaemon
             platforms: linux/amd64,linux/arm64
     timeout-minutes: 20


### PR DESCRIPTION
## Description
Docker build job breaks due to workflow timeout limit at [Line24](https://github.com/dragonflyoss/Dragonfly2/blob/920e348f6d5e047d981996a3b9a556eb5a39cc6c/.github/workflows/docker.yml#L24)

```
crane config ghcr.io/dragonflyoss/dragonfly2/manager:latest@sha256:f896f04f90f8ccacf007f26c7513b3ff6068e96abddf2899982e90af89e6509d | jq
{
  "architecture": "unknown",
  "os": "unknown",
  "config": {},
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:53247f5000d7fa895af6d05686da234ab9fad161739489c070b1ca6d2fa0cb37"
    ]
  }
}
```

<!--- Describe your changes in detail -->
Increase timeout limit on the pipeline. 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue: #2271 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Arm64 architecture images released except Manager image.
## Screenshots (if appropriate)

<img width="1493" alt="image" src="https://user-images.githubusercontent.com/23084355/231697181-26402857-3562-4853-af75-0a40cc384632.png">

<img width="1493" alt="image" src="https://user-images.githubusercontent.com/23084355/231698452-5e58f036-0f48-473d-a45b-94f2ec4e6eee.png">


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
