### PR TITLE
feat: add StoreProbe function in network topology and CreatedAt function in probes

### DIFF
--- a/scheduler/networktopology/mocks/network_topology_mock.go
+++ b/scheduler/networktopology/mocks/network_topology_mock.go
@@ -91,3 +91,17 @@ func (mr *MockNetworkTopologyMockRecorder) ProbedCount(arg0 interface{}) *gomock
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProbedCount", reflect.TypeOf((*MockNetworkTopology)(nil).ProbedCount), arg0)
 }
+
+// StoreProbe mocks base method.
+func (m *MockNetworkTopology) StoreProbe(srcHostID, destHostID string, probe *networktopology.Probe) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreProbe", srcHostID, destHostID, probe)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StoreProbe indicates an expected call of StoreProbe.
+func (mr *MockNetworkTopologyMockRecorder) StoreProbe(srcHostID, destHostID, probe interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreProbe", reflect.TypeOf((*MockNetworkTopology)(nil).StoreProbe), srcHostID, destHostID, probe)
+}

--- a/scheduler/networktopology/mocks/probes_mock.go
+++ b/scheduler/networktopology/mocks/probes_mock.go
@@ -50,6 +50,21 @@ func (mr *MockProbesMockRecorder) AverageRTT() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AverageRTT", reflect.TypeOf((*MockProbes)(nil).AverageRTT))
 }
 
+// CreatedAt mocks base method.
+func (m *MockProbes) CreatedAt() (time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatedAt")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatedAt indicates an expected call of CreatedAt.
+func (mr *MockProbesMockRecorder) CreatedAt() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatedAt", reflect.TypeOf((*MockProbes)(nil).CreatedAt))
+}
+
 // Dequeue mocks base method.
 func (m *MockProbes) Dequeue() (*networktopology.Probe, error) {
 	m.ctrl.T.Helper()

--- a/scheduler/networktopology/network_topology.go
+++ b/scheduler/networktopology/network_topology.go
@@ -91,7 +91,7 @@ func (nt *networkTopology) StoreProbe(srcHostID, destHostID string, probe *Probe
 	}
 
 	if exists == 0 {
-		if err := nt.rdb.HSet(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(srcHostID, destHostID), "createdAt", time.Now()).Err(); err != nil {
+		if err := nt.rdb.HSet(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(srcHostID, destHostID), "createdAt", time.Now().Format(time.RFC3339Nano)).Err(); err != nil {
 			return err
 		}
 	}

--- a/scheduler/networktopology/network_topology.go
+++ b/scheduler/networktopology/network_topology.go
@@ -83,7 +83,8 @@ func (nt *networkTopology) StoreProbe(srcHostID, destHostID string, probe *Probe
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
-	// If network topology from srcHost to destHost does not exist, create a new hash table in redis and set creation time.
+	// If network topology from source host to destination host does not exist,
+	// create a new hash table in redis and set creation time.
 	exists, err := nt.rdb.Exists(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(srcHostID, destHostID)).Result()
 	if err != nil {
 		return err
@@ -95,7 +96,8 @@ func (nt *networkTopology) StoreProbe(srcHostID, destHostID string, probe *Probe
 		}
 	}
 
-	// If probed count of destHost does not exist, create a new key-value and set the initial value to 0.
+	// If probed count of host does not exist, create a new key-value
+	// in redis and set the initial value to 0.
 	exists, err = nt.rdb.Exists(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID)).Result()
 	if err != nil {
 		return err

--- a/scheduler/networktopology/network_topology.go
+++ b/scheduler/networktopology/network_topology.go
@@ -85,27 +85,27 @@ func (nt *networkTopology) StoreProbe(srcHostID, destHostID string, probe *Probe
 
 	// If network topology from source host to destination host does not exist,
 	// create a new hash table in redis and set creation time.
-	exists, err := nt.rdb.Exists(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(srcHostID, destHostID)).Result()
+	networkTopologyExists, err := nt.rdb.Exists(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(srcHostID, destHostID)).Result()
 	if err != nil {
 		return err
 	}
 
-	if exists == 0 {
+	if networkTopologyExists == 0 {
 		if err := nt.rdb.HSet(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(srcHostID, destHostID), "createdAt", time.Now().Format(time.RFC3339Nano)).Err(); err != nil {
 			return err
 		}
-	}
 
-	// If probed count of host does not exist, create a new key-value
-	// in redis and set the initial value to 0.
-	exists, err = nt.rdb.Exists(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID)).Result()
-	if err != nil {
-		return err
-	}
-
-	if exists == 0 {
-		if err := nt.rdb.Set(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID), 0, 0).Err(); err != nil {
+		// If probed count of host does not exist, create a new key-value
+		// in redis and set the initial value to 0.
+		probedCountExists, err := nt.rdb.Exists(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID)).Result()
+		if err != nil {
 			return err
+		}
+
+		if probedCountExists == 0 {
+			if err := nt.rdb.Set(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID), 0, 0).Err(); err != nil {
+				return err
+			}
 		}
 
 		// Update probed count.

--- a/scheduler/networktopology/network_topology.go
+++ b/scheduler/networktopology/network_topology.go
@@ -107,15 +107,15 @@ func (nt *networkTopology) StoreProbe(srcHostID, destHostID string, probe *Probe
 		if err := nt.rdb.Set(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID), 0, 0).Err(); err != nil {
 			return err
 		}
+
+		// Update probed count.
+		if err := nt.rdb.Incr(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID)).Err(); err != nil {
+			return err
+		}
 	}
 
 	// Store probe in queue.
 	if err := nt.LoadProbes(srcHostID, destHostID).Enqueue(probe); err != nil {
-		return err
-	}
-
-	// Update probed count.
-	if err := nt.rdb.Incr(ctx, pkgredis.MakeProbedCountKeyInScheduler(destHostID)).Err(); err != nil {
 		return err
 	}
 

--- a/scheduler/networktopology/network_topology_test.go
+++ b/scheduler/networktopology/network_topology_test.go
@@ -159,6 +159,8 @@ var (
 			Count:       10,
 		},
 	}
+
+	mockProbesCreatedAt = time.Now()
 )
 
 func Test_NewNetworkTopology(t *testing.T) {

--- a/scheduler/networktopology/network_topology_test.go
+++ b/scheduler/networktopology/network_topology_test.go
@@ -210,6 +210,7 @@ func TestNetworkTopology_StoreProbe(t *testing.T) {
 
 				mockRDBClient.ExpectExists(pkgredis.MakeProbedCountKeyInScheduler(mockHost.ID)).SetVal(0)
 				mockRDBClient.ExpectSet(pkgredis.MakeProbedCountKeyInScheduler(mockHost.ID), 0, 0).SetVal("ok")
+				mockRDBClient.ExpectIncr(pkgredis.MakeProbedCountKeyInScheduler(mockHost.ID)).SetVal(1)
 
 				data, err := json.Marshal(ps[0])
 				if err != nil {
@@ -220,8 +221,6 @@ func TestNetworkTopology_StoreProbe(t *testing.T) {
 				mockRDBClient.ExpectRPush(pkgredis.MakeProbesKeyInScheduler(mockSeedHost.ID, mockHost.ID), data).SetVal(1)
 				mockRDBClient.ExpectHSet(pkgredis.MakeNetworkTopologyKeyInScheduler(mockSeedHost.ID, mockHost.ID), "averageRTT", mockProbe.RTT.Nanoseconds()).SetVal(1)
 				mockRDBClient.ExpectHSet(pkgredis.MakeNetworkTopologyKeyInScheduler(mockSeedHost.ID, mockHost.ID), "updatedAt", mockProbe.CreatedAt.Format(time.RFC3339Nano)).SetVal(1)
-
-				mockRDBClient.ExpectIncr(pkgredis.MakeProbedCountKeyInScheduler(mockHost.ID)).SetVal(1)
 			},
 			expect: func(t *testing.T, networkTopology NetworkTopology, err error) {
 				assert := assert.New(t)
@@ -256,8 +255,6 @@ func TestNetworkTopology_StoreProbe(t *testing.T) {
 				mockRDBClient.ExpectLRange(pkgredis.MakeProbesKeyInScheduler(mockSeedHost.ID, mockHost.ID), 0, -1).SetVal([]string{rawProbes[1], rawProbes[0]})
 				mockRDBClient.ExpectHSet(pkgredis.MakeNetworkTopologyKeyInScheduler(mockSeedHost.ID, mockHost.ID), "averageRTT", int64(30100000)).SetVal(1)
 				mockRDBClient.ExpectHSet(pkgredis.MakeNetworkTopologyKeyInScheduler(mockSeedHost.ID, mockHost.ID), "updatedAt", mockProbe.CreatedAt.Format(time.RFC3339Nano)).SetVal(1)
-
-				mockRDBClient.ExpectIncr(pkgredis.MakeProbedCountKeyInScheduler(mockHost.ID)).SetVal(2)
 			},
 			expect: func(t *testing.T, networkTopology NetworkTopology, err error) {
 				assert := assert.New(t)
@@ -296,8 +293,6 @@ func TestNetworkTopology_StoreProbe(t *testing.T) {
 				mockRDBClient.ExpectLRange(pkgredis.MakeProbesKeyInScheduler(mockSeedHost.ID, mockHost.ID), 0, -1).SetVal(rawProbes)
 				mockRDBClient.ExpectHSet(pkgredis.MakeNetworkTopologyKeyInScheduler(mockSeedHost.ID, mockHost.ID), "averageRTT", int64(30388900)).SetVal(1)
 				mockRDBClient.ExpectHSet(pkgredis.MakeNetworkTopologyKeyInScheduler(mockSeedHost.ID, mockHost.ID), "updatedAt", mockProbe.CreatedAt.Format(time.RFC3339Nano)).SetVal(1)
-
-				mockRDBClient.ExpectIncr(pkgredis.MakeProbedCountKeyInScheduler(mockHost.ID)).SetVal(5)
 			},
 			expect: func(t *testing.T, networkTopology NetworkTopology, err error) {
 				assert := assert.New(t)

--- a/scheduler/networktopology/probes.go
+++ b/scheduler/networktopology/probes.go
@@ -73,6 +73,9 @@ type Probes interface {
 	// UpdatedAt is the updated time to store probe.
 	UpdatedAt() (time.Time, error)
 
+	// CreatedAt is the creation time of probes.
+	CreatedAt() (time.Time, error)
+
 	// AverageRTT is the moving average round-trip time of probes.
 	AverageRTT() (time.Duration, error)
 }
@@ -222,6 +225,14 @@ func (p *probes) UpdatedAt() (time.Time, error) {
 	defer cancel()
 
 	return p.rdb.HGet(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(p.srcHostID, p.destHostID), "updatedAt").Time()
+}
+
+// CreatedAt is the creation time of probes.
+func (p *probes) CreatedAt() (time.Time, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	return p.rdb.HGet(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(p.srcHostID, p.destHostID), "createdAt").Time()
 }
 
 // AverageRTT is the moving average round-trip time of probes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add store probe function in network topology.
If network topology from source host to destination host does not exist, create a new hash table in redis and set creation time.
If probed count of host does not exist, create a new key-value and set the initial value to 0.
Store probe in queue and update probed count.

Add CreatedAt function in probes to get creation time of probes.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
