### PR TITLE
fix: call MakeNamespaceKeyInScheduler function error

### DIFF
--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -115,7 +115,7 @@ func MakeNamespaceKeyInScheduler(namespace string) string {
 
 // MakeKeyInScheduler make key in scheduler.
 func MakeKeyInScheduler(namespace, id string) string {
-	return fmt.Sprintf("%s:%s", MakeNamespaceKeyInManager(namespace), id)
+	return fmt.Sprintf("%s:%s", MakeNamespaceKeyInScheduler(namespace), id)
 }
 
 // MakeNetworkTopologyKeyInScheduler make network topology key in scheduler.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It should call MakeNamespaceKeyInScheduler() function in MakeKeyInScheduler() function, instead of MakeNamespaceKeyInManager() function.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
