### PR TITLE
fix: Vertex.DeleteInEdges and Vertex.DeleteOutEdges functions are not thread safe

### DIFF
--- a/pkg/graph/dag/dag_test.go
+++ b/pkg/graph/dag/dag_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewDAG(t *testing.T) {
+func TestDAG_New(t *testing.T) {
 	d := NewDAG[string]()
 	assert := assert.New(t)
 	assert.Equal(reflect.TypeOf(d).Elem().Name(), "dag[string]")
 }
 
-func TestDAGAddVertex(t *testing.T) {
+func TestDAG_AddVertex(t *testing.T) {
 	tests := []struct {
 		name   string
 		id     string
@@ -68,7 +68,7 @@ func TestDAGAddVertex(t *testing.T) {
 	}
 }
 
-func TestDAGDeleteVertex(t *testing.T) {
+func TestDAG_DeleteVertex(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -126,7 +126,7 @@ func TestDAGDeleteVertex(t *testing.T) {
 	}
 }
 
-func TestDAGGetVertex(t *testing.T) {
+func TestDAG_GetVertex(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -165,7 +165,7 @@ func TestDAGGetVertex(t *testing.T) {
 	}
 }
 
-func TestDAGVertexVertexCount(t *testing.T) {
+func TestDAG_VertexCount(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -202,7 +202,7 @@ func TestDAGVertexVertexCount(t *testing.T) {
 	}
 }
 
-func TestDAGGetVertices(t *testing.T) {
+func TestDAG_GetVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -243,7 +243,7 @@ func TestDAGGetVertices(t *testing.T) {
 	}
 }
 
-func TestDAGGetRandomVertices(t *testing.T) {
+func TestDAG_GetRandomVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -299,7 +299,7 @@ func TestDAGGetRandomVertices(t *testing.T) {
 	}
 }
 
-func TestDAGGetVertexKeys(t *testing.T) {
+func TestDAG_GetVertexKeys(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -331,7 +331,7 @@ func TestDAGGetVertexKeys(t *testing.T) {
 	}
 }
 
-func TestDAGAddEdge(t *testing.T) {
+func TestDAG_AddEdge(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -486,7 +486,88 @@ func TestDAGAddEdge(t *testing.T) {
 	}
 }
 
-func TestDAGCanAddEdge(t *testing.T) {
+func TestDAG_DeleteEdge(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect func(t *testing.T, d DAG[string])
+	}{
+		{
+			name: "delete edge",
+			expect: func(t *testing.T, d DAG[string]) {
+				assert := assert.New(t)
+				var (
+					mockVertexEID = "bae"
+					mockVertexFID = "baf"
+				)
+
+				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddVertex(mockVertexFID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.DeleteEdge(mockVertexFID, mockVertexEID); err != nil {
+					assert.NoError(err)
+				}
+
+				vf, err := d.GetVertex(mockVertexFID)
+				assert.NoError(err)
+				assert.Equal(vf.Parents.Len(), uint(1))
+				ve, err := d.GetVertex(mockVertexEID)
+				assert.NoError(err)
+				assert.Equal(ve.Children.Len(), uint(1))
+
+				if err := d.DeleteEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.NoError(err)
+				}
+
+				vf, err = d.GetVertex(mockVertexFID)
+				assert.NoError(err)
+				assert.Equal(vf.Parents.Len(), uint(0))
+				ve, err = d.GetVertex(mockVertexEID)
+				assert.NoError(err)
+				assert.Equal(ve.Children.Len(), uint(0))
+			},
+		},
+		{
+			name: "vertex not found",
+			expect: func(t *testing.T, d DAG[string]) {
+				assert := assert.New(t)
+				var (
+					mockVertexEID = "bae"
+					mockVertexFID = "baf"
+				)
+
+				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.EqualError(err, ErrVertexNotFound.Error())
+				}
+
+				if err := d.AddEdge(mockVertexFID, mockVertexEID); err != nil {
+					assert.EqualError(err, ErrVertexNotFound.Error())
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDAG[string]()
+			tc.expect(t, d)
+		})
+	}
+}
+
+func TestDAG_CanAddEdge(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -636,13 +717,13 @@ func TestDAGCanAddEdge(t *testing.T) {
 	}
 }
 
-func TestDAGDeleteEdge(t *testing.T) {
+func TestDAG_DeleteVertexInEdges(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
 	}{
 		{
-			name: "delete edge",
+			name: "delete inedges",
 			expect: func(t *testing.T, d DAG[string]) {
 				assert := assert.New(t)
 				var (
@@ -662,47 +743,25 @@ func TestDAGDeleteEdge(t *testing.T) {
 					assert.NoError(err)
 				}
 
-				if err := d.DeleteEdge(mockVertexFID, mockVertexEID); err != nil {
+				if err := d.DeleteVertexInEdges(mockVertexFID); err != nil {
 					assert.NoError(err)
 				}
 
 				vf, err := d.GetVertex(mockVertexFID)
 				assert.NoError(err)
-				assert.Equal(vf.Parents.Len(), uint(1))
+				assert.Equal(vf.Children.Len(), uint(0))
 				ve, err := d.GetVertex(mockVertexEID)
 				assert.NoError(err)
-				assert.Equal(ve.Children.Len(), uint(1))
-
-				if err := d.DeleteEdge(mockVertexEID, mockVertexFID); err != nil {
-					assert.NoError(err)
-				}
-
-				vf, err = d.GetVertex(mockVertexFID)
-				assert.NoError(err)
-				assert.Equal(vf.Parents.Len(), uint(0))
-				ve, err = d.GetVertex(mockVertexEID)
-				assert.NoError(err)
-				assert.Equal(ve.Children.Len(), uint(0))
+				assert.Equal(ve.Parents.Len(), uint(0))
 			},
 		},
 		{
 			name: "vertex not found",
 			expect: func(t *testing.T, d DAG[string]) {
 				assert := assert.New(t)
-				var (
-					mockVertexEID = "bae"
-					mockVertexFID = "baf"
-				)
+				mockVertexEID := "bae"
 
-				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
-					assert.NoError(err)
-				}
-
-				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
-					assert.EqualError(err, ErrVertexNotFound.Error())
-				}
-
-				if err := d.AddEdge(mockVertexFID, mockVertexEID); err != nil {
+				if err := d.DeleteVertexInEdges(mockVertexEID); err != nil {
 					assert.EqualError(err, ErrVertexNotFound.Error())
 				}
 			},
@@ -717,7 +776,66 @@ func TestDAGDeleteEdge(t *testing.T) {
 	}
 }
 
-func TestDAGSourceVertices(t *testing.T) {
+func TestDAG_DeleteVertexOutEdges(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect func(t *testing.T, d DAG[string])
+	}{
+		{
+			name: "delete outedges",
+			expect: func(t *testing.T, d DAG[string]) {
+				assert := assert.New(t)
+				var (
+					mockVertexEID = "bae"
+					mockVertexFID = "baf"
+				)
+
+				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddVertex(mockVertexFID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.DeleteVertexOutEdges(mockVertexEID); err != nil {
+					assert.NoError(err)
+				}
+
+				vf, err := d.GetVertex(mockVertexFID)
+				assert.NoError(err)
+				assert.Equal(vf.Children.Len(), uint(0))
+				ve, err := d.GetVertex(mockVertexEID)
+				assert.NoError(err)
+				assert.Equal(ve.Parents.Len(), uint(0))
+			},
+		},
+		{
+			name: "vertex not found",
+			expect: func(t *testing.T, d DAG[string]) {
+				assert := assert.New(t)
+				mockVertexEID := "bae"
+
+				if err := d.DeleteVertexOutEdges(mockVertexEID); err != nil {
+					assert.EqualError(err, ErrVertexNotFound.Error())
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDAG[string]()
+			tc.expect(t, d)
+		})
+	}
+}
+
+func TestDAG_SourceVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -764,7 +882,7 @@ func TestDAGSourceVertices(t *testing.T) {
 	}
 }
 
-func TestDAGSinkVertices(t *testing.T) {
+func TestDAG_SinkVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DAG[string])
@@ -811,7 +929,7 @@ func TestDAGSinkVertices(t *testing.T) {
 	}
 }
 
-func BenchmarkDAGAddVertex(b *testing.B) {
+func BenchmarkDAG_AddVertex(b *testing.B) {
 	var ids []string
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {
@@ -826,7 +944,7 @@ func BenchmarkDAGAddVertex(b *testing.B) {
 	}
 }
 
-func BenchmarkDAGDeleteVertex(b *testing.B) {
+func BenchmarkDAG_DeleteVertex(b *testing.B) {
 	var ids []string
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {
@@ -844,7 +962,7 @@ func BenchmarkDAGDeleteVertex(b *testing.B) {
 	}
 }
 
-func BenchmarkDAGGetRandomKeys(b *testing.B) {
+func BenchmarkDAG_GetRandomKeys(b *testing.B) {
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {
 		id := fmt.Sprint(n)
@@ -862,7 +980,7 @@ func BenchmarkDAGGetRandomKeys(b *testing.B) {
 	}
 }
 
-func BenchmarkDAGDeleteVertexWithMultiEdges(b *testing.B) {
+func BenchmarkDAG_DeleteVertexWithMultiEdges(b *testing.B) {
 	var ids []string
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {
@@ -893,7 +1011,7 @@ func BenchmarkDAGDeleteVertexWithMultiEdges(b *testing.B) {
 	}
 }
 
-func BenchmarkDAGAddEdge(b *testing.B) {
+func BenchmarkDAG_AddEdge(b *testing.B) {
 	var ids []string
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {
@@ -917,7 +1035,7 @@ func BenchmarkDAGAddEdge(b *testing.B) {
 	}
 }
 
-func BenchmarkDAGAddEdgeWithMultiEdges(b *testing.B) {
+func BenchmarkDAG_AddEdgeWithMultiEdges(b *testing.B) {
 	var ids []string
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {
@@ -954,7 +1072,7 @@ func BenchmarkDAGAddEdgeWithMultiEdges(b *testing.B) {
 	}
 }
 
-func BenchmarkDAGDeleteEdge(b *testing.B) {
+func BenchmarkDAG_DeleteEdge(b *testing.B) {
 	var ids []string
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {

--- a/pkg/graph/dag/mocks/dag_mock.go
+++ b/pkg/graph/dag/mocks/dag_mock.go
@@ -102,6 +102,34 @@ func (mr *MockDAGMockRecorder[T]) DeleteVertex(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertex", reflect.TypeOf((*MockDAG[T])(nil).DeleteVertex), id)
 }
 
+// DeleteVertexInEdges mocks base method.
+func (m *MockDAG[T]) DeleteVertexInEdges(id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVertexInEdges", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVertexInEdges indicates an expected call of DeleteVertexInEdges.
+func (mr *MockDAGMockRecorder[T]) DeleteVertexInEdges(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexInEdges", reflect.TypeOf((*MockDAG[T])(nil).DeleteVertexInEdges), id)
+}
+
+// DeleteVertexOutEdges mocks base method.
+func (m *MockDAG[T]) DeleteVertexOutEdges(id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVertexOutEdges", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVertexOutEdges indicates an expected call of DeleteVertexOutEdges.
+func (mr *MockDAGMockRecorder[T]) DeleteVertexOutEdges(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexOutEdges", reflect.TypeOf((*MockDAG[T])(nil).DeleteVertexOutEdges), id)
+}
+
 // GetRandomVertices mocks base method.
 func (m *MockDAG[T]) GetRandomVertices(n uint) []*dag.Vertex[T] {
 	m.ctrl.T.Helper()

--- a/pkg/graph/dag/vertex.go
+++ b/pkg/graph/dag/vertex.go
@@ -17,8 +17,6 @@
 package dag
 
 import (
-	"sync"
-
 	"d7y.io/dragonfly/v2/pkg/container/set"
 )
 
@@ -28,7 +26,6 @@ type Vertex[T comparable] struct {
 	Value    T
 	Parents  set.SafeSet[*Vertex[T]]
 	Children set.SafeSet[*Vertex[T]]
-	mu       sync.RWMutex
 }
 
 // New returns a new Vertex instance.
@@ -54,28 +51,4 @@ func (v *Vertex[T]) InDegree() int {
 // OutDegree returns the outdegree of vertex.
 func (v *Vertex[T]) OutDegree() int {
 	return int(v.Children.Len())
-}
-
-// DeleteInEdges deletes inedges of vertex.
-func (v *Vertex[T]) DeleteInEdges() {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	for _, parent := range v.Parents.Values() {
-		parent.Children.Delete(v)
-	}
-
-	v.Parents = set.NewSafeSet[*Vertex[T]]()
-}
-
-// DeleteOutEdges deletes outedges of vertex.
-func (v *Vertex[T]) DeleteOutEdges() {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	for _, child := range v.Children.Values() {
-		child.Parents.Delete(v)
-	}
-
-	v.Children = set.NewSafeSet[*Vertex[T]]()
 }

--- a/pkg/graph/dag/vertex_test.go
+++ b/pkg/graph/dag/vertex_test.go
@@ -27,7 +27,7 @@ const (
 	mockVertexValue = "bar"
 )
 
-func TestNewVertex(t *testing.T) {
+func TestVertex_New(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -36,7 +36,7 @@ func TestNewVertex(t *testing.T) {
 	assert.Equal(v.Children.Len(), uint(0))
 }
 
-func TestVertexDegree(t *testing.T) {
+func TestVertex_Degree(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -56,7 +56,7 @@ func TestVertexDegree(t *testing.T) {
 	assert.Equal(v.Degree(), 0)
 }
 
-func TestVertexInDegree(t *testing.T) {
+func TestVertex_InDegree(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -76,7 +76,7 @@ func TestVertexInDegree(t *testing.T) {
 	assert.Equal(v.InDegree(), 0)
 }
 
-func TestVertexOutDegree(t *testing.T) {
+func TestVertex_OutDegree(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -94,34 +94,4 @@ func TestVertexOutDegree(t *testing.T) {
 
 	v.Children.Delete(v)
 	assert.Equal(v.OutDegree(), 0)
-}
-
-func TestVertexDeleteInEdges(t *testing.T) {
-	va := NewVertex(mockVertexID, mockVertexValue)
-	vb := NewVertex(mockVertexID, mockVertexValue)
-	assert := assert.New(t)
-
-	va.Parents.Add(vb)
-	vb.Children.Add(va)
-	assert.Equal(va.Parents.Len(), uint(1))
-	assert.Equal(vb.Children.Len(), uint(1))
-
-	va.DeleteInEdges()
-	assert.Equal(va.Parents.Len(), uint(0))
-	assert.Equal(vb.Children.Len(), uint(0))
-}
-
-func TestVertexDeleteOutEdges(t *testing.T) {
-	va := NewVertex(mockVertexID, mockVertexValue)
-	vb := NewVertex(mockVertexID, mockVertexValue)
-	assert := assert.New(t)
-
-	va.Parents.Add(vb)
-	vb.Children.Add(va)
-	assert.Equal(va.Parents.Len(), uint(1))
-	assert.Equal(vb.Children.Len(), uint(1))
-
-	vb.DeleteOutEdges()
-	assert.Equal(va.Parents.Len(), uint(0))
-	assert.Equal(vb.Children.Len(), uint(0))
 }

--- a/pkg/graph/dg/dg_test.go
+++ b/pkg/graph/dg/dg_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewDG(t *testing.T) {
+func TestDG_New(t *testing.T) {
 	d := NewDG[string]()
 	assert := assert.New(t)
 	assert.Equal(reflect.TypeOf(d).Elem().Name(), "dg[string]")
 }
 
-func TestDGAddVertex(t *testing.T) {
+func TestDG_AddVertex(t *testing.T) {
 	tests := []struct {
 		name   string
 		id     string
@@ -68,7 +68,7 @@ func TestDGAddVertex(t *testing.T) {
 	}
 }
 
-func TestDGDeleteVertex(t *testing.T) {
+func TestDG_DeleteVertex(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -126,7 +126,7 @@ func TestDGDeleteVertex(t *testing.T) {
 	}
 }
 
-func TestDGGetVertex(t *testing.T) {
+func TestDG_GetVertex(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -165,7 +165,7 @@ func TestDGGetVertex(t *testing.T) {
 	}
 }
 
-func TestDGVertexVertexCount(t *testing.T) {
+func TestDG_VertexCount(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -202,7 +202,7 @@ func TestDGVertexVertexCount(t *testing.T) {
 	}
 }
 
-func TestDGGetVertices(t *testing.T) {
+func TestDG_GetVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -243,7 +243,7 @@ func TestDGGetVertices(t *testing.T) {
 	}
 }
 
-func TestDGGetRandomVertices(t *testing.T) {
+func TestDG_GetRandomVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -299,7 +299,7 @@ func TestDGGetRandomVertices(t *testing.T) {
 	}
 }
 
-func TestDGGetVertexKeys(t *testing.T) {
+func TestDG_GetVertexKeys(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -331,7 +331,7 @@ func TestDGGetVertexKeys(t *testing.T) {
 	}
 }
 
-func TestDGAddEdge(t *testing.T) {
+func TestDG_AddEdge(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -421,7 +421,88 @@ func TestDGAddEdge(t *testing.T) {
 	}
 }
 
-func TestDGCanAddEdge(t *testing.T) {
+func TestDG_DeleteEdge(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect func(t *testing.T, d DG[string])
+	}{
+		{
+			name: "delete edge",
+			expect: func(t *testing.T, d DG[string]) {
+				assert := assert.New(t)
+				var (
+					mockVertexEID = "bae"
+					mockVertexFID = "baf"
+				)
+
+				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddVertex(mockVertexFID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.DeleteEdge(mockVertexFID, mockVertexEID); err != nil {
+					assert.NoError(err)
+				}
+
+				vf, err := d.GetVertex(mockVertexFID)
+				assert.NoError(err)
+				assert.Equal(vf.Parents.Len(), uint(1))
+				ve, err := d.GetVertex(mockVertexEID)
+				assert.NoError(err)
+				assert.Equal(ve.Children.Len(), uint(1))
+
+				if err := d.DeleteEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.NoError(err)
+				}
+
+				vf, err = d.GetVertex(mockVertexFID)
+				assert.NoError(err)
+				assert.Equal(vf.Parents.Len(), uint(0))
+				ve, err = d.GetVertex(mockVertexEID)
+				assert.NoError(err)
+				assert.Equal(ve.Children.Len(), uint(0))
+			},
+		},
+		{
+			name: "vertex not found",
+			expect: func(t *testing.T, d DG[string]) {
+				assert := assert.New(t)
+				var (
+					mockVertexEID = "bae"
+					mockVertexFID = "baf"
+				)
+
+				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.EqualError(err, ErrVertexNotFound.Error())
+				}
+
+				if err := d.AddEdge(mockVertexFID, mockVertexEID); err != nil {
+					assert.EqualError(err, ErrVertexNotFound.Error())
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDG[string]()
+			tc.expect(t, d)
+		})
+	}
+}
+
+func TestDG_CanAddEdge(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -571,13 +652,13 @@ func TestDGCanAddEdge(t *testing.T) {
 	}
 }
 
-func TestDGDeleteEdge(t *testing.T) {
+func TestDG_DeleteVertexInEdges(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
 	}{
 		{
-			name: "delete edge",
+			name: "delete inedges",
 			expect: func(t *testing.T, d DG[string]) {
 				assert := assert.New(t)
 				var (
@@ -597,47 +678,25 @@ func TestDGDeleteEdge(t *testing.T) {
 					assert.NoError(err)
 				}
 
-				if err := d.DeleteEdge(mockVertexFID, mockVertexEID); err != nil {
+				if err := d.DeleteVertexInEdges(mockVertexFID); err != nil {
 					assert.NoError(err)
 				}
 
 				vf, err := d.GetVertex(mockVertexFID)
 				assert.NoError(err)
-				assert.Equal(vf.Parents.Len(), uint(1))
+				assert.Equal(vf.Children.Len(), uint(0))
 				ve, err := d.GetVertex(mockVertexEID)
 				assert.NoError(err)
-				assert.Equal(ve.Children.Len(), uint(1))
-
-				if err := d.DeleteEdge(mockVertexEID, mockVertexFID); err != nil {
-					assert.NoError(err)
-				}
-
-				vf, err = d.GetVertex(mockVertexFID)
-				assert.NoError(err)
-				assert.Equal(vf.Parents.Len(), uint(0))
-				ve, err = d.GetVertex(mockVertexEID)
-				assert.NoError(err)
-				assert.Equal(ve.Children.Len(), uint(0))
+				assert.Equal(ve.Parents.Len(), uint(0))
 			},
 		},
 		{
 			name: "vertex not found",
 			expect: func(t *testing.T, d DG[string]) {
 				assert := assert.New(t)
-				var (
-					mockVertexEID = "bae"
-					mockVertexFID = "baf"
-				)
+				mockVertexEID := "bae"
 
-				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
-					assert.NoError(err)
-				}
-
-				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
-					assert.EqualError(err, ErrVertexNotFound.Error())
-				}
-
-				if err := d.AddEdge(mockVertexFID, mockVertexEID); err != nil {
+				if err := d.DeleteVertexInEdges(mockVertexEID); err != nil {
 					assert.EqualError(err, ErrVertexNotFound.Error())
 				}
 			},
@@ -652,7 +711,66 @@ func TestDGDeleteEdge(t *testing.T) {
 	}
 }
 
-func TestDGSourceVertices(t *testing.T) {
+func TestDG_DeleteVertexOutEdges(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect func(t *testing.T, d DG[string])
+	}{
+		{
+			name: "delete outedges",
+			expect: func(t *testing.T, d DG[string]) {
+				assert := assert.New(t)
+				var (
+					mockVertexEID = "bae"
+					mockVertexFID = "baf"
+				)
+
+				if err := d.AddVertex(mockVertexEID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddVertex(mockVertexFID, mockVertexValue); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.AddEdge(mockVertexEID, mockVertexFID); err != nil {
+					assert.NoError(err)
+				}
+
+				if err := d.DeleteVertexOutEdges(mockVertexEID); err != nil {
+					assert.NoError(err)
+				}
+
+				vf, err := d.GetVertex(mockVertexFID)
+				assert.NoError(err)
+				assert.Equal(vf.Children.Len(), uint(0))
+				ve, err := d.GetVertex(mockVertexEID)
+				assert.NoError(err)
+				assert.Equal(ve.Parents.Len(), uint(0))
+			},
+		},
+		{
+			name: "vertex not found",
+			expect: func(t *testing.T, d DG[string]) {
+				assert := assert.New(t)
+				mockVertexEID := "bae"
+
+				if err := d.DeleteVertexOutEdges(mockVertexEID); err != nil {
+					assert.EqualError(err, ErrVertexNotFound.Error())
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDG[string]()
+			tc.expect(t, d)
+		})
+	}
+}
+
+func TestDG_SourceVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -699,7 +817,7 @@ func TestDGSourceVertices(t *testing.T) {
 	}
 }
 
-func TestDGSinkVertices(t *testing.T) {
+func TestDG_SinkVertices(t *testing.T) {
 	tests := []struct {
 		name   string
 		expect func(t *testing.T, d DG[string])
@@ -746,7 +864,7 @@ func TestDGSinkVertices(t *testing.T) {
 	}
 }
 
-func BenchmarkDGAddVertex(b *testing.B) {
+func BenchmarkDG_AddVertex(b *testing.B) {
 	var ids []string
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {
@@ -761,7 +879,7 @@ func BenchmarkDGAddVertex(b *testing.B) {
 	}
 }
 
-func BenchmarkDGDeleteVertex(b *testing.B) {
+func BenchmarkDG_DeleteVertex(b *testing.B) {
 	var ids []string
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {
@@ -779,7 +897,7 @@ func BenchmarkDGDeleteVertex(b *testing.B) {
 	}
 }
 
-func BenchmarkDGGetRandomKeys(b *testing.B) {
+func BenchmarkDG_GetRandomKeys(b *testing.B) {
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {
 		id := fmt.Sprint(n)
@@ -797,7 +915,7 @@ func BenchmarkDGGetRandomKeys(b *testing.B) {
 	}
 }
 
-func BenchmarkDGDeleteVertexWithMultiEdges(b *testing.B) {
+func BenchmarkDG_DeleteVertexWithMultiEdges(b *testing.B) {
 	var ids []string
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {
@@ -828,7 +946,7 @@ func BenchmarkDGDeleteVertexWithMultiEdges(b *testing.B) {
 	}
 }
 
-func BenchmarkDGAddEdge(b *testing.B) {
+func BenchmarkDG_AddEdge(b *testing.B) {
 	var ids []string
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {
@@ -852,7 +970,7 @@ func BenchmarkDGAddEdge(b *testing.B) {
 	}
 }
 
-func BenchmarkDGAddEdgeWithMultiEdges(b *testing.B) {
+func BenchmarkDG_AddEdgeWithMultiEdges(b *testing.B) {
 	var ids []string
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {
@@ -889,7 +1007,7 @@ func BenchmarkDGAddEdgeWithMultiEdges(b *testing.B) {
 	}
 }
 
-func BenchmarkDGDeleteEdge(b *testing.B) {
+func BenchmarkDG_DeleteEdge(b *testing.B) {
 	var ids []string
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {

--- a/pkg/graph/dg/mocks/dg_mock.go
+++ b/pkg/graph/dg/mocks/dg_mock.go
@@ -102,6 +102,34 @@ func (mr *MockDGMockRecorder[T]) DeleteVertex(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertex", reflect.TypeOf((*MockDG[T])(nil).DeleteVertex), id)
 }
 
+// DeleteVertexInEdges mocks base method.
+func (m *MockDG[T]) DeleteVertexInEdges(id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVertexInEdges", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVertexInEdges indicates an expected call of DeleteVertexInEdges.
+func (mr *MockDGMockRecorder[T]) DeleteVertexInEdges(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexInEdges", reflect.TypeOf((*MockDG[T])(nil).DeleteVertexInEdges), id)
+}
+
+// DeleteVertexOutEdges mocks base method.
+func (m *MockDG[T]) DeleteVertexOutEdges(id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVertexOutEdges", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVertexOutEdges indicates an expected call of DeleteVertexOutEdges.
+func (mr *MockDGMockRecorder[T]) DeleteVertexOutEdges(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexOutEdges", reflect.TypeOf((*MockDG[T])(nil).DeleteVertexOutEdges), id)
+}
+
 // GetRandomVertices mocks base method.
 func (m *MockDG[T]) GetRandomVertices(n uint) []*dg.Vertex[T] {
 	m.ctrl.T.Helper()

--- a/pkg/graph/dg/vertex.go
+++ b/pkg/graph/dg/vertex.go
@@ -16,7 +16,9 @@
 
 package dg
 
-import "d7y.io/dragonfly/v2/pkg/container/set"
+import (
+	"d7y.io/dragonfly/v2/pkg/container/set"
+)
 
 // Vertex is a vertex of the directed graph.
 type Vertex[T comparable] struct {
@@ -49,22 +51,4 @@ func (v *Vertex[T]) InDegree() int {
 // OutDegree returns the outdegree of vertex.
 func (v *Vertex[T]) OutDegree() int {
 	return int(v.Children.Len())
-}
-
-// DeleteInEdges deletes inedges of vertex.
-func (v *Vertex[T]) DeleteInEdges() {
-	for _, parent := range v.Parents.Values() {
-		parent.Children.Delete(v)
-	}
-
-	v.Parents = set.NewSafeSet[*Vertex[T]]()
-}
-
-// DeleteOutEdges deletes outedges of vertex.
-func (v *Vertex[T]) DeleteOutEdges() {
-	for _, child := range v.Children.Values() {
-		child.Parents.Delete(v)
-	}
-
-	v.Children = set.NewSafeSet[*Vertex[T]]()
 }

--- a/pkg/graph/dg/vertex_test.go
+++ b/pkg/graph/dg/vertex_test.go
@@ -27,7 +27,7 @@ const (
 	mockVertexValue = "bar"
 )
 
-func TestNewVertex(t *testing.T) {
+func TestVertex_New(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -36,7 +36,7 @@ func TestNewVertex(t *testing.T) {
 	assert.Equal(v.Children.Len(), uint(0))
 }
 
-func TestVertexDegree(t *testing.T) {
+func TestVertex_Degree(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -56,7 +56,7 @@ func TestVertexDegree(t *testing.T) {
 	assert.Equal(v.Degree(), 0)
 }
 
-func TestVertexInDegree(t *testing.T) {
+func TestVertex_InDegree(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -76,7 +76,7 @@ func TestVertexInDegree(t *testing.T) {
 	assert.Equal(v.InDegree(), 0)
 }
 
-func TestVertexOutDegree(t *testing.T) {
+func TestVertex_OutDegree(t *testing.T) {
 	v := NewVertex(mockVertexID, mockVertexValue)
 	assert := assert.New(t)
 	assert.Equal(v.ID, mockVertexID)
@@ -94,34 +94,4 @@ func TestVertexOutDegree(t *testing.T) {
 
 	v.Children.Delete(v)
 	assert.Equal(v.OutDegree(), 0)
-}
-
-func TestVertexDeleteInEdges(t *testing.T) {
-	va := NewVertex(mockVertexID, mockVertexValue)
-	vb := NewVertex(mockVertexID, mockVertexValue)
-	assert := assert.New(t)
-
-	va.Parents.Add(vb)
-	vb.Children.Add(va)
-	assert.Equal(va.Parents.Len(), uint(1))
-	assert.Equal(vb.Children.Len(), uint(1))
-
-	va.DeleteInEdges()
-	assert.Equal(va.Parents.Len(), uint(0))
-	assert.Equal(vb.Children.Len(), uint(0))
-}
-
-func TestVertexDeleteOutEdges(t *testing.T) {
-	va := NewVertex(mockVertexID, mockVertexValue)
-	vb := NewVertex(mockVertexID, mockVertexValue)
-	assert := assert.New(t)
-
-	va.Parents.Add(vb)
-	vb.Children.Add(va)
-	assert.Equal(va.Parents.Len(), uint(1))
-	assert.Equal(vb.Children.Len(), uint(1))
-
-	vb.DeleteOutEdges()
-	assert.Equal(va.Parents.Len(), uint(0))
-	assert.Equal(vb.Children.Len(), uint(0))
 }

--- a/pkg/objectstorage/mocks/objectstorage_mock.go
+++ b/pkg/objectstorage/mocks/objectstorage_mock.go
@@ -125,10 +125,10 @@ func (mr *MockObjectStorageMockRecorder) GetObjectMetadata(ctx, bucketName, obje
 }
 
 // GetObjectMetadatas mocks base method.
-func (m *MockObjectStorage) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker, delimiter string, limit int64) ([]*objectstorage.ObjectMetadata, error) {
+func (m *MockObjectStorage) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker, delimiter string, limit int64) (*objectstorage.ObjectMetadatas, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetObjectMetadatas", ctx, bucketName, prefix, marker, delimiter, limit)
-	ret0, _ := ret[0].([]*objectstorage.ObjectMetadata)
+	ret0, _ := ret[0].(*objectstorage.ObjectMetadatas)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/scheduler/resource/task.go
+++ b/scheduler/resource/task.go
@@ -298,7 +298,10 @@ func (t *Task) DeletePeerInEdges(key string) error {
 		parent.Value.Host.ConcurrentUploadCount.Dec()
 	}
 
-	vertex.DeleteInEdges()
+	if err := t.DAG.DeleteVertexInEdges(key); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -313,9 +316,12 @@ func (t *Task) DeletePeerOutEdges(key string) error {
 	if peer == nil {
 		return errors.New("vertex value is nil")
 	}
-
 	peer.Host.ConcurrentUploadCount.Sub(int32(vertex.Children.Len()))
-	vertex.DeleteOutEdges()
+
+	if err := t.DAG.DeleteVertexOutEdges(key); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
