### PR TITLE
fix: add option to disable prepared statement for postgres

### DIFF
--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -181,6 +181,9 @@ type PostgresConfig struct {
 	// SSL mode.
 	SSLMode string `yaml:"sslMode" mapstructure:"sslMode"`
 
+	// Disable prepared statement.
+	PreferSimpleProtocol bool `yaml:"preferSimpleProtocol" mapstructure:"preferSimpleProtocol"`
+
 	// Server timezone.
 	Timezone string `yaml:"timezone" mapstructure:"timezone"`
 
@@ -414,11 +417,12 @@ func New() *Config {
 				Migrate: true,
 			},
 			Postgres: PostgresConfig{
-				Port:     DefaultPostgresPort,
-				DBName:   DefaultPostgresDBName,
-				SSLMode:  DefaultPostgresSSLMode,
-				Timezone: DefaultPostgresTimezone,
-				Migrate:  true,
+				Port:                 DefaultPostgresPort,
+				DBName:               DefaultPostgresDBName,
+				SSLMode:              DefaultPostgresSSLMode,
+				PreferSimpleProtocol: DefaultPostgresPreferSimpleProtocol,
+				Timezone:             DefaultPostgresTimezone,
+				Migrate:              true,
 			},
 			Redis: RedisConfig{
 				DB:        DefaultRedisDB,

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -56,14 +56,15 @@ var (
 	}
 
 	mockPostgresConfig = PostgresConfig{
-		User:     "foo",
-		Password: "bar",
-		Host:     "localhost",
-		Port:     DefaultPostgresPort,
-		DBName:   DefaultPostgresDBName,
-		SSLMode:  DefaultPostgresSSLMode,
-		Timezone: DefaultPostgresTimezone,
-		Migrate:  true,
+		User:                 "foo",
+		Password:             "bar",
+		Host:                 "localhost",
+		Port:                 DefaultPostgresPort,
+		DBName:               DefaultPostgresDBName,
+		SSLMode:              DefaultPostgresSSLMode,
+		PreferSimpleProtocol: DefaultPostgresPreferSimpleProtocol,
+		Timezone:             DefaultPostgresTimezone,
+		Migrate:              true,
 	}
 
 	mockRedisConfig = RedisConfig{
@@ -160,14 +161,15 @@ func TestConfig_Load(t *testing.T) {
 				Migrate: true,
 			},
 			Postgres: PostgresConfig{
-				User:     "foo",
-				Password: "foo",
-				Host:     "foo",
-				Port:     5432,
-				DBName:   "foo",
-				SSLMode:  "disable",
-				Timezone: "UTC",
-				Migrate:  true,
+				User:                 "foo",
+				Password:             "foo",
+				Host:                 "foo",
+				Port:                 5432,
+				DBName:               "foo",
+				SSLMode:              "disable",
+				PreferSimpleProtocol: false,
+				Timezone:             "UTC",
+				Migrate:              true,
 			},
 			Redis: RedisConfig{
 				Password:   "bar",

--- a/manager/config/constants.go
+++ b/manager/config/constants.go
@@ -113,6 +113,9 @@ const (
 	// DefaultPostgresSSLMode is default ssl mode for postgres.
 	DefaultPostgresSSLMode = "disable"
 
+	// DefaultPostgresPreferSimpleProtocol is default disable prepared statement option for postgres.
+	DefaultPostgresPreferSimpleProtocol = false
+
 	// DefaultPostgresTimezone is default timezone for postgres.
 	DefaultPostgresTimezone = "UTC"
 )

--- a/manager/database/postgres.go
+++ b/manager/database/postgres.go
@@ -34,8 +34,11 @@ func newPostgres(cfg *config.Config) (*gorm.DB, error) {
 	// Format dsn string.
 	dsn := formatPostgresDSN(postgresCfg)
 
-	// Connect to mysql.
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+	// Connect to postgres.
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  dsn,
+		PreferSimpleProtocol: cfg.Database.Postgres.PreferSimpleProtocol,
+	}), &gorm.Config{
 		NamingStrategy: schema.NamingStrategy{
 			SingularTable: true,
 		},


### PR DESCRIPTION
Add option to disable prepared statement for postgres.
This option is required for use with PgBouncer. PgBouncer does not support prepared statements.

## Description

To disable prepared statements, pass gorm PreferSimpleProtocol: true.

## Related Issue

https://github.com/dragonflyoss/Dragonfly2/issues/2767

## Motivation and Context

Solves problems when working with pgbouncer.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
