### PR TITLE
test: add ParseProbedCountKeyInScheduler and Snapshot tests

### DIFF
--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -153,6 +153,16 @@ func MakeProbesKeyInScheduler(srcHostID, destHostID string) string {
 	return MakeKeyInScheduler(ProbesNamespace, fmt.Sprintf("%s:%s", srcHostID, destHostID))
 }
 
+// ParseProbedCountKeyInScheduler parse probed count key in scheduler.
+func ParseProbedCountKeyInScheduler(key string) (string, string, string, error) {
+	elements := strings.Split(key, KeySeparator)
+	if len(elements) != 3 {
+		return "", "", "", fmt.Errorf("invalid probed count key: %s", key)
+	}
+
+	return elements[0], elements[1], elements[2], nil
+}
+
 // MakeProbedCountKeyInScheduler make probed count key in scheduler.
 func MakeProbedCountKeyInScheduler(hostID string) string {
 	return MakeKeyInScheduler(ProbedCountNamespace, hostID)

--- a/pkg/redis/redis_test.go
+++ b/pkg/redis/redis_test.go
@@ -6,6 +6,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		addrs  []string
+		expect func(t *testing.T, ok bool)
+	}{
+		{
+			name:  "check redis is enabled",
+			addrs: []string{"172.0.0.1"},
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+			},
+		},
+		{
+			name:  "addrs is empty",
+			addrs: []string{},
+			expect: func(t *testing.T, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.expect(t, IsEnabled(tc.addrs))
+		})
+	}
+}
+
 func Test_MakeNamespaceKeyInManager(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -46,19 +76,19 @@ func Test_MakeKeyInManager(t *testing.T) {
 		{
 			name:      "make key in manager",
 			namespace: "namespace",
-			id:        "id",
+			id:        "foo",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:namespace:id")
+				assert.Equal(s, "manager:namespace:foo")
 			},
 		},
 		{
 			name:      "namespace is empty",
 			namespace: "",
-			id:        "id",
+			id:        "foo",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager::id")
+				assert.Equal(s, "manager::foo")
 			},
 		},
 		{
@@ -98,11 +128,11 @@ func Test_MakeSeedPeerKeyInManager(t *testing.T) {
 		{
 			name:      "make seed peer key in manager",
 			clusterID: 1,
-			hostname:  "hostname",
+			hostname:  "foo",
 			ip:        "127.0.0.1",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:seed-peers:1-hostname-127.0.0.1")
+				assert.Equal(s, "manager:seed-peers:1-foo-127.0.0.1")
 			},
 		},
 		{
@@ -118,11 +148,11 @@ func Test_MakeSeedPeerKeyInManager(t *testing.T) {
 		{
 			name:      "ip is empty",
 			clusterID: 1,
-			hostname:  "hostname",
+			hostname:  "bar",
 			ip:        "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:seed-peers:1-hostname-")
+				assert.Equal(s, "manager:seed-peers:1-bar-")
 			},
 		},
 		{
@@ -154,11 +184,11 @@ func Test_MakeSchedulerKeyInManager(t *testing.T) {
 		{
 			name:      "make scheduler key in manager",
 			clusterID: 1,
-			hostname:  "hostname",
+			hostname:  "bar",
 			ip:        "127.0.0.1",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:schedulers:1-hostname-127.0.0.1")
+				assert.Equal(s, "manager:schedulers:1-bar-127.0.0.1")
 			},
 		},
 		{
@@ -174,11 +204,11 @@ func Test_MakeSchedulerKeyInManager(t *testing.T) {
 		{
 			name:      "ip is empty",
 			clusterID: 1,
-			hostname:  "hostname",
+			hostname:  "bar",
 			ip:        "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:schedulers:1-hostname-")
+				assert.Equal(s, "manager:schedulers:1-bar-")
 			},
 		},
 		{
@@ -208,11 +238,11 @@ func Test_MakePeerKeyInManager(t *testing.T) {
 	}{
 		{
 			name:     "make peer key in manager",
-			hostname: "hostname",
+			hostname: "baz",
 			ip:       "127.0.0.1",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:hostname-127.0.0.1")
+				assert.Equal(s, "manager:peers:baz-127.0.0.1")
 			},
 		},
 		{
@@ -226,11 +256,11 @@ func Test_MakePeerKeyInManager(t *testing.T) {
 		},
 		{
 			name:     "ip is empty",
-			hostname: "hostname",
+			hostname: "baz",
 			ip:       "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:hostname-")
+				assert.Equal(s, "manager:peers:baz-")
 			},
 		},
 		{
@@ -259,11 +289,11 @@ func Test_MakeSchedulersKeyForPeerInManager(t *testing.T) {
 	}{
 		{
 			name:     "make scheduler key for peer in manager",
-			hostname: "hostname",
+			hostname: "bar",
 			ip:       "127.0.0.1",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:hostname-127.0.0.1:schedulers")
+				assert.Equal(s, "manager:peers:bar-127.0.0.1:schedulers")
 			},
 		},
 		{
@@ -277,11 +307,11 @@ func Test_MakeSchedulersKeyForPeerInManager(t *testing.T) {
 		},
 		{
 			name:     "ip is empty",
-			hostname: "hostname",
+			hostname: "bar",
 			ip:       "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:hostname-:schedulers")
+				assert.Equal(s, "manager:peers:bar-:schedulers")
 			},
 		},
 		{
@@ -329,10 +359,10 @@ func Test_MakeBucketKeyInManager(t *testing.T) {
 	}{
 		{
 			name:      "make bucket key in manager",
-			namespace: "namespace",
+			namespace: "baz",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:buckets:namespace")
+				assert.Equal(s, "manager:buckets:baz")
 			},
 		},
 		{
@@ -359,10 +389,10 @@ func Test_MakeNamespaceKeyInScheduler(t *testing.T) {
 	}{
 		{
 			name:      "make namespace key in scheduler",
-			namespace: "namespace",
+			namespace: "baz",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:namespace")
+				assert.Equal(s, "scheduler:baz")
 			},
 		},
 		{
@@ -390,11 +420,11 @@ func Test_MakeKeyInScheduler(t *testing.T) {
 	}{
 		{
 			name:      "make key in scheduler",
-			namespace: "namespace",
+			namespace: "bas",
 			id:        "id",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:namespace:id")
+				assert.Equal(s, "scheduler:bas:id")
 			},
 		},
 		{
@@ -408,11 +438,11 @@ func Test_MakeKeyInScheduler(t *testing.T) {
 		},
 		{
 			name:      "id is empty",
-			namespace: "namespace",
+			namespace: "bas",
 			id:        "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:namespace:")
+				assert.Equal(s, "scheduler:bas:")
 			},
 		},
 		{
@@ -441,29 +471,29 @@ func Test_MakeNetworkTopologyKeyInScheduler(t *testing.T) {
 	}{
 		{
 			name:       "make network topology key in scheduler",
-			srcHostID:  "src",
-			destHostID: "dest",
+			srcHostID:  "foo",
+			destHostID: "bar",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:network-topology:src:dest")
+				assert.Equal(s, "scheduler:network-topology:foo:bar")
 			},
 		},
 		{
 			name:       "source host id is empty",
 			srcHostID:  "",
-			destHostID: "dest",
+			destHostID: "bar",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:network-topology::dest")
+				assert.Equal(s, "scheduler:network-topology::bar")
 			},
 		},
 		{
 			name:       "destination host id is empty",
-			srcHostID:  "src",
+			srcHostID:  "foo",
 			destHostID: "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:network-topology:src:")
+				assert.Equal(s, "scheduler:network-topology:foo:")
 			},
 		},
 		{
@@ -492,29 +522,29 @@ func Test_MakeProbesKeyInScheduler(t *testing.T) {
 	}{
 		{
 			name:       "make probes key in scheduler",
-			srcHostID:  "src",
-			destHostID: "dest",
+			srcHostID:  "foo",
+			destHostID: "bar",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:probes:src:dest")
+				assert.Equal(s, "scheduler:probes:foo:bar")
 			},
 		},
 		{
 			name:       "source host id is empty",
 			srcHostID:  "",
-			destHostID: "dest",
+			destHostID: "bar",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:probes::dest")
+				assert.Equal(s, "scheduler:probes::bar")
 			},
 		},
 		{
 			name:       "destination host id is empty",
-			srcHostID:  "src",
+			srcHostID:  "foo",
 			destHostID: "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:probes:src:")
+				assert.Equal(s, "scheduler:probes:foo:")
 			},
 		},
 		{
@@ -534,6 +564,45 @@ func Test_MakeProbesKeyInScheduler(t *testing.T) {
 	}
 }
 
+func Test_ParseNetworkTopologyKeyInScheduler(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		expect func(t *testing.T, schedulerNamespace, networkTopologyNamespace, srcHostID, destHostID string, err error)
+	}{
+		{
+			name: "parse network topology key in scheduler",
+			key:  "schedulers:network-topology:foo:bar",
+			expect: func(t *testing.T, schedulerNamespace, networkTopologyNamespace, srcHostID, destHostID string, err error) {
+				assert := assert.New(t)
+				assert.Equal(schedulerNamespace, SchedulersNamespace)
+				assert.Equal(networkTopologyNamespace, NetworkTopologyNamespace)
+				assert.Equal(srcHostID, "foo")
+				assert.Equal(destHostID, "bar")
+				assert.NoError(err)
+			},
+		},
+		{
+			name: "parse network topology key in scheduler error",
+			key:  "foo",
+			expect: func(t *testing.T, schedulerNamespace, networkTopologyNamespace, srcHostID, destHostID string, err error) {
+				assert := assert.New(t)
+				assert.Equal(schedulerNamespace, "")
+				assert.Equal(networkTopologyNamespace, "")
+				assert.Equal(srcHostID, "")
+				assert.Equal(destHostID, "")
+				assert.EqualError(err, "invalid network topology key: foo")
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			schedulerNamespace, networkTopologyNamespace, srcHostID, destHostID, err := ParseNetworkTopologyKeyInScheduler(tc.key)
+			tc.expect(t, schedulerNamespace, networkTopologyNamespace, srcHostID, destHostID, err)
+		})
+	}
+}
+
 func Test_MakeProbedCountKeyInScheduler(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -542,10 +611,10 @@ func Test_MakeProbedCountKeyInScheduler(t *testing.T) {
 	}{
 		{
 			name:   "make probed count key in scheduler",
-			hostID: "host_id",
+			hostID: "foo",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "scheduler:probed-count:host_id")
+				assert.Equal(s, "scheduler:probed-count:foo")
 			},
 		},
 		{
@@ -564,6 +633,43 @@ func Test_MakeProbedCountKeyInScheduler(t *testing.T) {
 	}
 }
 
+func Test_ParseProbedCountKeyInScheduler(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		expect func(t *testing.T, schedulerNamespace, probedCountNamespace, hostID string, err error)
+	}{
+		{
+			name: "parse probed count key in scheduler",
+			key:  "schedulers:probed-count:foo",
+			expect: func(t *testing.T, schedulerNamespace, probedCountNamespace, hostID string, err error) {
+				assert := assert.New(t)
+				assert.Equal(schedulerNamespace, SchedulersNamespace)
+				assert.Equal(probedCountNamespace, probedCountNamespace)
+				assert.Equal(hostID, "foo")
+				assert.NoError(err)
+			},
+		},
+		{
+			name: "parse probed count key in scheduler error",
+			key:  "foo",
+			expect: func(t *testing.T, schedulerNamespace, probedCountNamespace, hostID string, err error) {
+				assert := assert.New(t)
+				assert.Equal(schedulerNamespace, "")
+				assert.Equal(probedCountNamespace, "")
+				assert.Equal(hostID, "")
+				assert.EqualError(err, "invalid probed count key: foo")
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			schedulerNamespace, probedCountNamespace, hostID, err := ParseProbedCountKeyInScheduler(tc.key)
+			tc.expect(t, schedulerNamespace, probedCountNamespace, hostID, err)
+		})
+	}
+}
+
 func Test_MakeProbedAtKeyInScheduler(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -572,10 +678,10 @@ func Test_MakeProbedAtKeyInScheduler(t *testing.T) {
 	}{
 		{
 			name:   "make probed at key in scheduler",
-			hostID: "host_id",
+			hostID: "bas",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal("scheduler:probed-at:host_id", s)
+				assert.Equal("scheduler:probed-at:bas", s)
 			},
 		},
 		{

--- a/scheduler/networktopology/network_topology.go
+++ b/scheduler/networktopology/network_topology.go
@@ -226,7 +226,13 @@ func (nt *networkTopology) Snapshot() error {
 		return err
 	}
 
-	for _, srcHostID := range probedCountKeys {
+	for _, probedCountKey := range probedCountKeys {
+		_, _, srcHostID, err := pkgredis.ParseProbedCountKeyInScheduler(probedCountKey)
+		if err != nil {
+			logger.Error(err)
+			continue
+		}
+
 		// Construct destination hosts for network topology.
 		networkTopologyKeys, err := nt.rdb.Keys(ctx, pkgredis.MakeNetworkTopologyKeyInScheduler(srcHostID, "*")).Result()
 		if err != nil {

--- a/scheduler/networktopology/probes_test.go
+++ b/scheduler/networktopology/probes_test.go
@@ -38,9 +38,9 @@ import (
 
 var (
 	mockHost = &resource.Host{
-		ID:                    idgen.HostIDV2("127.0.0.1", "hostname"),
+		ID:                    idgen.HostIDV2("127.0.0.1", "foo"),
 		Type:                  types.HostTypeNormal,
-		Hostname:              "hostname",
+		Hostname:              "foo",
 		IP:                    "127.0.0.1",
 		Port:                  8003,
 		DownloadPort:          8001,
@@ -63,9 +63,9 @@ var (
 	}
 
 	mockSeedHost = &resource.Host{
-		ID:                    idgen.HostIDV2("127.0.0.1", "hostname_seed"),
+		ID:                    idgen.HostIDV2("127.0.0.1", "bar"),
 		Type:                  types.HostTypeSuperSeed,
-		Hostname:              "hostname_seed",
+		Hostname:              "bar",
 		IP:                    "127.0.0.1",
 		Port:                  8003,
 		DownloadPort:          8001,

--- a/scheduler/resource/host_test.go
+++ b/scheduler/resource/host_test.go
@@ -34,7 +34,7 @@ var (
 	mockRawHost = Host{
 		ID:              mockHostID,
 		Type:            types.HostTypeNormal,
-		Hostname:        "hostname",
+		Hostname:        "foo",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -55,7 +55,7 @@ var (
 	mockRawSeedHost = Host{
 		ID:              mockSeedHostID,
 		Type:            types.HostTypeSuperSeed,
-		Hostname:        "hostname_seed",
+		Hostname:        "bar",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -126,10 +126,10 @@ var (
 		Platform:   "darwin",
 	}
 
-	mockHostID       = idgen.HostIDV2("127.0.0.1", "hostname")
-	mockSeedHostID   = idgen.HostIDV2("127.0.0.1", "hostname_seed")
-	mockHostLocation = "location"
-	mockHostIDC      = "idc"
+	mockHostID       = idgen.HostIDV2("127.0.0.1", "foo")
+	mockSeedHostID   = idgen.HostIDV2("127.0.0.1", "bar")
+	mockHostLocation = "baz"
+	mockHostIDC      = "bas"
 )
 
 func TestHost_NewHost(t *testing.T) {

--- a/scheduler/scheduling/evaluator/evaluator_base_test.go
+++ b/scheduler/scheduling/evaluator/evaluator_base_test.go
@@ -36,7 +36,7 @@ var (
 	mockRawHost = resource.Host{
 		ID:              mockHostID,
 		Type:            types.HostTypeNormal,
-		Hostname:        "hostname",
+		Hostname:        "foo",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -57,7 +57,7 @@ var (
 	mockRawSeedHost = resource.Host{
 		ID:              mockSeedHostID,
 		Type:            types.HostTypeSuperSeed,
-		Hostname:        "hostname_seed",
+		Hostname:        "bar",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -137,10 +137,10 @@ var (
 	mockTaskFilters                 = []string{"bar"}
 	mockTaskHeader                  = map[string]string{"content-length": "100"}
 	mockTaskPieceLength       int32 = 2048
-	mockHostID                      = idgen.HostIDV2("127.0.0.1", "hostname")
-	mockSeedHostID                  = idgen.HostIDV2("127.0.0.1", "hostname_seed")
-	mockHostLocation                = "location"
-	mockHostIDC                     = "idc"
+	mockHostID                      = idgen.HostIDV2("127.0.0.1", "foo")
+	mockSeedHostID                  = idgen.HostIDV2("127.0.0.1", "bar")
+	mockHostLocation                = "bas"
+	mockHostIDC                     = "baz"
 	mockPeerID                      = idgen.PeerIDV2()
 )
 

--- a/scheduler/scheduling/scheduling_test.go
+++ b/scheduler/scheduling/scheduling_test.go
@@ -53,7 +53,7 @@ import (
 )
 
 var (
-	mockPluginDir       = "plugin_dir"
+	mockPluginDir       = "bas"
 	mockSchedulerConfig = &config.SchedulerConfig{
 		RetryLimit:             2,
 		RetryBackToSourceLimit: 1,
@@ -65,7 +65,7 @@ var (
 	mockRawHost = resource.Host{
 		ID:              mockHostID,
 		Type:            pkgtypes.HostTypeNormal,
-		Hostname:        "hostname",
+		Hostname:        "foo",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -86,7 +86,7 @@ var (
 	mockRawSeedHost = resource.Host{
 		ID:              mockSeedHostID,
 		Type:            pkgtypes.HostTypeSuperSeed,
-		Hostname:        "hostname_seed",
+		Hostname:        "bar",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -166,10 +166,10 @@ var (
 	mockTaskFilters                 = []string{"bar"}
 	mockTaskHeader                  = map[string]string{"content-length": "100"}
 	mockTaskPieceLength       int32 = 2048
-	mockHostID                      = idgen.HostIDV2("127.0.0.1", "hostname")
-	mockSeedHostID                  = idgen.HostIDV2("127.0.0.1", "hostname_seed")
-	mockHostLocation                = "location"
-	mockHostIDC                     = "idc"
+	mockHostID                      = idgen.HostIDV2("127.0.0.1", "foo")
+	mockSeedHostID                  = idgen.HostIDV2("127.0.0.1", "bar")
+	mockHostLocation                = "baz"
+	mockHostIDC                     = "bas"
 	mockPeerID                      = idgen.PeerIDV2()
 	mockSeedPeerID                  = idgen.PeerIDV2()
 	mockPiece                       = resource.Piece{

--- a/scheduler/service/service_v1_test.go
+++ b/scheduler/service/service_v1_test.go
@@ -72,7 +72,7 @@ var (
 	mockRawHost = resource.Host{
 		ID:              mockHostID,
 		Type:            pkgtypes.HostTypeNormal,
-		Hostname:        "hostname",
+		Hostname:        "foo",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -93,7 +93,7 @@ var (
 	mockRawSeedHost = resource.Host{
 		ID:              mockSeedHostID,
 		Type:            pkgtypes.HostTypeSuperSeed,
-		Hostname:        "hostname_seed",
+		Hostname:        "bar",
 		IP:              "127.0.0.1",
 		Port:            8003,
 		DownloadPort:    8001,
@@ -169,7 +169,7 @@ var (
 		Ip:       "127.0.0.1",
 		RpcPort:  8003,
 		DownPort: 8001,
-		Hostname: "hostname",
+		Hostname: "baz",
 		Location: mockHostLocation,
 		Idc:      mockHostIDC,
 	}
@@ -183,10 +183,10 @@ var (
 	mockTaskFilters                 = []string{"bar"}
 	mockTaskHeader                  = map[string]string{"content-length": "100"}
 	mockTaskPieceLength       int32 = 2048
-	mockHostID                      = idgen.HostIDV2("127.0.0.1", "hostname")
-	mockSeedHostID                  = idgen.HostIDV2("127.0.0.1", "hostname_seed")
-	mockHostLocation                = "location"
-	mockHostIDC                     = "idc"
+	mockHostID                      = idgen.HostIDV2("127.0.0.1", "foo")
+	mockSeedHostID                  = idgen.HostIDV2("127.0.0.1", "bar")
+	mockHostLocation                = "bas"
+	mockHostIDC                     = "baz"
 	mockPeerID                      = idgen.PeerIDV2()
 	mockSeedPeerID                  = idgen.PeerIDV2()
 	mockPeerRange                   = nethttp.Range{
@@ -2126,7 +2126,7 @@ func TestServiceV1_AnnounceHost(t *testing.T) {
 			req: &schedulerv1.AnnounceHostRequest{
 				Id:              mockHostID,
 				Type:            pkgtypes.HostTypeNormal.Name(),
-				Hostname:        "hostname",
+				Hostname:        "foo",
 				Ip:              "127.0.0.1",
 				Port:            8003,
 				DownloadPort:    8001,
@@ -2224,7 +2224,7 @@ func TestServiceV1_AnnounceHost(t *testing.T) {
 			req: &schedulerv1.AnnounceHostRequest{
 				Id:              mockHostID,
 				Type:            pkgtypes.HostTypeNormal.Name(),
-				Hostname:        "hostname",
+				Hostname:        "foo",
 				Ip:              "127.0.0.1",
 				Port:            8003,
 				DownloadPort:    8001,

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -625,7 +625,7 @@ func TestServiceV2_AnnounceHost(t *testing.T) {
 				Host: &commonv2.Host{
 					Id:              mockHostID,
 					Type:            uint32(pkgtypes.HostTypeNormal),
-					Hostname:        "hostname",
+					Hostname:        "foo",
 					Ip:              "127.0.0.1",
 					Port:            8003,
 					DownloadPort:    8001,
@@ -725,7 +725,7 @@ func TestServiceV2_AnnounceHost(t *testing.T) {
 				Host: &commonv2.Host{
 					Id:              mockHostID,
 					Type:            uint32(pkgtypes.HostTypeNormal),
-					Hostname:        "hostname",
+					Hostname:        "foo",
 					Ip:              "127.0.0.1",
 					Port:            8003,
 					DownloadPort:    8001,

--- a/scheduler/storage/storage_test.go
+++ b/scheduler/storage/storage_test.go
@@ -119,7 +119,7 @@ var (
 	mockSeedHost = Host{
 		ID:                    "3",
 		Type:                  "super",
-		Hostname:              "seed_host",
+		Hostname:              "foo",
 		IP:                    "127.0.0.1",
 		Port:                  8080,
 		DownloadPort:          8081,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add ParseProbedCountKeyInScheduler and Snapshot tests.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/Dragonfly2/pull/2438
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
