### PR TITLE
feat: add MaxScheduleCount and GetSeedPeers

### DIFF
--- a/client/config/dynconfig.go
+++ b/client/config/dynconfig.go
@@ -44,11 +44,15 @@ const (
 var watchInterval = 10 * time.Second
 
 type DynconfigData struct {
+	SeedPeers     []*managerv1.SeedPeer
 	Schedulers    []*managerv1.Scheduler
 	ObjectStorage *managerv1.ObjectStorage
 }
 
 type Dynconfig interface {
+	// Get the dynamic seed peers config.
+	GetSeedPeers() ([]*managerv1.SeedPeer, error)
+
 	// Get the dynamic schedulers resolve addrs.
 	GetResolveSchedulerAddrs() ([]resolver.Address, error)
 

--- a/client/config/dynconfig_local.go
+++ b/client/config/dynconfig_local.go
@@ -56,6 +56,11 @@ func newDynconfigLocal(cfg *DaemonOption, creds credentials.TransportCredentials
 	}, nil
 }
 
+// Get the dynamic seed peers config.
+func (d *dynconfigLocal) GetSeedPeers() ([]*managerv1.SeedPeer, error) {
+	return nil, ErrUnimplemented
+}
+
 // Get the dynamic schedulers resolve addrs.
 func (d *dynconfigLocal) GetResolveSchedulerAddrs() ([]resolver.Address, error) {
 	var (

--- a/client/config/dynconfig_manager_test.go
+++ b/client/config/dynconfig_manager_test.go
@@ -420,7 +420,7 @@ func TestDynconfigManager_GetResolveSchedulerAddrs(t *testing.T) {
 			expect: func(t *testing.T, dynconfig Dynconfig, data *DynconfigData) {
 				assert := assert.New(t)
 				_, err := dynconfig.GetResolveSchedulerAddrs()
-				assert.EqualError(err, "invalid schedulers")
+				assert.EqualError(err, "schedulers not found")
 			},
 		},
 	}

--- a/client/config/mocks/dynconfig_mock.go
+++ b/client/config/mocks/dynconfig_mock.go
@@ -126,6 +126,21 @@ func (mr *MockDynconfigMockRecorder) GetSchedulers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulers", reflect.TypeOf((*MockDynconfig)(nil).GetSchedulers))
 }
 
+// GetSeedPeers mocks base method.
+func (m *MockDynconfig) GetSeedPeers() ([]*manager.SeedPeer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSeedPeers")
+	ret0, _ := ret[0].([]*manager.SeedPeer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSeedPeers indicates an expected call of GetSeedPeers.
+func (mr *MockDynconfigMockRecorder) GetSeedPeers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeedPeers", reflect.TypeOf((*MockDynconfig)(nil).GetSeedPeers))
+}
+
 // Notify mocks base method.
 func (m *MockDynconfig) Notify() error {
 	m.ctrl.T.Helper()

--- a/pkg/rpc/manager/client/client_v1.go
+++ b/pkg/rpc/manager/client/client_v1.go
@@ -88,6 +88,9 @@ func GetV1ByNetAddrs(ctx context.Context, netAddrs []dfnet.NetAddr, opts ...grpc
 
 // V1 is the interface for v1 version of the grpc client.
 type V1 interface {
+	// List Seed peer configuration.
+	ListSeedPeers(context.Context, *managerv1.ListSeedPeersRequest, ...grpc.CallOption) (*managerv1.ListSeedPeersResponse, error)
+
 	// Update Seed peer configuration.
 	UpdateSeedPeer(context.Context, *managerv1.UpdateSeedPeerRequest, ...grpc.CallOption) (*managerv1.SeedPeer, error)
 
@@ -124,6 +127,14 @@ type v1 struct {
 	managerv1.ManagerClient
 	securityv1.CertificateClient
 	*grpc.ClientConn
+}
+
+// List acitve seed peers configuration.
+func (v *v1) ListSeedPeers(ctx context.Context, req *managerv1.ListSeedPeersRequest, opts ...grpc.CallOption) (*managerv1.ListSeedPeersResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+
+	return v.ManagerClient.ListSeedPeers(ctx, req, opts...)
 }
 
 // Update SeedPeer configuration.

--- a/pkg/rpc/manager/client/client_v2.go
+++ b/pkg/rpc/manager/client/client_v2.go
@@ -88,6 +88,9 @@ func GetV2ByNetAddrs(ctx context.Context, netAddrs []dfnet.NetAddr, opts ...grpc
 
 // V2 is the interface for v2 version of the grpc client.
 type V2 interface {
+	// List Seed peer configuration.
+	ListSeedPeers(context.Context, *managerv2.ListSeedPeersRequest, ...grpc.CallOption) (*managerv2.ListSeedPeersResponse, error)
+
 	// Update Seed peer configuration.
 	UpdateSeedPeer(context.Context, *managerv2.UpdateSeedPeerRequest, ...grpc.CallOption) (*managerv2.SeedPeer, error)
 
@@ -127,6 +130,14 @@ type v2 struct {
 	managerv2.ManagerClient
 	securityv1.CertificateClient
 	*grpc.ClientConn
+}
+
+// List acitve seed peers configuration.
+func (v *v2) ListSeedPeers(ctx context.Context, req *managerv2.ListSeedPeersRequest, opts ...grpc.CallOption) (*managerv2.ListSeedPeersResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+
+	return v.ManagerClient.ListSeedPeers(ctx, req, opts...)
 }
 
 // Update SeedPeer configuration.

--- a/pkg/rpc/manager/client/mocks/client_v1_mock.go
+++ b/pkg/rpc/manager/client/mocks/client_v1_mock.go
@@ -191,6 +191,26 @@ func (mr *MockV1MockRecorder) ListSchedulers(arg0, arg1 any, arg2 ...any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSchedulers", reflect.TypeOf((*MockV1)(nil).ListSchedulers), varargs...)
 }
 
+// ListSeedPeers mocks base method.
+func (m *MockV1) ListSeedPeers(arg0 context.Context, arg1 *manager.ListSeedPeersRequest, arg2 ...grpc.CallOption) (*manager.ListSeedPeersResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeedPeers", varargs...)
+	ret0, _ := ret[0].(*manager.ListSeedPeersResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSeedPeers indicates an expected call of ListSeedPeers.
+func (mr *MockV1MockRecorder) ListSeedPeers(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeedPeers", reflect.TypeOf((*MockV1)(nil).ListSeedPeers), varargs...)
+}
+
 // UpdateScheduler mocks base method.
 func (m *MockV1) UpdateScheduler(arg0 context.Context, arg1 *manager.UpdateSchedulerRequest, arg2 ...grpc.CallOption) (*manager.Scheduler, error) {
 	m.ctrl.T.Helper()

--- a/pkg/rpc/manager/client/mocks/client_v2_mock.go
+++ b/pkg/rpc/manager/client/mocks/client_v2_mock.go
@@ -210,6 +210,26 @@ func (mr *MockV2MockRecorder) ListSchedulers(arg0, arg1 any, arg2 ...any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSchedulers", reflect.TypeOf((*MockV2)(nil).ListSchedulers), varargs...)
 }
 
+// ListSeedPeers mocks base method.
+func (m *MockV2) ListSeedPeers(arg0 context.Context, arg1 *manager.ListSeedPeersRequest, arg2 ...grpc.CallOption) (*manager.ListSeedPeersResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeedPeers", varargs...)
+	ret0, _ := ret[0].(*manager.ListSeedPeersResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSeedPeers indicates an expected call of ListSeedPeers.
+func (mr *MockV2MockRecorder) ListSeedPeers(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeedPeers", reflect.TypeOf((*MockV2)(nil).ListSeedPeers), varargs...)
+}
+
 // UpdateScheduler mocks base method.
 func (m *MockV2) UpdateScheduler(arg0 context.Context, arg1 *manager.UpdateSchedulerRequest, arg2 ...grpc.CallOption) (*manager.Scheduler, error) {
 	m.ctrl.T.Helper()

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -116,6 +116,9 @@ type SchedulerConfig struct {
 	// Algorithm is scheduling algorithm used by the scheduler.
 	Algorithm string `yaml:"algorithm" mapstructure:"algorithm"`
 
+	// MaxScheduleCount is max schedule count.
+	MaxScheduleCount int `yaml:"maxScheduleCount" mapstructure:"maxScheduleCount"`
+
 	// BackToSourceCount is single task allows the peer to back-to-source count.
 	BackToSourceCount int `yaml:"backToSourceCount" mapstructure:"backToSourceCount"`
 
@@ -370,6 +373,7 @@ func New() *Config {
 		},
 		Scheduler: SchedulerConfig{
 			Algorithm:              DefaultSchedulerAlgorithm,
+			MaxScheduleCount:       DefaultSchedulerMaxScheduleCount,
 			BackToSourceCount:      DefaultSchedulerBackToSourceCount,
 			RetryBackToSourceLimit: DefaultSchedulerRetryBackToSourceLimit,
 			RetryLimit:             DefaultSchedulerRetryLimit,
@@ -484,6 +488,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Scheduler.Algorithm == "" {
 		return errors.New("scheduler requires parameter algorithm")
+	}
+
+	if cfg.Scheduler.MaxScheduleCount <= 0 {
+		return errors.New("scheduler requires parameter maxScheduleCount")
 	}
 
 	if cfg.Scheduler.BackToSourceCount == 0 {

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -76,6 +76,7 @@ func TestConfig_Load(t *testing.T) {
 	config := &Config{
 		Scheduler: SchedulerConfig{
 			Algorithm:              "default",
+			MaxScheduleCount:       12,
 			BackToSourceCount:      3,
 			RetryBackToSourceLimit: 2,
 			RetryLimit:             10,

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -63,6 +63,9 @@ const (
 	// DefaultSchedulerAlgorithm is default algorithm for scheduler.
 	DefaultSchedulerAlgorithm = "default"
 
+	// DefaultSchedulerMaxScheduleCount is default schedule limit for peer.
+	DefaultSchedulerMaxScheduleCount = 30
+
 	// DefaultSchedulerBackToSourceCount is default back-to-source count for scheduler.
 	DefaultSchedulerBackToSourceCount = 3
 

--- a/scheduler/config/dynconfig.go
+++ b/scheduler/config/dynconfig.go
@@ -247,10 +247,6 @@ func (d *dynconfig) GetApplications() ([]*managerv2.Application, error) {
 		return nil, err
 	}
 
-	if data.Applications == nil {
-		return nil, errors.New("invalid applications")
-	}
-
 	if len(data.Applications) == 0 {
 		return nil, errors.New("application not found")
 	}
@@ -263,10 +259,6 @@ func (d *dynconfig) GetSeedPeers() ([]*managerv2.SeedPeer, error) {
 	scheduler, err := d.GetScheduler()
 	if err != nil {
 		return nil, err
-	}
-
-	if scheduler.SeedPeers == nil {
-		return nil, errors.New("invalid seed peers")
 	}
 
 	if len(scheduler.SeedPeers) == 0 {

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -12,6 +12,7 @@ server:
 
 scheduler:
   algorithm: default
+  maxScheduleCount: 12
   backToSourceCount: 3
   retryBackToSourceLimit: 2
   retryLimit: 10

--- a/scheduler/resource/peer.go
+++ b/scheduler/resource/peer.go
@@ -186,6 +186,9 @@ type Peer struct {
 	// NeedBackToSource is set to true.
 	NeedBackToSource *atomic.Bool
 
+	// ScheduleCount is schedule count.
+	ScheduleCount *atomic.Int32
+
 	// PieceUpdatedAt is piece update time.
 	PieceUpdatedAt *atomic.Time
 
@@ -215,6 +218,7 @@ func NewPeer(id string, cfg *config.ResourceConfig, task *Task, host *Host, opti
 		Host:                    host,
 		BlockParents:            set.NewSafeSet[string](),
 		NeedBackToSource:        atomic.NewBool(false),
+		ScheduleCount:           atomic.NewInt32(0),
 		PieceUpdatedAt:          atomic.NewTime(time.Now()),
 		CreatedAt:               atomic.NewTime(time.Now()),
 		UpdatedAt:               atomic.NewTime(time.Now()),

--- a/scheduler/scheduling/scheduling_test.go
+++ b/scheduler/scheduling/scheduling_test.go
@@ -56,6 +56,7 @@ var (
 	mockPluginDir       = "bas"
 	mockSchedulerConfig = &config.SchedulerConfig{
 		RetryLimit:             2,
+		MaxScheduleCount:       3,
 		RetryBackToSourceLimit: 1,
 		RetryInterval:          10 * time.Millisecond,
 		BackToSourceCount:      int(mockTaskBackToSourceLimit),
@@ -245,6 +246,22 @@ func TestScheduling_ScheduleCandidateParents(t *testing.T) {
 			expect: func(t *testing.T, peer *resource.Peer, err error) {
 				assert := assert.New(t)
 				assert.ErrorIs(err, context.Canceled)
+				assert.True(peer.FSM.Is(resource.PeerStateRunning))
+				assert.True(peer.Task.FSM.Is(resource.TaskStatePending))
+			},
+		},
+		{
+			name: "peer exceeded MaxScheduleCount and peer stream load failed",
+			mock: func(cancel context.CancelFunc, peer *resource.Peer, seedPeer *resource.Peer, blocklist set.SafeSet[string], stream schedulerv2.Scheduler_AnnouncePeerServer, ma *schedulerv2mocks.MockScheduler_AnnouncePeerServerMockRecorder, md *configmocks.MockDynconfigInterfaceMockRecorder) {
+				task := peer.Task
+				task.StorePeer(peer)
+				peer.ScheduleCount.Store(5)
+				peer.FSM.SetState(resource.PeerStateRunning)
+			},
+			expect: func(t *testing.T, peer *resource.Peer, err error) {
+				assert := assert.New(t)
+				assert.ErrorIs(err, status.Error(codes.FailedPrecondition, "load stream failed"))
+				assert.Equal(len(peer.Parents()), 0)
 				assert.True(peer.FSM.Is(resource.PeerStateRunning))
 				assert.True(peer.Task.FSM.Is(resource.TaskStatePending))
 			},
@@ -472,6 +489,21 @@ func TestScheduling_ScheduleParentAndCandidateParents(t *testing.T) {
 			},
 			expect: func(t *testing.T, peer *resource.Peer) {
 				assert := assert.New(t)
+				assert.True(peer.FSM.Is(resource.PeerStateRunning))
+				assert.True(peer.Task.FSM.Is(resource.TaskStatePending))
+			},
+		},
+		{
+			name: "peer exceeded MaxScheduleCount and peer stream load failed",
+			mock: func(cancel context.CancelFunc, peer *resource.Peer, seedPeer *resource.Peer, blocklist set.SafeSet[string], stream schedulerv1.Scheduler_ReportPieceResultServer, mr *schedulerv1mocks.MockScheduler_ReportPieceResultServerMockRecorder, md *configmocks.MockDynconfigInterfaceMockRecorder) {
+				task := peer.Task
+				task.StorePeer(peer)
+				peer.ScheduleCount.Store(5)
+				peer.FSM.SetState(resource.PeerStateRunning)
+			},
+			expect: func(t *testing.T, peer *resource.Peer) {
+				assert := assert.New(t)
+				assert.Equal(len(peer.Parents()), 0)
 				assert.True(peer.FSM.Is(resource.PeerStateRunning))
 				assert.True(peer.Task.FSM.Is(resource.TaskStatePending))
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add GetSeedPeers to dfdaemon dynconfig.
- Add MaxScheduleCount to scheduler. When peer schedule count exceeded the MaxScheduleCount, scheduler will notify peer back-to-source.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
