### PR TITLE
feat: replace net dial with grpc health check in client

### DIFF
--- a/pkg/rpc/manager/client/client_v2.go
+++ b/pkg/rpc/manager/client/client_v2.go
@@ -37,7 +37,7 @@ import (
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/pkg/dfnet"
-	"d7y.io/dragonfly/v2/pkg/reachable"
+	healthclient "d7y.io/dragonfly/v2/pkg/rpc/health/client"
 )
 
 // GetV2ByAddr returns v2 version of the manager client by address.
@@ -76,15 +76,14 @@ func GetV2ByAddr(ctx context.Context, target string, opts ...grpc.DialOption) (V
 // GetV2ByNetAddrs returns v2 version of the manager client with net addresses.
 func GetV2ByNetAddrs(ctx context.Context, netAddrs []dfnet.NetAddr, opts ...grpc.DialOption) (V2, error) {
 	for _, netAddr := range netAddrs {
-		ipReachable := reachable.New(&reachable.Config{Address: netAddr.Addr})
-		if err := ipReachable.Check(); err == nil {
-			logger.Infof("use %s address for manager grpc client", netAddr.Addr)
+		if err := healthclient.Check(context.Background(), netAddr.String(), opts...); err == nil {
+			logger.Infof("manager address %s is reachable", netAddr.String())
 			return GetV2ByAddr(ctx, netAddr.Addr, opts...)
 		}
-		logger.Warnf("%s manager address can not reachable", netAddr.Addr)
+		logger.Warnf("manager address %s is unreachable", netAddr.String())
 	}
 
-	return nil, errors.New("can not find available manager addresses")
+	return nil, errors.New("can not find reachable manager addresses")
 }
 
 // V2 is the interface for v2 version of the grpc client.


### PR DESCRIPTION
Replace net dial with grpc health check in manager grpc client and security grpc client. Make grpc health check consistent.

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Replace net dial with grpc health check in client.
<!--- Describe your changes in detail -->

## Related Issue
#2360 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
