### PR TITLE
Fix s3 commonPrefix initial issue.

### DIFF
--- a/pkg/objectstorage/s3.go
+++ b/pkg/objectstorage/s3.go
@@ -146,7 +146,7 @@ func (s *s3) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker,
 		})
 	}
 
-	commonPrefixes := make([]string, len(resp.CommonPrefixes))
+	commonPrefixes := make([]string, 0, len(resp.CommonPrefixes))
 	for _, commonPrefix := range resp.CommonPrefixes {
 		prefix, err := url.QueryUnescape(*commonPrefix.Prefix)
 		if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix the issue of improper initialization of return commonPrefixes slice in the S3 list interface when using delimiter.

## Related Issue
#2176
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
