### PR TITLE
Fix issues in the objectstorage based on JuiceFS use cases.

### DIFF
--- a/client/daemon/objectstorage/objectstorage.go
+++ b/client/daemon/objectstorage/objectstorage.go
@@ -188,7 +188,7 @@ func (o *objectStorage) initRouter(cfg *config.DaemonOption, logDir string) *gin
 
 	// Buckets
 	b := r.Group(RouterGroupBuckets)
-	b.POST("/:id", o.createBucket)
+	b.POST(":id", o.createBucket)
 	b.GET(":id/metadatas", o.getObjectMetadatas)
 	b.HEAD(":id/objects/*object_key", o.headObject)
 	b.GET(":id/objects/*object_key", o.getObject)

--- a/client/daemon/objectstorage/objectstorage.go
+++ b/client/daemon/objectstorage/objectstorage.go
@@ -545,7 +545,7 @@ func (o *objectStorage) copyObject(ctx *gin.Context) {
 
 	var (
 		bucketName  = params.ID
-		destination = params.ObjectKey
+		destination = strings.TrimPrefix(params.ObjectKey, string(os.PathSeparator))
 		source      = form.SourceObjectKey
 	)
 

--- a/client/dfstore/dfstore.go
+++ b/client/dfstore/dfstore.go
@@ -637,7 +637,7 @@ func (dfs *dfstore) CreateBucketRequestWithContext(ctx context.Context, input *C
 
 	u.RawQuery = query.Encode()
 
-	return http.NewRequestWithContext(ctx, http.MethodPut, u.String(), nil)
+	return http.NewRequestWithContext(ctx, http.MethodPost, u.String(), nil)
 }
 
 // DeleteObjectInput is used to construct request of deleting object.

--- a/client/dfstore/dfstore.go
+++ b/client/dfstore/dfstore.go
@@ -64,7 +64,7 @@ type Dfstore interface {
 	GetObjectMetadatasRequestWithContext(ctx context.Context, input *GetObjectMetadatasInput) (*http.Request, error)
 
 	// GetObjectMetadatasWithContext returns list of object metadatas.
-	GetObjectMetadatasWithContext(ctx context.Context, input *GetObjectMetadatasInput) ([]*pkgobjectstorage.ObjectMetadata, error)
+	GetObjectMetadatasWithContext(ctx context.Context, input *GetObjectMetadatasInput) (*pkgobjectstorage.ObjectMetadatas, error)
 
 	// PutObjectRequestWithContext returns *http.Request of putting object.
 	PutObjectRequestWithContext(ctx context.Context, input *PutObjectInput) (*http.Request, error)
@@ -232,6 +232,10 @@ func (i *GetObjectMetadatasInput) Validate() error {
 		return errors.New("invalid BucketName")
 	}
 
+	if i.Limit < 0 || i.Limit > pkgobjectstorage.DefaultGetObjectMetadatasLimit {
+		return errors.New("invalid limit")
+	}
+
 	return nil
 }
 
@@ -276,7 +280,7 @@ func (dfs *dfstore) GetObjectMetadatasRequestWithContext(ctx context.Context, in
 }
 
 // GetObjectMetadatasWithContext returns *http.Request of getting object metadatas.
-func (dfs *dfstore) GetObjectMetadatasWithContext(ctx context.Context, input *GetObjectMetadatasInput) ([]*pkgobjectstorage.ObjectMetadata, error) {
+func (dfs *dfstore) GetObjectMetadatasWithContext(ctx context.Context, input *GetObjectMetadatasInput) (*pkgobjectstorage.ObjectMetadatas, error) {
 	req, err := dfs.GetObjectMetadatasRequestWithContext(ctx, input)
 	if err != nil {
 		return nil, err
@@ -292,12 +296,12 @@ func (dfs *dfstore) GetObjectMetadatasWithContext(ctx context.Context, input *Ge
 		return nil, fmt.Errorf("bad response status %s", resp.Status)
 	}
 
-	var metadatas []*pkgobjectstorage.ObjectMetadata
+	var metadatas pkgobjectstorage.ObjectMetadatas
 	if err := json.NewDecoder(resp.Body).Decode(&metadatas); err != nil {
 		return nil, err
 	}
 
-	return metadatas, nil
+	return &metadatas, nil
 }
 
 // GetObjectInput is used to construct request of getting object.

--- a/client/dfstore/dfstore.go
+++ b/client/dfstore/dfstore.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-http-utils/headers"
@@ -133,7 +134,6 @@ type GetObjectMetadataInput struct {
 func (i *GetObjectMetadataInput) Validate() error {
 	if i.BucketName == "" {
 		return errors.New("invalid BucketName")
-
 	}
 
 	if i.ObjectKey == "" {
@@ -155,6 +155,11 @@ func (dfs *dfstore) GetObjectMetadataRequestWithContext(ctx context.Context, inp
 	}
 
 	u.Path = filepath.Join("buckets", input.BucketName, "objects", input.ObjectKey)
+
+	if strings.HasSuffix(input.ObjectKey, "/") {
+		u.Path += "/"
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
 	if err != nil {
 		return nil, err
@@ -241,7 +246,7 @@ func (dfs *dfstore) GetObjectMetadatasRequestWithContext(ctx context.Context, in
 		return nil, err
 	}
 
-	u.Path = filepath.Join("buckets", input.BucketName, "objects")
+	u.Path = filepath.Join("buckets", input.BucketName, "metadatas")
 
 	query := u.Query()
 	if input.Prefix != "" {
@@ -316,7 +321,6 @@ type GetObjectInput struct {
 func (i *GetObjectInput) Validate() error {
 	if i.BucketName == "" {
 		return errors.New("invalid BucketName")
-
 	}
 
 	if i.ObjectKey == "" {
@@ -338,6 +342,10 @@ func (dfs *dfstore) GetObjectRequestWithContext(ctx context.Context, input *GetO
 	}
 
 	u.Path = filepath.Join("buckets", input.BucketName, "objects", input.ObjectKey)
+
+	if strings.HasSuffix(input.ObjectKey, "/") {
+		u.Path += "/"
+	}
 
 	query := u.Query()
 	if input.Filter != "" {
@@ -405,7 +413,6 @@ type PutObjectInput struct {
 func (i *PutObjectInput) Validate() error {
 	if i.BucketName == "" {
 		return errors.New("invalid BucketName")
-
 	}
 
 	if i.ObjectKey == "" {
@@ -468,6 +475,10 @@ func (dfs *dfstore) PutObjectRequestWithContext(ctx context.Context, input *PutO
 	}
 
 	u.Path = filepath.Join("buckets", input.BucketName, "objects", input.ObjectKey)
+
+	if strings.HasSuffix(input.ObjectKey, "/") {
+		u.Path += "/"
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), body)
 	if err != nil {
@@ -653,7 +664,6 @@ type DeleteObjectInput struct {
 func (i *DeleteObjectInput) Validate() error {
 	if i.BucketName == "" {
 		return errors.New("invalid BucketName")
-
 	}
 
 	if i.ObjectKey == "" {
@@ -675,6 +685,11 @@ func (dfs *dfstore) DeleteObjectRequestWithContext(ctx context.Context, input *D
 	}
 
 	u.Path = filepath.Join("buckets", input.BucketName, "objects", input.ObjectKey)
+
+	if strings.HasSuffix(input.ObjectKey, "/") {
+		u.Path += "/"
+	}
+
 	return http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), nil)
 }
 
@@ -711,7 +726,6 @@ type IsObjectExistInput struct {
 func (i *IsObjectExistInput) Validate() error {
 	if i.BucketName == "" {
 		return errors.New("invalid BucketName")
-
 	}
 
 	if i.ObjectKey == "" {
@@ -733,6 +747,11 @@ func (dfs *dfstore) IsObjectExistRequestWithContext(ctx context.Context, input *
 	}
 
 	u.Path = filepath.Join("buckets", input.BucketName, "objects", input.ObjectKey)
+
+	if strings.HasSuffix(input.ObjectKey, "/") {
+		u.Path += "/"
+	}
+
 	return http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
 }
 

--- a/pkg/objectstorage/objectstorage.go
+++ b/pkg/objectstorage/objectstorage.go
@@ -58,6 +58,13 @@ type ObjectMetadata struct {
 	StorageClass string
 }
 
+type ObjectMetadatas struct {
+	// CommonPrefixes are similar prefixes in object storage.
+	CommonPrefixes []string `json:"CommonPrefixes"`
+
+	Metadatas []*ObjectMetadata `json:"Metadatas"`
+}
+
 // BucketMetadata provides metadata of bucket.
 type BucketMetadata struct {
 	// Name is bucket name.
@@ -88,7 +95,7 @@ type ObjectStorage interface {
 	GetObjectMetadata(ctx context.Context, bucketName, objectKey string) (*ObjectMetadata, bool, error)
 
 	// GetObjectMetadatas returns the metadata of the objects.
-	GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker, delimiter string, limit int64) ([]*ObjectMetadata, error)
+	GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker, delimiter string, limit int64) (*ObjectMetadatas, error)
 
 	// GetOject returns data of object.
 	GetOject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error)

--- a/pkg/objectstorage/objectstorage.go
+++ b/pkg/objectstorage/objectstorage.go
@@ -20,8 +20,10 @@ package objectstorage
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 )
 
@@ -58,10 +60,12 @@ type ObjectMetadata struct {
 	StorageClass string
 }
 
+// ObjectMetadatas provides metadatas of object.
 type ObjectMetadatas struct {
 	// CommonPrefixes are similar prefixes in object storage.
 	CommonPrefixes []string `json:"CommonPrefixes"`
 
+	// Metadatas are metadata of objects.
 	Metadatas []*ObjectMetadata `json:"Metadatas"`
 }
 
@@ -135,6 +139,9 @@ type objectStorage struct {
 
 	// secretKey is access key secret.
 	s3ForcePathStyle bool
+
+	// httpClient is http client.
+	httpClient *http.Client
 }
 
 // Option is a functional option for configuring the objectStorage.
@@ -147,6 +154,13 @@ func WithS3ForcePathStyle(s3ForcePathStyle bool) Option {
 	}
 }
 
+// WithHTTPClient set the http client for objectStorage.
+func WithHTTPClient(client *http.Client) Option {
+	return func(o *objectStorage) {
+		o.httpClient = client
+	}
+}
+
 // New object storage interface.
 func New(name, region, endpoint, accessKey, secretKey string, options ...Option) (ObjectStorage, error) {
 	o := &objectStorage{
@@ -156,6 +170,20 @@ func New(name, region, endpoint, accessKey, secretKey string, options ...Option)
 		accessKey:        accessKey,
 		secretKey:        secretKey,
 		s3ForcePathStyle: true,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy:                 http.ProxyFromEnvironment,
+				TLSHandshakeTimeout:   time.Second * 20,
+				ResponseHeaderTimeout: time.Second * 30,
+				IdleConnTimeout:       time.Second * 300,
+				MaxIdleConnsPerHost:   500,
+				ReadBufferSize:        32 << 10,
+				WriteBufferSize:       32 << 10,
+				DisableCompression:    true,
+				TLSClientConfig:       &tls.Config{},
+			},
+			Timeout: time.Hour,
+		},
 	}
 
 	for _, opt := range options {
@@ -164,11 +192,11 @@ func New(name, region, endpoint, accessKey, secretKey string, options ...Option)
 
 	switch o.name {
 	case ServiceNameS3:
-		return newS3(o.region, o.endpoint, o.accessKey, o.secretKey, o.s3ForcePathStyle)
+		return newS3(o.region, o.endpoint, o.accessKey, o.secretKey, o.s3ForcePathStyle, o.httpClient)
 	case ServiceNameOSS:
-		return newOSS(o.region, o.endpoint, o.accessKey, o.secretKey)
+		return newOSS(o.region, o.endpoint, o.accessKey, o.secretKey, o.httpClient)
 	case ServiceNameOBS:
-		return newOBS(o.region, o.endpoint, o.accessKey, o.secretKey)
+		return newOBS(o.region, o.endpoint, o.accessKey, o.secretKey, o.httpClient)
 	}
 
 	return nil, fmt.Errorf("unknow service name %s", name)

--- a/pkg/objectstorage/obs.go
+++ b/pkg/objectstorage/obs.go
@@ -120,7 +120,7 @@ func (o *obs) GetObjectMetadata(ctx context.Context, bucketName, objectKey strin
 }
 
 // GetObjectMetadatas returns the metadatas of the objects.
-func (o *obs) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker, delimiter string, limit int64) ([]*ObjectMetadata, error) {
+func (o *obs) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker, delimiter string, limit int64) (*ObjectMetadatas, error) {
 	if limit == 0 {
 		limit = DefaultGetObjectMetadatasLimit
 	}
@@ -148,7 +148,10 @@ func (o *obs) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker
 		})
 	}
 
-	return metadatas, nil
+	return &ObjectMetadatas{
+		Metadatas:      metadatas,
+		CommonPrefixes: resp.CommonPrefixes,
+	}, nil
 }
 
 // GetOject returns data of object.

--- a/pkg/objectstorage/obs.go
+++ b/pkg/objectstorage/obs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -32,8 +33,8 @@ type obs struct {
 }
 
 // New oss instance.
-func newOBS(region, endpoint, accessKey, secretKey string) (ObjectStorage, error) {
-	client, err := huaweiobs.New(accessKey, secretKey, endpoint)
+func newOBS(region, endpoint, accessKey, secretKey string, httpClient *http.Client) (ObjectStorage, error) {
+	client, err := huaweiobs.New(accessKey, secretKey, endpoint, huaweiobs.WithHttpClient(httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("new obs client failed: %s", err)
 	}

--- a/pkg/objectstorage/oss.go
+++ b/pkg/objectstorage/oss.go
@@ -96,7 +96,7 @@ func (o *oss) GetObjectMetadata(ctx context.Context, bucketName, objectKey strin
 
 	header, err := bucket.GetObjectDetailedMeta(objectKey)
 	if err != nil {
-		var serr *aliyunoss.ServiceError
+		var serr aliyunoss.ServiceError
 		if errors.As(err, &serr) && serr.StatusCode == http.StatusNotFound {
 			return nil, false, nil
 		}

--- a/pkg/objectstorage/oss.go
+++ b/pkg/objectstorage/oss.go
@@ -35,8 +35,8 @@ type oss struct {
 }
 
 // New oss instance.
-func newOSS(region, endpoint, accessKey, secretKey string) (ObjectStorage, error) {
-	client, err := aliyunoss.New(endpoint, accessKey, secretKey, aliyunoss.Region(region))
+func newOSS(region, endpoint, accessKey, secretKey string, httpClient *http.Client) (ObjectStorage, error) {
+	client, err := aliyunoss.New(endpoint, accessKey, secretKey, aliyunoss.Region(region), aliyunoss.HTTPClient(httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("new oss client failed: %s", err)
 	}

--- a/pkg/objectstorage/oss.go
+++ b/pkg/objectstorage/oss.go
@@ -166,7 +166,9 @@ func (o *oss) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker
 				StorageClass:     o.getStorageClass(""),
 			})
 		}
-		sort.Slice(metadatas, func(i, j int) bool { return metadatas[i].Key < metadatas[j].Key })
+		sort.Slice(metadatas, func(i, j int) bool {
+			return metadatas[i].Key < metadatas[j].Key
+		})
 	}
 	return metadatas, nil
 }

--- a/pkg/objectstorage/s3.go
+++ b/pkg/objectstorage/s3.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"path"
+	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -138,6 +140,7 @@ func (s *s3) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker,
 	}
 
 	metadatas := make([]*ObjectMetadata, 0, len(resp.Contents))
+
 	for _, content := range resp.Contents {
 		metadatas = append(metadatas, &ObjectMetadata{
 			Key:              aws.StringValue(content.Key),
@@ -145,6 +148,25 @@ func (s *s3) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker,
 			ETag:             aws.StringValue(content.ETag),
 			LastModifiedTime: aws.TimeValue(content.LastModified),
 			StorageClass:     aws.StringValue(s.getStorageClass(content.StorageClass)),
+		})
+	}
+
+	if delimiter != "" {
+		for _, p := range resp.CommonPrefixes {
+			prefix, err := url.QueryUnescape(*p.Prefix)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode commonPrefixes %s, error: %s", *p.Prefix, err)
+			}
+			metadatas = append(metadatas, &ObjectMetadata{
+				Key:              prefix,
+				ContentLength:    0,
+				ETag:             "",
+				LastModifiedTime: time.Unix(0, 0),
+				StorageClass:     aws.StringValue(s.getStorageClass(nil)),
+			})
+		}
+		sort.Slice(metadatas, func(i, j int) bool {
+			return metadatas[i].Key < metadatas[j].Key
 		})
 	}
 
@@ -193,7 +215,6 @@ func (s *s3) DeleteObject(ctx context.Context, bucketName, objectKey string) err
 func (s *s3) IsObjectExist(ctx context.Context, bucketName, objectKey string) (bool, error) {
 	_, isExist, err := s.GetObjectMetadata(ctx, bucketName, objectKey)
 	if err != nil {
-
 		return false, err
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

"Fixing issues in the object storage based on JuiceFS use cases. Mainly includes:

1. Route path of createbucket.
2. Unable to properly pass objectkey when calling copyobject.
3. Oss GetObjectMeta return not found error.
4. getObjectMetadatas does not include directories.

## Related Issue
#2176 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To provide support for JuiceFS objectStorage implementation.
## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
