### PR TITLE
fix: when bufferSize is zero, storage can not write data to file

### DIFF
--- a/scheduler/storage/storage.go
+++ b/scheduler/storage/storage.go
@@ -146,7 +146,7 @@ func (s *storage) CreateDownload(download Download) error {
 
 	// Write without buffer.
 	if s.bufferSize == 0 {
-		if err := s.createDownload(s.downloadBuffer...); err != nil {
+		if err := s.createDownload(download); err != nil {
 			return err
 		}
 
@@ -180,7 +180,7 @@ func (s *storage) CreateNetworkTopology(networkTopology NetworkTopology) error {
 
 	// Write without buffer.
 	if s.bufferSize == 0 {
-		if err := s.createNetworkTopology(s.networkTopologyBuffer...); err != nil {
+		if err := s.createNetworkTopology(networkTopology); err != nil {
 			return err
 		}
 

--- a/scheduler/storage/storage_test.go
+++ b/scheduler/storage/storage_test.go
@@ -316,6 +316,10 @@ func TestStorage_CreateDownload(t *testing.T) {
 				err := s.CreateDownload(Download{})
 				assert.NoError(err)
 				assert.Equal(s.(*storage).downloadCount, int64(1))
+
+				downloads, err := s.ListDownload()
+				assert.NoError(err)
+				assert.Equal(len(downloads), 1)
 			},
 		},
 		{
@@ -396,6 +400,10 @@ func TestStorage_CreateNetworkTopology(t *testing.T) {
 				err := s.CreateNetworkTopology(NetworkTopology{})
 				assert.NoError(err)
 				assert.Equal(s.(*storage).networkTopologyCount, int64(1))
+
+				networkTopologies, err := s.ListNetworkTopology()
+				assert.NoError(err)
+				assert.Equal(len(networkTopologies), 1)
 			},
 		},
 		{


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- When bufferSize is zero, createDownload and createNetworkTopology can not write data to file, because buffer is empty.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
