### PR TITLE
refactor: Rename 'Path' field to 'Input' in CacheOption struct

### DIFF
--- a/client/config/dfcache.go
+++ b/client/config/dfcache.go
@@ -70,9 +70,8 @@ type CacheOption struct {
 	// Output full output path for export task
 	Output string `yaml:"output,omitempty" mapstructure:"output,omitempty"`
 
-	// Path full input path for import task
-	// TODO: change to Input
-	Path string `yaml:"path,omitempty" mapstructure:"path,omitempty"`
+	// Input full input path for import task
+	Input string `yaml:"input,omitempty" mapstructure:"input,omitempty"`
 
 	// RateLimit limits export task
 	RateLimit rate.Limit `yaml:"rateLimit,omitempty" mapstructure:"rateLimit,omitempty"`
@@ -140,15 +139,15 @@ func ConvertCacheStat(cfg *CacheOption, args []string) error {
 
 func convertCacheImport(cfg *CacheOption, args []string) error {
 	var err error
-	if cfg.Path == "" && len(args) > 0 {
-		cfg.Path = args[0]
+	if cfg.Input == "" && len(args) > 0 {
+		cfg.Input = args[0]
 	}
-	if cfg.Path == "" {
+	if cfg.Input == "" {
 		return fmt.Errorf("missing input file: %w", dferrors.ErrInvalidArgument)
 	}
 
-	if cfg.Path, err = filepath.Abs(cfg.Path); err != nil {
-		return fmt.Errorf("get absulate path for %s: %w", cfg.Path, err)
+	if cfg.Input, err = filepath.Abs(cfg.Input); err != nil {
+		return fmt.Errorf("get absulate path for %s: %w", cfg.Input, err)
 	}
 	return nil
 }
@@ -197,15 +196,15 @@ func (cfg *CacheOption) String() string {
 }
 
 func (cfg *CacheOption) checkInput() error {
-	stat, err := os.Stat(cfg.Path)
+	stat, err := os.Stat(cfg.Input)
 	if err != nil {
-		return fmt.Errorf("stat input path %q: %w", cfg.Path, err)
+		return fmt.Errorf("stat input path %q: %w", cfg.Input, err)
 	}
 	if stat.IsDir() {
-		return fmt.Errorf("path[%q] is directory but requires file path", cfg.Path)
+		return fmt.Errorf("path[%q] is directory but requires file path", cfg.Input)
 	}
-	if err := syscall.Access(cfg.Path, syscall.O_RDONLY); err != nil {
-		return fmt.Errorf("access %q: %w", cfg.Path, err)
+	if err := syscall.Access(cfg.Input, syscall.O_RDONLY); err != nil {
+		return fmt.Errorf("access %q: %w", cfg.Input, err)
 	}
 	return nil
 }

--- a/client/dfcache/dfcache.go
+++ b/client/dfcache/dfcache.go
@@ -120,7 +120,7 @@ func Import(cfg *config.DfcacheConfig, client dfdaemonclient.V1) error {
 		return fmt.Errorf("validate import option failed: %w", err)
 	}
 
-	wLog := logger.With("Cid", cfg.Cid, "Tag", cfg.Tag, "file", cfg.Path)
+	wLog := logger.With("Cid", cfg.Cid, "Tag", cfg.Tag, "file", cfg.Input)
 	wLog.Info("init success and start to import")
 
 	if cfg.Timeout > 0 {
@@ -162,7 +162,7 @@ func newImportRequest(cfg *config.DfcacheConfig) *dfdaemonv1.ImportTaskRequest {
 	return &dfdaemonv1.ImportTaskRequest{
 		Type: commonv1.TaskType_DfCache,
 		Url:  newCid(cfg.Cid),
-		Path: cfg.Path,
+		Path: cfg.Input,
 		UrlMeta: &commonv1.UrlMeta{
 			Tag: cfg.Tag,
 		},

--- a/cmd/dfcache/cmd/import.go
+++ b/cmd/dfcache/cmd/import.go
@@ -48,7 +48,7 @@ func initImport() {
 	rootCmd.AddCommand(importCmd)
 
 	flags := importCmd.Flags()
-	flags.StringVarP(&dfcacheConfig.Path, "input", "I", "", "import the given file into P2P network")
+	flags.StringVarP(&dfcacheConfig.Input, "input", "I", "", "import the given file into P2P network")
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache import flags to viper: %w", err))
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Rename 'Path' field to 'Input' in CacheOption struct
## Description
This commit refactors the CacheOption struct by renaming the 'Path' field to 'Input'.These changes better reflect the purpose of these fields and improve consistency within the struct.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
