### PR TITLE
fix: snapshot network topology id

### DIFF
--- a/scheduler/networktopology/network_topology.go
+++ b/scheduler/networktopology/network_topology.go
@@ -278,6 +278,7 @@ func (nt *networkTopology) Snapshot() error {
 	defer cancel()
 
 	now := time.Now()
+	id := uuid.NewString()
 	probedCountKeys, _, err := nt.rdb.Scan(ctx, 0, pkgredis.MakeProbedCountKeyInScheduler("*"), math.MaxInt64).Result()
 	if err != nil {
 		return err
@@ -360,7 +361,7 @@ func (nt *networkTopology) Snapshot() error {
 		}
 
 		if err = nt.storage.CreateNetworkTopology(storage.NetworkTopology{
-			ID: uuid.NewString(),
+			ID: id,
 			Host: storage.SrcHost{
 				ID:       host.ID,
 				Type:     host.Type.Name(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A snapshot should be represented by one network topology id in network topology record.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
