### PR TITLE
feat: proxy graceful shutdown

### DIFF
--- a/client/daemon/daemon.go
+++ b/client/daemon/daemon.go
@@ -815,6 +815,13 @@ func (cd *clientDaemon) Serve() error {
 func (cd *clientDaemon) Stop() {
 	cd.once.Do(func() {
 		close(cd.done)
+
+		if cd.ProxyManager.IsEnabled() {
+			if err := cd.ProxyManager.Stop(); err != nil {
+				logger.Errorf("proxy manager stop failed %s", err)
+			}
+		}
+
 		if cd.schedulerClient != nil {
 			if !cd.Option.KeepStorage {
 				logger.Info("leave host with scheduler client")
@@ -843,12 +850,6 @@ func (cd *clientDaemon) Stop() {
 		if cd.Option.ObjectStorage.Enable {
 			if err := cd.ObjectStorage.Stop(); err != nil {
 				logger.Errorf("object storage stop failed %s", err)
-			}
-		}
-
-		if cd.ProxyManager.IsEnabled() {
-			if err := cd.ProxyManager.Stop(); err != nil {
-				logger.Errorf("proxy manager stop failed %s", err)
 			}
 		}
 

--- a/client/daemon/proxy/proxy_manager.go
+++ b/client/daemon/proxy/proxy_manager.go
@@ -142,7 +142,12 @@ func (pm *proxyManager) ServeSNI(listener net.Listener) error {
 }
 
 func (pm *proxyManager) Stop() error {
-	return pm.Server.Shutdown(context.Background())
+	err := pm.Server.Shutdown(context.Background())
+	if err != nil {
+		logger.Errorf("proxy shut down error: %s", err)
+	}
+	pm.Proxy.wg.Wait()
+	return err
 }
 
 func (pm *proxyManager) IsEnabled() bool {

--- a/client/daemon/proxy/proxy_sni.go
+++ b/client/daemon/proxy/proxy_sni.go
@@ -66,6 +66,9 @@ func handshakeTLSConn(clientConn net.Conn, config *tls.Config) (net.Conn, error)
 }
 
 func (proxy *Proxy) handleTLSConn(clientConn net.Conn, port int) {
+	proxy.wg.Add(1)
+	defer proxy.wg.Done()
+
 	var serverName string
 	sConfig := new(tls.Config)
 	if !proxy.cert.Leaf.IsCA {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When shutdown, we must wait the flying proxy request completed, this PR does:

* Add sync.WaitGroup to proxy - Done
* Add graceful shutdown timeout - WIP

## Related Issue

Fix #2761

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
