### PR TITLE
chore: optimize stream task id

### DIFF
--- a/client/daemon/peer/peertask_manager.go
+++ b/client/daemon/peer/peertask_manager.go
@@ -341,6 +341,7 @@ func (ptm *peerTaskManager) StartStreamTask(ctx context.Context, req *StreamTask
 		IsMigrating: false,
 	}
 
+	taskID := idgen.TaskIDV1(req.URL, req.URLMeta)
 	if ptm.Multiplex {
 		// try breakpoint resume for task has range header
 		if req.Range != nil && !ptm.SplitRunningTasks {
@@ -357,14 +358,14 @@ func (ptm *peerTaskManager) StartStreamTask(ctx context.Context, req *StreamTask
 		}
 
 		// reuse by completed task
-		r, attr, ok := ptm.tryReuseStreamPeerTask(ctx, req)
+		r, attr, ok := ptm.tryReuseStreamPeerTask(ctx, taskID, req)
 		if ok {
 			metrics.PeerTaskCacheHitCount.Add(1)
 			return r, attr, nil
 		}
 	}
 
-	pt, err := ptm.newStreamTask(ctx, peerTaskRequest, req.Range)
+	pt, err := ptm.newStreamTask(ctx, taskID, peerTaskRequest, req.Range)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/daemon/peer/peertask_manager_test.go
+++ b/client/daemon/peer/peertask_manager_test.go
@@ -910,6 +910,7 @@ func (ts *testSpec) runConductorTest(assert *testifyassert.Assertions, require *
 
 	// test reuse stream task
 	rc, _, ok := ptm.tryReuseStreamPeerTask(context.Background(),
+		taskID,
 		&StreamTaskRequest{
 			URL:     ts.url,
 			URLMeta: urlMeta,

--- a/client/daemon/peer/peertask_reuse.go
+++ b/client/daemon/peer/peertask_reuse.go
@@ -225,9 +225,8 @@ func (ptm *peerTaskManager) storePartialFile(ctx context.Context, request *FileT
 	return nil
 }
 
-func (ptm *peerTaskManager) tryReuseStreamPeerTask(ctx context.Context,
+func (ptm *peerTaskManager) tryReuseStreamPeerTask(ctx context.Context, taskID string,
 	request *StreamTaskRequest) (io.ReadCloser, map[string]string, bool) {
-	taskID := idgen.TaskIDV1(request.URL, request.URLMeta)
 	var (
 		reuse      *storage.ReusePeerTask
 		reuseRange *http.Range // the range of parent peer task data to read

--- a/client/daemon/peer/peertask_reuse_test.go
+++ b/client/daemon/peer/peertask_reuse_test.go
@@ -33,11 +33,11 @@ import (
 
 	commonv1 "d7y.io/api/v2/pkg/apis/common/v1"
 	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
-	"d7y.io/dragonfly/v2/pkg/idgen"
 
 	"d7y.io/dragonfly/v2/client/daemon/storage"
 	"d7y.io/dragonfly/v2/client/daemon/storage/mocks"
 	"d7y.io/dragonfly/v2/client/daemon/test"
+	"d7y.io/dragonfly/v2/pkg/idgen"
 	"d7y.io/dragonfly/v2/pkg/net/http"
 )
 

--- a/client/daemon/peer/peertask_reuse_test.go
+++ b/client/daemon/peer/peertask_reuse_test.go
@@ -33,6 +33,7 @@ import (
 
 	commonv1 "d7y.io/api/v2/pkg/apis/common/v1"
 	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
+	"d7y.io/dragonfly/v2/pkg/idgen"
 
 	"d7y.io/dragonfly/v2/client/daemon/storage"
 	"d7y.io/dragonfly/v2/client/daemon/storage/mocks"
@@ -713,7 +714,9 @@ func TestReuseStreamPeerTask(t *testing.T) {
 					},
 				},
 			}
-			tc.verify(ptm.tryReuseStreamPeerTask(context.Background(), tc.request))
+
+			taskID := idgen.TaskIDV1(tc.request.URL, tc.request.URLMeta)
+			tc.verify(ptm.tryReuseStreamPeerTask(context.Background(), taskID, tc.request))
 		})
 	}
 }

--- a/client/daemon/peer/peertask_stream.go
+++ b/client/daemon/peer/peertask_stream.go
@@ -33,7 +33,6 @@ import (
 	"d7y.io/dragonfly/v2/client/daemon/storage"
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/internal/util"
-	"d7y.io/dragonfly/v2/pkg/idgen"
 	"d7y.io/dragonfly/v2/pkg/net/http"
 )
 
@@ -73,6 +72,7 @@ type resumeStreamTask struct {
 
 func (ptm *peerTaskManager) newStreamTask(
 	ctx context.Context,
+	taskID string,
 	request *schedulerv1.PeerTaskRequest,
 	rg *http.Range) (*streamTask, error) {
 	metrics.StreamTaskCount.Add(1)
@@ -87,7 +87,6 @@ func (ptm *peerTaskManager) newStreamTask(
 		parent = ptm.prefetchParentTask(request, "")
 	}
 
-	taskID := idgen.TaskIDV1(request.Url, request.UrlMeta)
 	ptc, err := ptm.getPeerTaskConductor(ctx, taskID, request, limit, parent, rg, "", false)
 	if err != nil {
 		return nil, err

--- a/client/daemon/peer/peertask_stream_backsource_partial_test.go
+++ b/client/daemon/peer/peertask_stream_backsource_partial_test.go
@@ -317,7 +317,7 @@ func TestStreamPeerTask_BackSource_Partial_WithContentLength(t *testing.T) {
 		PeerHost: &schedulerv1.PeerHost{},
 	}
 	ctx := context.Background()
-	pt, err := ptm.newStreamTask(ctx, req, nil)
+	pt, err := ptm.newStreamTask(ctx, taskID, req, nil)
 	assert.Nil(err, "new stream peer task")
 
 	rc, _, err := pt.Start(ctx)

--- a/client/daemon/peer/peertask_stream_resume_test.go
+++ b/client/daemon/peer/peertask_stream_resume_test.go
@@ -35,6 +35,7 @@ import (
 	commonv1 "d7y.io/api/v2/pkg/apis/common/v1"
 	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
 	schedulerv1mocks "d7y.io/api/v2/pkg/apis/scheduler/v1/mocks"
+
 	"d7y.io/dragonfly/v2/client/config"
 	"d7y.io/dragonfly/v2/client/daemon/storage"
 	"d7y.io/dragonfly/v2/client/daemon/test"

--- a/client/daemon/peer/peertask_stream_resume_test.go
+++ b/client/daemon/peer/peertask_stream_resume_test.go
@@ -35,7 +35,6 @@ import (
 	commonv1 "d7y.io/api/v2/pkg/apis/common/v1"
 	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
 	schedulerv1mocks "d7y.io/api/v2/pkg/apis/scheduler/v1/mocks"
-
 	"d7y.io/dragonfly/v2/client/config"
 	"d7y.io/dragonfly/v2/client/daemon/storage"
 	"d7y.io/dragonfly/v2/client/daemon/test"
@@ -215,7 +214,8 @@ func TestStreamPeerTask_Resume(t *testing.T) {
 
 	// set up parent task
 	wg.Add(1)
-	pt, err := ptm.newStreamTask(ctx, req, nil)
+
+	pt, err := ptm.newStreamTask(ctx, taskID, req, nil)
 	assert.Nil(err, "new parent stream peer task")
 
 	rc, _, err := pt.Start(ctx)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Optimize superfluous `idgen.TaskIDV1` in stream task.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
