### PR TITLE
feat: optimize graph based on sync.Map

### DIFF
--- a/pkg/container/set/safe_set.go
+++ b/pkg/container/set/safe_set.go
@@ -47,7 +47,11 @@ func (s *safeSet[T]) Values() []T {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var result []T
+	if len(s.data) == 0 {
+		return nil
+	}
+
+	result := make([]T, 0, len(s.data))
 	for k := range s.data {
 		result = append(result, k)
 	}

--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -34,7 +34,11 @@ func New[T comparable]() Set[T] {
 }
 
 func (s *set[T]) Values() []T {
-	var result []T
+	if len(*s) == 0 {
+		return nil
+	}
+
+	result := make([]T, 0, len(*s))
 	for k := range *s {
 		result = append(result, k)
 	}

--- a/pkg/graph/dag/dag_test.go
+++ b/pkg/graph/dag/dag_test.go
@@ -179,17 +179,17 @@ func TestDAG_VertexCount(t *testing.T) {
 				}
 
 				d.VertexCount()
-				assert.Equal(d.VertexCount(), 1)
+				assert.Equal(d.VertexCount(), uint64(1))
 
 				d.DeleteVertex(mockVertexID)
-				assert.Equal(d.VertexCount(), 0)
+				assert.Equal(d.VertexCount(), uint64(0))
 			},
 		},
 		{
 			name: "empty dag",
 			expect: func(t *testing.T, d DAG[string]) {
 				assert := assert.New(t)
-				assert.Equal(d.VertexCount(), 0)
+				assert.Equal(d.VertexCount(), uint64(0))
 			},
 		},
 	}
@@ -290,38 +290,6 @@ func TestDAG_GetRandomVertices(t *testing.T) {
 
 				vertices = d.GetRandomVertices(1)
 				assert.Equal(len(vertices), 0)
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			d := NewDAG[string]()
-			tc.expect(t, d)
-		})
-	}
-}
-
-func TestDAG_GetVertexKeys(t *testing.T) {
-	tests := []struct {
-		name   string
-		expect func(t *testing.T, d DAG[string])
-	}{
-		{
-			name: "get keys of vertices",
-			expect: func(t *testing.T, d DAG[string]) {
-				assert := assert.New(t)
-				if err := d.AddVertex(mockVertexID, mockVertexValue); err != nil {
-					assert.NoError(err)
-				}
-
-				keys := d.GetVertexKeys()
-				assert.Equal(len(keys), 1)
-				assert.Equal(keys[0], mockVertexID)
-
-				d.DeleteVertex(mockVertexID)
-				keys = d.GetVertexKeys()
-				assert.Equal(len(keys), 0)
 			},
 		},
 	}
@@ -965,7 +933,25 @@ func BenchmarkDAG_DeleteVertex(b *testing.B) {
 	}
 }
 
-func BenchmarkDAG_GetRandomKeys(b *testing.B) {
+func BenchmarkDAG_GetVertices(b *testing.B) {
+	d := NewDAG[string]()
+	for n := 0; n < b.N; n++ {
+		id := fmt.Sprint(n)
+		if err := d.AddVertex(id, string(id)); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		vertices := d.GetVertices()
+		if len(vertices) != b.N {
+			b.Fatal(errors.New("get vertices failed"))
+		}
+	}
+}
+
+func BenchmarkDAG_GetRandomVertices(b *testing.B) {
 	d := NewDAG[string]()
 	for n := 0; n < b.N; n++ {
 		id := fmt.Sprint(n)

--- a/pkg/graph/dag/mocks/dag_mock.go
+++ b/pkg/graph/dag/mocks/dag_mock.go
@@ -191,20 +191,6 @@ func (mr *MockDAGMockRecorder[T]) GetVertex(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVertex", reflect.TypeOf((*MockDAG[T])(nil).GetVertex), id)
 }
 
-// GetVertexKeys mocks base method.
-func (m *MockDAG[T]) GetVertexKeys() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVertexKeys")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// GetVertexKeys indicates an expected call of GetVertexKeys.
-func (mr *MockDAGMockRecorder[T]) GetVertexKeys() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVertexKeys", reflect.TypeOf((*MockDAG[T])(nil).GetVertexKeys))
-}
-
 // GetVertices mocks base method.
 func (m *MockDAG[T]) GetVertices() map[string]*dag.Vertex[T] {
 	m.ctrl.T.Helper()
@@ -220,10 +206,10 @@ func (mr *MockDAGMockRecorder[T]) GetVertices() *gomock.Call {
 }
 
 // VertexCount mocks base method.
-func (m *MockDAG[T]) VertexCount() int {
+func (m *MockDAG[T]) VertexCount() uint64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VertexCount")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(uint64)
 	return ret0
 }
 

--- a/pkg/graph/dag/vertex.go
+++ b/pkg/graph/dag/vertex.go
@@ -24,8 +24,8 @@ import (
 type Vertex[T comparable] struct {
 	ID       string
 	Value    T
-	Parents  set.SafeSet[*Vertex[T]]
-	Children set.SafeSet[*Vertex[T]]
+	Parents  set.Set[*Vertex[T]]
+	Children set.Set[*Vertex[T]]
 }
 
 // New returns a new Vertex instance.
@@ -33,8 +33,8 @@ func NewVertex[T comparable](id string, value T) *Vertex[T] {
 	return &Vertex[T]{
 		ID:       id,
 		Value:    value,
-		Parents:  set.NewSafeSet[*Vertex[T]](),
-		Children: set.NewSafeSet[*Vertex[T]](),
+		Parents:  set.New[*Vertex[T]](),
+		Children: set.New[*Vertex[T]](),
 	}
 }
 

--- a/pkg/graph/dg/dg_test.go
+++ b/pkg/graph/dg/dg_test.go
@@ -179,17 +179,17 @@ func TestDG_VertexCount(t *testing.T) {
 				}
 
 				d.VertexCount()
-				assert.Equal(d.VertexCount(), 1)
+				assert.Equal(d.VertexCount(), uint64(1))
 
 				d.DeleteVertex(mockVertexID)
-				assert.Equal(d.VertexCount(), 0)
+				assert.Equal(d.VertexCount(), uint64(0))
 			},
 		},
 		{
 			name: "empty dg",
 			expect: func(t *testing.T, d DG[string]) {
 				assert := assert.New(t)
-				assert.Equal(d.VertexCount(), 0)
+				assert.Equal(d.VertexCount(), uint64(0))
 			},
 		},
 	}
@@ -287,38 +287,6 @@ func TestDG_GetRandomVertices(t *testing.T) {
 
 				vertices = d.GetRandomVertices(1)
 				assert.Equal(len(vertices), 0)
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			d := NewDG[string]()
-			tc.expect(t, d)
-		})
-	}
-}
-
-func TestDG_GetVertexKeys(t *testing.T) {
-	tests := []struct {
-		name   string
-		expect func(t *testing.T, d DG[string])
-	}{
-		{
-			name: "get keys of vertices",
-			expect: func(t *testing.T, d DG[string]) {
-				assert := assert.New(t)
-				if err := d.AddVertex(mockVertexID, mockVertexValue); err != nil {
-					assert.NoError(err)
-				}
-
-				keys := d.GetVertexKeys()
-				assert.Equal(len(keys), 1)
-				assert.Equal(keys[0], mockVertexID)
-
-				d.DeleteVertex(mockVertexID)
-				keys = d.GetVertexKeys()
-				assert.Equal(len(keys), 0)
 			},
 		},
 	}
@@ -897,7 +865,25 @@ func BenchmarkDG_DeleteVertex(b *testing.B) {
 	}
 }
 
-func BenchmarkDG_GetRandomKeys(b *testing.B) {
+func BenchmarkDAG_GetVertices(b *testing.B) {
+	d := NewDG[string]()
+	for n := 0; n < b.N; n++ {
+		id := fmt.Sprint(n)
+		if err := d.AddVertex(id, string(id)); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		vertices := d.GetVertices()
+		if len(vertices) != b.N {
+			b.Fatal(errors.New("get vertices failed"))
+		}
+	}
+}
+
+func BenchmarkDG_GetRandomVertices(b *testing.B) {
 	d := NewDG[string]()
 	for n := 0; n < b.N; n++ {
 		id := fmt.Sprint(n)

--- a/pkg/graph/dg/mocks/dg_mock.go
+++ b/pkg/graph/dg/mocks/dg_mock.go
@@ -191,20 +191,6 @@ func (mr *MockDGMockRecorder[T]) GetVertex(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVertex", reflect.TypeOf((*MockDG[T])(nil).GetVertex), id)
 }
 
-// GetVertexKeys mocks base method.
-func (m *MockDG[T]) GetVertexKeys() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVertexKeys")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// GetVertexKeys indicates an expected call of GetVertexKeys.
-func (mr *MockDGMockRecorder[T]) GetVertexKeys() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVertexKeys", reflect.TypeOf((*MockDG[T])(nil).GetVertexKeys))
-}
-
 // GetVertices mocks base method.
 func (m *MockDG[T]) GetVertices() map[string]*dg.Vertex[T] {
 	m.ctrl.T.Helper()
@@ -220,10 +206,10 @@ func (mr *MockDGMockRecorder[T]) GetVertices() *gomock.Call {
 }
 
 // VertexCount mocks base method.
-func (m *MockDG[T]) VertexCount() int {
+func (m *MockDG[T]) VertexCount() uint64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VertexCount")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(uint64)
 	return ret0
 }
 

--- a/pkg/graph/dg/vertex.go
+++ b/pkg/graph/dg/vertex.go
@@ -24,8 +24,8 @@ import (
 type Vertex[T comparable] struct {
 	ID       string
 	Value    T
-	Parents  set.SafeSet[*Vertex[T]]
-	Children set.SafeSet[*Vertex[T]]
+	Parents  set.Set[*Vertex[T]]
+	Children set.Set[*Vertex[T]]
 }
 
 // New returns a new Vertex instance.
@@ -33,8 +33,8 @@ func NewVertex[T comparable](id string, value T) *Vertex[T] {
 	return &Vertex[T]{
 		ID:       id,
 		Value:    value,
-		Parents:  set.NewSafeSet[*Vertex[T]](),
-		Children: set.NewSafeSet[*Vertex[T]](),
+		Parents:  set.New[*Vertex[T]](),
+		Children: set.New[*Vertex[T]](),
 	}
 }
 

--- a/scheduler/resource/task.go
+++ b/scheduler/resource/task.go
@@ -269,7 +269,7 @@ func (t *Task) DeletePeer(key string) {
 
 // PeerCount returns count of peer.
 func (t *Task) PeerCount() int {
-	return t.DAG.VertexCount()
+	return int(t.DAG.VertexCount())
 }
 
 // AddPeerEdge adds inedges between two peers.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
![image](https://github.com/dragonflyoss/Dragonfly2/assets/15955374/7b259ee8-48fa-41dc-9a91-5b2b35abc1f4)

`dag.GetVertices` calls `concurrent-map.fanIn`.
`dag.GetRandomVertices` calls `concurrent-map.Keys`.

### Benchmark

#### Benchtime 100x

`sync.Map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	     100	       943.1 ns/op	     379 B/op	       8 allocs/op
BenchmarkDAG_DeleteVertex-12                  	     100	       221.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	     100	     13220 ns/op	    8280 B/op	       4 allocs/op
BenchmarkDAG_GetRandomVertices-12             	     100	      3158 ns/op	     429 B/op	       1 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	     100	       372.3 ns/op	      30 B/op	       0 allocs/op
BenchmarkDAG_AddEdge-12                       	     100	     13555 ns/op	    3794 B/op	      55 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	     100	     18151 ns/op	    4130 B/op	      45 allocs/op
BenchmarkDAG_DeleteEdge-12                    	     100	       163.1 ns/op	       0 B/op	       0 allocs/op
```

`concurrent-map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	     100	      1027 ns/op	     306 B/op	       7 allocs/op
BenchmarkDAG_DeleteVertex-12                  	     100	       187.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	     100	     82795 ns/op	   29776 B/op	     211 allocs/op
BenchmarkDAG_GetRandomVertices-12             	     100	     57982 ns/op	   12243 B/op	      72 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	     100	       648.7 ns/op	      53 B/op	       2 allocs/op
BenchmarkDAG_AddEdge-12                       	     100	     14631 ns/op	    3798 B/op	      55 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	     100	     28167 ns/op	    5126 B/op	     127 allocs/op
BenchmarkDAG_DeleteEdge-12                    	     100	       242.3 ns/op	       0 B/op	       0 allocs/op
```

#### Benchtime 200x

`sync.Map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	     200	       864.0 ns/op	     368 B/op	       8 allocs/op
BenchmarkDAG_DeleteVertex-12                  	     200	       222.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	     200	     26645 ns/op	   14424 B/op	       4 allocs/op
BenchmarkDAG_GetRandomVertices-12             	     200	      5833 ns/op	     855 B/op	       1 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	     200	       402.5 ns/op	      31 B/op	       0 allocs/op
BenchmarkDAG_AddEdge-12                       	     200	     28191 ns/op	    8100 B/op	     107 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	     200	     40909 ns/op	    9431 B/op	      97 allocs/op
BenchmarkDAG_DeleteEdge-12                    	     200	       173.5 ns/op	       0 B/op	       0 allocs/op
```

`concurrent-map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	     200	       573.6 ns/op	     273 B/op	       7 allocs/op
BenchmarkDAG_DeleteVertex-12                  	     200	       175.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	     200	    104406 ns/op	   48495 B/op	     212 allocs/op
BenchmarkDAG_GetRandomVertices-12             	     200	     73090 ns/op	   16377 B/op	      72 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	     200	       595.5 ns/op	      54 B/op	       2 allocs/op
BenchmarkDAG_AddEdge-12                       	     200	     27644 ns/op	    8095 B/op	     107 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	     200	     52376 ns/op	   11617 B/op	     278 allocs/op
BenchmarkDAG_DeleteEdge-12                    	     200	       209.7 ns/op	       0 B/op	       0 allocs/op
```

#### Benchtime 500x

`sync.Map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	     500	       729.0 ns/op	     337 B/op	       8 allocs/op
BenchmarkDAG_DeleteVertex-12                  	     500	       187.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	     500	     36739 ns/op	   28769 B/op	       4 allocs/op
BenchmarkDAG_GetRandomVertices-12             	     500	      5532 ns/op	    2145 B/op	       1 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	     500	       349.0 ns/op	      31 B/op	       0 allocs/op
BenchmarkDAG_AddEdge-12                       	     500	     73208 ns/op	   22240 B/op	     260 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	     500	    112766 ns/op	   27286 B/op	     249 allocs/op
BenchmarkDAG_DeleteEdge-12                    	     500	       160.1 ns/op	       0 B/op	       0 allocs/op
PASS
```

`concurrent-map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	     500	       682.1 ns/op	     340 B/op	       7 allocs/op
BenchmarkDAG_DeleteVertex-12                  	     500	       165.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	     500	    169293 ns/op	   92843 B/op	     217 allocs/op
BenchmarkDAG_GetRandomVertices-12             	     500	    113078 ns/op	   29966 B/op	      72 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	     500	       578.1 ns/op	      55 B/op	       2 allocs/op
BenchmarkDAG_AddEdge-12                       	     500	     66000 ns/op	   22229 B/op	     259 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	     500	    141998 ns/op	   33042 B/op	     730 allocs/op
BenchmarkDAG_DeleteEdge-12                    	     500	       217.8 ns/op	       0 B/op	       0 allocs/op
```

#### Benchtime 1000x

`sync.Map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	    1000	       704.7 ns/op	     336 B/op	       8 allocs/op
BenchmarkDAG_DeleteVertex-12                  	    1000	       163.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	    1000	     62127 ns/op	   57445 B/op	       4 allocs/op
BenchmarkDAG_GetRandomVertices-12             	    1000	      9519 ns/op	    4281 B/op	       1 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	    1000	       313.2 ns/op	      31 B/op	       0 allocs/op
BenchmarkDAG_AddEdge-12                       	    1000	    115281 ns/op	   44626 B/op	     513 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	    1000	    200593 ns/op	   55668 B/op	     503 allocs/op
BenchmarkDAG_DeleteEdge-12                    	    1000	       144.0 ns/op	       0 B/op	       0 allocs/op
```

`concurrent-map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	    1000	       650.5 ns/op	     350 B/op	       7 allocs/op
BenchmarkDAG_DeleteVertex-12                  	    1000	       181.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	    1000	    256066 ns/op	  177430 B/op	     228 allocs/op
BenchmarkDAG_GetRandomVertices-12             	    1000	    164286 ns/op	   52572 B/op	      72 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	    1000	       482.3 ns/op	      55 B/op	       2 allocs/op
BenchmarkDAG_AddEdge-12                       	    1000	    126466 ns/op	   44616 B/op	     513 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	    1000	    236006 ns/op	   67444 B/op	    1484 allocs/op
BenchmarkDAG_DeleteEdge-12                    	    1000	       172.1 ns/op	       0 B/op	       0 allocs/op
```

#### Benchtime 2000x

`sync.Map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	    2000	       629.2 ns/op	     335 B/op	       8 allocs/op
BenchmarkDAG_DeleteVertex-12                  	    2000	       157.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	    2000	    128119 ns/op	  114783 B/op	       4 allocs/op
BenchmarkDAG_GetRandomVertices-12             	    2000	     19159 ns/op	    8478 B/op	       1 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	    2000	       315.4 ns/op	      31 B/op	       0 allocs/op
BenchmarkDAG_AddEdge-12                       	    2000	    234313 ns/op	   89441 B/op	    1020 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	    2000	    373789 ns/op	  112454 B/op	    1010 allocs/op
BenchmarkDAG_DeleteEdge-12                    	    2000	       120.7 ns/op	       0 B/op	       0 allocs/op
```

`concurrent-map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	    2000	       608.2 ns/op	     365 B/op	       7 allocs/op
BenchmarkDAG_DeleteVertex-12                  	    2000	       167.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	    2000	    504419 ns/op	  344498 B/op	     249 allocs/op
BenchmarkDAG_GetRandomVertices-12             	    2000	    310858 ns/op	   97731 B/op	      72 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	    2000	       510.5 ns/op	      55 B/op	       2 allocs/op
BenchmarkDAG_AddEdge-12                       	    2000	    244671 ns/op	   89414 B/op	    1020 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	    2000	    496890 ns/op	  136214 B/op	    2991 allocs/op
BenchmarkDAG_DeleteEdge-12                    	    2000	       214.6 ns/op	       0 B/op	       0 allocs/op
```

#### Benchtime 5000x

`sync.Map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	    5000	       641.4 ns/op	     311 B/op	       8 allocs/op
BenchmarkDAG_DeleteVertex-12                  	    5000	       175.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	    5000	    370481 ns/op	  229473 B/op	       4 allocs/op
BenchmarkDAG_GetRandomVertices-12             	    5000	     52904 ns/op	   21552 B/op	       2 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	    5000	       292.5 ns/op	      31 B/op	       0 allocs/op
BenchmarkDAG_AddEdge-12                       	    5000	    609847 ns/op	  217224 B/op	    2537 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	    5000	    971242 ns/op	  276391 B/op	    2527 allocs/op
BenchmarkDAG_DeleteEdge-12                    	    5000	       135.3 ns/op	       0 B/op	       0 allocs/op
```

`concurrent-map`
```shell
goos: darwin
goarch: amd64
pkg: d7y.io/dragonfly/v2/pkg/graph/dag
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDAG_AddVertex-12                     	    5000	       603.6 ns/op	     342 B/op	       7 allocs/op
BenchmarkDAG_DeleteVertex-12                  	    5000	       192.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkDAG_GetVertices-12                   	    5000	   1376891 ns/op	  737590 B/op	     289 allocs/op
BenchmarkDAG_GetRandomVertices-12             	    5000	    864467 ns/op	  233696 B/op	      72 allocs/op
BenchmarkDAG_DeleteVertexWithMultiEdges-12    	    5000	       548.6 ns/op	      55 B/op	       2 allocs/op
BenchmarkDAG_AddEdge-12                       	    5000	    758226 ns/op	  217201 B/op	    2537 allocs/op
BenchmarkDAG_AddEdgeWithMultiEdges-12         	    5000	   1461472 ns/op	  336138 B/op	    7508 allocs/op
BenchmarkDAG_DeleteEdge-12                    	    5000	       222.6 ns/op	       0 B/op	       0 allocs/op
```

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
