### PR TITLE
feat: change DefaultServerPort to 9090 in trainer

### DIFF
--- a/trainer/config/config_test.go
+++ b/trainer/config/config_test.go
@@ -60,7 +60,7 @@ func TestConfig_Load(t *testing.T) {
 			AdvertiseIP:   net.ParseIP("127.0.0.1"),
 			AdvertisePort: 9090,
 			ListenIP:      net.ParseIP("0.0.0.0"),
-			Port:          9092,
+			Port:          9090,
 			LogDir:        "foo",
 			DataDir:       "foo",
 		},

--- a/trainer/config/constants.go
+++ b/trainer/config/constants.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// DefaultServerPort is default port for server.
-	DefaultServerPort = 9092
+	DefaultServerPort = 9090
 
 	// DefaultServerAdvertisePort is default advertise port for server.
 	DefaultServerAdvertisePort = 9090

--- a/trainer/config/testdata/trainer.yaml
+++ b/trainer/config/testdata/trainer.yaml
@@ -5,7 +5,7 @@ server:
   advertiseIP: 127.0.0.1
   advertisePort: 9090
   listenIP: 0.0.0.0
-  port: 9092
+  port: 9090
   host: foo
   logDir: foo
   dataDir: foo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Change DefaultServerPort to 9090 in trainer.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
