### PR TITLE
feat: re-register when scheduler go away

### DIFF
--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -788,6 +788,17 @@ func (pt *peerTaskConductor) updateSynchronizers(lastNum int32, p *schedulerv1.P
 	return desiredPiece
 }
 
+/*
+When scheduler go away before a peer task done, we will receive the following error message:
+
+	receive peer packet failed: rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data: "graceful_stop"
+
+The underlay error is "connection error: desc = \"error reading from server: EOF\"", only can be checked by searching message.
+
+refer grpc-go link:
+https://github.com/grpc/grpc-go/blob/v1.60.1/test/goaway_test.go#L118
+https://github.com/grpc/grpc-go/blob/v1.60.1/internal/transport/http2_client.go#L987
+*/
 func isSchedulerGoAway(err error) bool {
 	return strings.Contains(err.Error(), `connection error: desc = "error reading from server: EOF"`)
 }

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -789,7 +789,7 @@ func (pt *peerTaskConductor) updateSynchronizers(lastNum int32, p *schedulerv1.P
 }
 
 /*
-When scheduler go away before a peer task done, we will receive the following error message:
+When one scheduler goes away before the peer task done, we will receive the following error message:
 
 	receive peer packet failed: rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data: "graceful_stop"
 

--- a/client/daemon/peer/peertask_conductor.go
+++ b/client/daemon/peer/peertask_conductor.go
@@ -788,7 +788,7 @@ func (pt *peerTaskConductor) updateSynchronizers(lastNum int32, p *schedulerv1.P
 }
 
 /*
-When one scheduler goes away before the peer task done, we will receive the following error message:
+When one scheduler goes away(force killed or broken tcp connection) before the peer task done, we will receive the following error message:
 
 	receive peer packet failed: rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data: "graceful_stop"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When one scheduler goes away, the daemon will print `receive peer packet failed: rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data: "graceful_stop"` and marks peer task failed.

The daemon should re-register to other schedulers instead of failed immediately.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
