### PR TITLE
fix traffic swap

### DIFF
--- a/client/daemon/peer/traffic_shaper.go
+++ b/client/daemon/peer/traffic_shaper.go
@@ -85,8 +85,7 @@ func (ts *plainTrafficShaper) Start() {
 		for {
 			select {
 			case <-ticker.C:
-				ts.lastSecondBandwidth.Store(ts.usingBandWidth.Load())
-				ts.usingBandWidth.Store(0)
+				ts.lastSecondBandwidth.Store(ts.usingBandWidth.Swap(0))
 			case <-ts.stopCh:
 				return
 			}
@@ -157,8 +156,7 @@ func (ts *samplingTrafficShaper) Start() {
 		for {
 			select {
 			case <-ticker.C:
-				ts.lastSecondBandwidth.Store(ts.usingBandWidth.Load())
-				ts.usingBandWidth.Store(0)
+				ts.lastSecondBandwidth.Store(ts.usingBandWidth.Swap(0))
 				ts.updateLimit()
 			case <-ts.stopCh:
 				return


### PR DESCRIPTION
Using `Swap` to keep the `usingBandWidth` swap into `lastSecondBandwidth` atomically;

otherwise, between `Load()` and `Store(0)`, `usingBandWidth` may be added, that will be dropped unexpectedly;