### PR TITLE
feat: remove traffic_type in DownloadPeerDuration metric

### DIFF
--- a/scheduler/metrics/metrics.go
+++ b/scheduler/metrics/metrics.go
@@ -244,7 +244,7 @@ var (
 		Name:      "download_peer_duration_milliseconds",
 		Help:      "Histogram of the time each peer downloading.",
 		Buckets:   []float64{100, 200, 500, 1000, 1500, 2 * 1000, 3 * 1000, 5 * 1000, 10 * 1000, 20 * 1000, 60 * 1000, 120 * 1000, 300 * 1000},
-	}, []string{"priority", "task_type", "task_tag", "task_app", "host_type", "traffic_type"})
+	}, []string{"priority", "task_type", "task_tag", "task_app", "host_type"})
 
 	ConcurrentScheduleGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: types.MetricsNamespace,

--- a/scheduler/service/service_v1.go
+++ b/scheduler/service/service_v1.go
@@ -317,12 +317,12 @@ func (v *V1) ReportPeerResult(ctx context.Context, req *schedulerv1.PeerResult) 
 		v.handleTaskSuccess(ctx, peer.Task, req)
 		v.handlePeerSuccess(ctx, peer)
 		metrics.DownloadPeerDuration.WithLabelValues(priority.String(), peer.Task.Type.String(),
-			peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name(), commonv2.TrafficType_BACK_TO_SOURCE.String()).Observe(float64(req.Cost))
+			peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name()).Observe(float64(req.Cost))
 		return nil
 	}
 
 	metrics.DownloadPeerDuration.WithLabelValues(priority.String(), peer.Task.Type.String(),
-		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name(), commonv2.TrafficType_REMOTE_PEER.String()).Observe(float64(req.Cost))
+		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name()).Observe(float64(req.Cost))
 
 	go v.createDownloadRecord(peer, parents, req)
 	v.handlePeerSuccess(ctx, peer)

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -797,7 +797,7 @@ func (v *V2) handleDownloadPeerFinishedRequest(ctx context.Context, peerID strin
 		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name()).Inc()
 	// TODO to be determined which traffic type to use, temporarily use TrafficType_REMOTE_PEER instead
 	metrics.DownloadPeerDuration.WithLabelValues(priority.String(), peer.Task.Type.String(),
-		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name(), commonv2.TrafficType_REMOTE_PEER.String()).Observe(float64(peer.Cost.Load()))
+		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name()).Observe(float64(peer.Cost.Load()))
 
 	return nil
 }
@@ -848,7 +848,7 @@ func (v *V2) handleDownloadPeerBackToSourceFinishedRequest(ctx context.Context, 
 		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name()).Inc()
 	// TODO to be determined which traffic type to use, temporarily use TrafficType_REMOTE_PEER instead
 	metrics.DownloadPeerDuration.WithLabelValues(priority.String(), peer.Task.Type.String(),
-		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name(), commonv2.TrafficType_REMOTE_PEER.String()).Observe(float64(peer.Cost.Load()))
+		peer.Task.Tag, peer.Task.Application, peer.Host.Type.Name()).Observe(float64(peer.Cost.Load()))
 
 	return nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove traffic_type in DownloadPeerDuration metric.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
