### PR TITLE
feat: remove ProbedAt function in network topology

### DIFF
--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -55,9 +55,6 @@ const (
 
 	// ProbedCountNamespace prefix of probed count namespace cache key.
 	ProbedCountNamespace = "probed-count"
-
-	// ProbedAtNamespace prefix of last probed time namespace cache key.
-	ProbedAtNamespace = "probed-at"
 )
 
 // NewRedis returns a new redis client.
@@ -166,9 +163,4 @@ func ParseProbedCountKeyInScheduler(key string) (string, string, string, error) 
 // MakeProbedCountKeyInScheduler make probed count key in scheduler.
 func MakeProbedCountKeyInScheduler(hostID string) string {
 	return MakeKeyInScheduler(ProbedCountNamespace, hostID)
-}
-
-// MakeProbedAtKeyInScheduler make last probed time in scheduler.
-func MakeProbedAtKeyInScheduler(hostID string) string {
-	return MakeKeyInScheduler(ProbedAtNamespace, hostID)
 }

--- a/pkg/redis/redis_test.go
+++ b/pkg/redis/redis_test.go
@@ -669,33 +669,3 @@ func Test_ParseProbedCountKeyInScheduler(t *testing.T) {
 		})
 	}
 }
-
-func Test_MakeProbedAtKeyInScheduler(t *testing.T) {
-	tests := []struct {
-		name   string
-		hostID string
-		expect func(t *testing.T, s string)
-	}{
-		{
-			name:   "make probed at key in scheduler",
-			hostID: "bas",
-			expect: func(t *testing.T, s string) {
-				assert := assert.New(t)
-				assert.Equal("scheduler:probed-at:bas", s)
-			},
-		},
-		{
-			name:   "host id is empty",
-			hostID: "",
-			expect: func(t *testing.T, s string) {
-				assert := assert.New(t)
-				assert.Equal("scheduler:probed-at:", s)
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.expect(t, MakeProbedAtKeyInScheduler(tc.hostID))
-		})
-	}
-}

--- a/scheduler/networktopology/mocks/network_topology_mock.go
+++ b/scheduler/networktopology/mocks/network_topology_mock.go
@@ -6,7 +6,6 @@ package mocks
 
 import (
 	reflect "reflect"
-	time "time"
 
 	networktopology "d7y.io/dragonfly/v2/scheduler/networktopology"
 	resource "d7y.io/dragonfly/v2/scheduler/resource"
@@ -77,21 +76,6 @@ func (m *MockNetworkTopology) Has(arg0, arg1 string) bool {
 func (mr *MockNetworkTopologyMockRecorder) Has(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Has", reflect.TypeOf((*MockNetworkTopology)(nil).Has), arg0, arg1)
-}
-
-// ProbedAt mocks base method.
-func (m *MockNetworkTopology) ProbedAt(arg0 string) (time.Time, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProbedAt", arg0)
-	ret0, _ := ret[0].(time.Time)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ProbedAt indicates an expected call of ProbedAt.
-func (mr *MockNetworkTopologyMockRecorder) ProbedAt(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProbedAt", reflect.TypeOf((*MockNetworkTopology)(nil).ProbedAt), arg0)
 }
 
 // ProbedCount mocks base method.

--- a/scheduler/networktopology/network_topology.go
+++ b/scheduler/networktopology/network_topology.go
@@ -74,9 +74,6 @@ type NetworkTopology interface {
 	// ProbedCount is the number of times the host has been probed.
 	ProbedCount(string) (uint64, error)
 
-	// ProbedAt is the time when the host was last probed.
-	ProbedAt(string) (time.Time, error)
-
 	// Snapshot writes the current network topology to the storage.
 	Snapshot() error
 }
@@ -218,7 +215,7 @@ func (nt *networkTopology) DeleteHost(hostID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
-	deleteKeys := []string{pkgredis.MakeProbedAtKeyInScheduler(hostID), pkgredis.MakeProbedCountKeyInScheduler(hostID)}
+	deleteKeys := []string{pkgredis.MakeProbedCountKeyInScheduler(hostID)}
 	srcNetworkTopologyKeys, _, err := nt.rdb.Scan(ctx, 0, pkgredis.MakeNetworkTopologyKeyInScheduler(hostID, "*"), math.MaxInt64).Result()
 	if err != nil {
 		return err
@@ -261,14 +258,6 @@ func (nt *networkTopology) ProbedCount(hostID string) (uint64, error) {
 	defer cancel()
 
 	return nt.rdb.Get(ctx, pkgredis.MakeProbedCountKeyInScheduler(hostID)).Uint64()
-}
-
-// ProbedAt is the time when the host was last probed.
-func (nt *networkTopology) ProbedAt(hostID string) (time.Time, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
-	defer cancel()
-
-	return nt.rdb.Get(ctx, pkgredis.MakeProbedAtKeyInScheduler(hostID)).Time()
 }
 
 // Snapshot writes the current network topology to the storage.

--- a/scheduler/networktopology/probes.go
+++ b/scheduler/networktopology/probes.go
@@ -178,10 +178,6 @@ func (p *probes) Enqueue(probe *Probe) error {
 		return err
 	}
 
-	if err := p.rdb.Set(ctx, pkgredis.MakeProbedAtKeyInScheduler(p.destHostID), probe.CreatedAt.Format(time.RFC3339Nano), 0).Err(); err != nil {
-		return err
-	}
-
 	if err := p.rdb.Incr(ctx, pkgredis.MakeProbedCountKeyInScheduler(p.destHostID)).Err(); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Remove ProbedAt function in network topology.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
