### PR TITLE
fix: dfget couldn't download s3 directory correctly

### DIFF
--- a/pkg/source/clients/s3protocol/s3_source_client.go
+++ b/pkg/source/clients/s3protocol/s3_source_client.go
@@ -203,7 +203,7 @@ func (s *s3SourceClient) List(request *source.Request) (urls []source.URLEntry, 
 	}
 
 	// list all files
-	path := addTrailingSlash(request.URL.Path)
+	path := buildListPrefix(request.URL.Path)
 	var continuationToken *string
 	delimiter := "/"
 
@@ -244,7 +244,7 @@ func (s *s3SourceClient) List(request *source.Request) (urls []source.URLEntry, 
 }
 
 func (s *s3SourceClient) isDirectory(client *s3.S3, request *source.Request) (bool, error) {
-	uPath := addTrailingSlash(request.URL.Path)
+	uPath := buildListPrefix(request.URL.Path)
 	delimiter := "/"
 	output, err := client.ListObjectsV2WithContext(
 		request.Context(),
@@ -285,4 +285,11 @@ func addTrailingSlash(s string) string {
 		return s
 	}
 	return s + "/"
+}
+
+func buildListPrefix(s string) string {
+	s = addTrailingSlash(s)
+
+	// s3 objects id should not start with '/'
+	return strings.TrimLeft(s, "/")
 }


### PR DESCRIPTION
## Description

Something exception raised when using `dfget` to download a s3 directory.
Below is my usage:
```
dfget --recursive  --url "s3://my-bucket/my-dir" \
      --header "awsEndpoint: xxx" \
      --header ... \
      --output local_dir
```

I find the bug is that:

When download a s3 directory, client will call a s3 API `ListObjectsV2`, to check whether the url is a directory. And the API need a parameter `prefix` (used as prefix filter for s3 object ids, should not start with leading slash "/"). In dragonfly's s3 client code, the url will be parsed as `request.URL` and `request.URL.path` will be used as `prefix`(after add a trailing slash). Such `path` always have leading slash "/", e.g. '/', '/my-dir/', make `ListObjectsV2` API response wrong result.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
