### PR TITLE
Improve the search order for localTaskStore array

### DIFF
--- a/client/daemon/storage/storage_manager.go
+++ b/client/daemon/storage/storage_manager.go
@@ -515,7 +515,8 @@ func (s *storageManager) FindCompletedTask(taskID string) *ReusePeerTask {
 	if !ok {
 		return nil
 	}
-	for _, t := range ts {
+	for i := len(ts) - 1; i > -1; i-- {
+		t := ts[i]
 		if t.invalid.Load() {
 			continue
 		}
@@ -549,7 +550,8 @@ func (s *storageManager) FindPartialCompletedTask(taskID string, rg *nethttp.Ran
 	if !ok {
 		return nil
 	}
-	for _, t := range ts {
+	for i := len(ts) - 1; i > -1; i-- {
+		t := ts[i]
 		if t.invalid.Load() {
 			continue
 		}
@@ -583,7 +585,8 @@ func (s *storageManager) FindCompletedSubTask(taskID string) *ReusePeerTask {
 	if !ok {
 		return nil
 	}
-	for _, t := range ts {
+	for i := len(ts) - 1; i > -1; i-- {
+		t := ts[i]
 		if t.invalid.Load() {
 			continue
 		}


### PR DESCRIPTION
for one of the taskID in `indexTask2PeerTask map[string][]*localTaskStore`, if the first localTaskStore of `[]*localTaskStore` lost the `xxx.cache.xxx` file, then cache for reuse will miss every time, until the first one removed by GC;
in the worst-case, disk will be full filled;

to avoid it, change to `reverse search order` for `[]*localTaskStore` in `FindXXXTask`;
in this case, cache will be hit again after it miss once;