### PR TITLE
fix: scheduler storage buffer size limit

### DIFF
--- a/cmd/trainer/cmd/root.go
+++ b/cmd/trainer/cmd/root.go
@@ -74,7 +74,7 @@ preprocessing original record data, establing datasets and training machine lear
 		if err := logger.InitTrainer(cfg.Verbose, cfg.Console, d.LogDir(), rotateConfig); err != nil {
 			return fmt.Errorf("init trainer logger: %w", err)
 		}
-		logger.RedirectStdoutAndStderr(cfg.Console, path.Join(d.LogDir(), types.SchedulerName))
+		logger.RedirectStdoutAndStderr(cfg.Console, path.Join(d.LogDir(), types.TrainerName))
 
 		return runTrainer(ctx, d)
 	},

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -615,7 +615,7 @@ func (cfg *Config) Validate() error {
 		return errors.New("storage requires parameter maxBackups")
 	}
 
-	if cfg.Storage.BufferSize <= 0 {
+	if cfg.Storage.BufferSize < 0 {
 		return errors.New("storage requires parameter bufferSize")
 	}
 

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -732,7 +732,7 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.Manager = mockManagerConfig
 				cfg.Database.Redis = mockRedisConfig
 				cfg.Job = mockJobConfig
-				cfg.Storage.BufferSize = 0
+				cfg.Storage.BufferSize = -1
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix buffer size limit: 
The parameter bufferSize in scheduler storage can not be set to 0.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
