### PR TITLE
test: improve hash file encode test case in digest test

### DIFF
--- a/pkg/digest/digest_test.go
+++ b/pkg/digest/digest_test.go
@@ -38,13 +38,20 @@ func TestDigest_HashFile(t *testing.T) {
 	assert.Nil(t, err)
 	defer f.Close()
 
+	hashAlgorithmResults := [][2]string{
+		{AlgorithmSHA1, "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"},
+		{AlgorithmSHA256, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"},
+		{AlgorithmSHA512, "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043"},
+		{AlgorithmMD5, "5d41402abc4b2a76b9719d911017c592"},
+	}
 	if _, err := f.Write([]byte("hello")); err != nil {
 		t.Fatal(err)
 	}
-	encoded, err := HashFile(path, AlgorithmMD5)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "5d41402abc4b2a76b9719d911017c592", encoded)
+	for i := 0; i < len(hashAlgorithmResults); i++ {
+		encoded, err := HashFile(path, hashAlgorithmResults[i][0])
+		assert.NoError(t, err)
+		assert.Equal(t, hashAlgorithmResults[i][1], encoded)
+	}
 }
 
 func TestDigest_Parse(t *testing.T) {


### PR DESCRIPTION
## Description

Improve the digest test by adding various hash file encode pattern.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
