### PR TITLE
fix: filter Authorization header from preheat log

### DIFF
--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -186,7 +186,7 @@ func (j *job) preheat(ctx context.Context, req string) error {
 	taskID := idgen.TaskIDV1(preheat.URL, urlMeta)
 	log := logger.WithTask(taskID, preheat.URL)
 	log.Infof("preheat %s headers: %#v, tag: %s, range: %s, filter: %s, digest: %s",
-		preheat.URL, urlMeta.Header, urlMeta.Tag, urlMeta.Range, urlMeta.Filter, urlMeta.Digest)
+		preheat.URL, filterHeaders(urlMeta.Header, log.IsDebug()), urlMeta.Tag, urlMeta.Range, urlMeta.Filter, urlMeta.Digest)
 	stream, err := j.resource.SeedPeer().Client().ObtainSeeds(ctx, &cdnsystemv1.SeedRequest{
 		TaskId:  taskID,
 		Url:     preheat.URL,
@@ -226,4 +226,15 @@ func (j *job) syncPeers() (string, error) {
 	})
 
 	return internaljob.MarshalResponse(hosts)
+}
+
+// filterHeaders filters Authorization header if debugging is not enabled
+func filterHeaders(urlHeader map[string]string, isDebug bool) map[string]string {
+	filteredHeaders := make(map[string]string)
+	for k, v := range urlHeader {
+		if isDebug || k != headers.Authorization {
+			filteredHeaders[k] = v
+		}
+	}
+	return filteredHeaders
 }


### PR DESCRIPTION
## Description

filter Authorization header from preheat log

## Related Issue

https://github.com/dragonflyoss/Dragonfly2/issues/2816

## Motivation and Context

Authorization tokens are included in the log

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
