### PR TITLE
fix: also add ca to RootCAs

### DIFF
--- a/client/daemon/daemon.go
+++ b/client/daemon/daemon.go
@@ -504,6 +504,7 @@ func (*clientDaemon) prepareTCPListener(opt config.ListenOption, withTLS bool) (
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM([]byte(opt.Security.CACert))
 		tlsConfig.ClientCAs = caCertPool
+		tlsConfig.RootCAs = caCertPool
 		if opt.Security.TLSVerify {
 			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 		}

--- a/client/daemon/peer/piece_downloader.go
+++ b/client/daemon/peer/piece_downloader.go
@@ -153,7 +153,10 @@ func NewPieceDownloader(timeout time.Duration, caCertPool *x509.CertPool) PieceD
 
 	if caCertPool != nil {
 		pd.scheme = "https"
-		defaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{ClientCAs: caCertPool}
+		defaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+			ClientCAs: caCertPool,
+			RootCAs: caCertPool,
+		}
 	}
 
 	return pd

--- a/client/daemon/peer/piece_downloader.go
+++ b/client/daemon/peer/piece_downloader.go
@@ -155,7 +155,7 @@ func NewPieceDownloader(timeout time.Duration, caCertPool *x509.CertPool) PieceD
 		pd.scheme = "https"
 		defaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
 			ClientCAs: caCertPool,
-			RootCAs: caCertPool,
+			RootCAs:   caCertPool,
 		}
 	}
 

--- a/pkg/rpc/credential.go
+++ b/pkg/rpc/credential.go
@@ -64,7 +64,7 @@ func NewServerCredentialsByCertify(tlsPolicy string, tlsVerify bool, pemClientCA
 			return certifyClient.GetCertificate(hello)
 		},
 		ClientCAs: certPool,
-		RootCAs: certPool,
+		RootCAs:   certPool,
 	}
 
 	if tlsVerify {

--- a/pkg/rpc/credential.go
+++ b/pkg/rpc/credential.go
@@ -64,6 +64,7 @@ func NewServerCredentialsByCertify(tlsPolicy string, tlsVerify bool, pemClientCA
 			return certifyClient.GetCertificate(hello)
 		},
 		ClientCAs: certPool,
+		RootCAs: certPool,
 	}
 
 	if tlsVerify {


### PR DESCRIPTION
## Description

add caCert to `RootCAs` in  tlsconfig of Go,not only ClientCAs.

## Related Issue

https://github.com/dragonflyoss/Dragonfly2/issues/2506

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
