### PR TITLE
fix: typo in manager database

### DIFF
--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -48,7 +48,7 @@ func New(cfg *config.Config) (*Database, error) {
 	)
 	switch cfg.Database.Type {
 	case config.DatabaseTypeMysql, config.DatabaseTypeMariaDB:
-		db, err = newMyqsl(cfg)
+		db, err = newMysql(cfg)
 		if err != nil {
 			logger.Errorf("mysql: %s", err.Error())
 			return nil, err

--- a/manager/database/mysql.go
+++ b/manager/database/mysql.go
@@ -43,7 +43,7 @@ const (
 	defaultMysqlWriteTimeout = 2 * time.Minute
 )
 
-func newMyqsl(cfg *config.Config) (*gorm.DB, error) {
+func newMysql(cfg *config.Config) (*gorm.DB, error) {
 	mysqlCfg := &cfg.Database.Mysql
 
 	// Format dsn string.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The newMysql() method in manager/database/ was misspelled as newMyqsl().

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
