### PR TITLE
chore: checkout code first in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - uses: actions/setup-go@v4
         with:
           go-version: '1.20'
-
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Golangci lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
setup-go has built-in functionality for caching and restoring go modules and build outputs. The action defaults to search for the dependency file - go.sum in the repository root, and uses its hash as a part of the cache key. To use the cache, we should first checkout code. Otherwise setup-go can't find go.sum and use/restore cache. Related: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
