### PR TITLE
only stop networkTopology when it is not nil

### DIFF
--- a/client/daemon/daemon.go
+++ b/client/daemon/daemon.go
@@ -862,7 +862,9 @@ func (cd *clientDaemon) Stop() {
 			logger.Errorf("announcer stop failed %s", err)
 		}
 
-		cd.networkTopology.Stop()
+		if cd.networkTopology != nil {
+			cd.networkTopology.Stop()
+		}
 
 		if err := cd.dynconfig.Stop(); err != nil {
 			logger.Errorf("dynconfig client closed failed %s", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `cd.networkTopology` is not be checked before calling the `Stop` method, a nil pointer panic will happen during the peer stop procedure.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x14d2c1b]

goroutine 321 [running]:
panic({0x169f5a0?, 0x2d44570?})
    /usr/local/go/src/runtime/panic.go:1017 +0x3ac fp=0xc000439cc8 sp=0xc000439c18 pc=0x43b2ec
runtime.panicmem(...)
    /usr/local/go/src/runtime/panic.go:261
runtime.sigpanic()
    /usr/local/go/src/runtime/signal_unix.go:861 +0x378 fp=0xc000439d28 sp=0xc000439cc8 pc=0x4526d8
d7y.io/dragonfly/v2/client/daemon.(*clientDaemon).Stop.func1()
    /var/run/dragonfly2-seed-peer/client/daemon/daemon.go:865 +0x57b fp=0xc000439e80 sp=0xc000439d28 pc=0x14d2c1b
sync.(*Once).doSlow(0x9715ac?, 0xc000d924e0?)
    /usr/local/go/src/sync/once.go:74 +0xbf fp=0xc000439ee0 sp=0xc000439e80 pc=0x47d39f
sync.(*Once).Do(...)
    /usr/local/go/src/sync/once.go:65
d7y.io/dragonfly/v2/client/daemon.(*clientDaemon).Stop(0xc000d924e0?)
    /var/run/dragonfly2-seed-peer/client/daemon/daemon.go:816 +0x3b fp=0xc000439f10 sp=0xc000439ee0 pc=0x14d267b
d7y.io/dragonfly/v2/cmd/dfget/cmd.runDaemon.func2()
    /var/run/dragonfly2-seed-peer/cmd/dfget/cmd/daemon.go:198 +0x1c fp=0xc000439f28 sp=0xc000439f10 pc=0x14e1c9c
d7y.io/dragonfly/v2/cmd/dependency.SetupQuitSignalHandler.func1()
    /var/run/dragonfly2-seed-peer/cmd/dependency/dependency.go:152 +0xe8 fp=0xc000439fe0 sp=0xc000439f28 pc=0x13f6188
runtime.goexit()
    /usr/local/go/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000439fe8 sp=0xc000439fe0 pc=0x471a01
created by d7y.io/dragonfly/v2/cmd/dependency.SetupQuitSignalHandler in goroutine 1
    /var/run/dragonfly2-seed-peer/cmd/dependency/dependency.go:144 +0xd9
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
