### PR TITLE
fix: redis validation in scheduler config

### DIFF
--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -520,11 +520,11 @@ func (cfg *Config) Validate() error {
 			return errors.New("job requires parameter addrs")
 		}
 
-		if cfg.Job.Redis.BrokerDB <= 0 {
+		if cfg.Job.Redis.BrokerDB < 0 {
 			return errors.New("job requires parameter redis brokerDB")
 		}
 
-		if cfg.Job.Redis.BackendDB <= 0 {
+		if cfg.Job.Redis.BackendDB < 0 {
 			return errors.New("job requires parameter redis backendDB")
 		}
 	}

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -506,7 +506,7 @@ func TestConfig_Validate(t *testing.T) {
 			mock: func(cfg *Config) {
 				cfg.Manager = mockManagerConfig
 				cfg.Job = mockJobConfig
-				cfg.Job.Redis.BrokerDB = 0
+				cfg.Job.Redis.BrokerDB = -1
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
@@ -519,7 +519,7 @@ func TestConfig_Validate(t *testing.T) {
 			mock: func(cfg *Config) {
 				cfg.Manager = mockManagerConfig
 				cfg.Job = mockJobConfig
-				cfg.Job.Redis.BackendDB = 0
+				cfg.Job.Redis.BackendDB = -1
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- When Redis is in cluster mode, only DB 0 can be used.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
