### PR TITLE
fix: client rpcserver subscriber hang

### DIFF
--- a/client/daemon/rpcserver/subscriber.go
+++ b/client/daemon/rpcserver/subscriber.go
@@ -232,17 +232,17 @@ loop:
 				return err
 			}
 
-			if s.isKnownTotalPieces() {
-				nextPieceNum = s.searchNextPieceNum(nextPieceNum)
-				if int32(nextPieceNum) < s.totalPieces {
-					s.Unlock()
-					msg := "task success, but not all pieces are sent out"
-					s.Errorf(msg)
-					return dferrors.Newf(commonv1.Code_ClientError, msg)
-				}
-			} else {
+			if s.isUnknownTotalPieces() {
 				s.Unlock()
 				msg := "task success, but total pieces is unknown"
+				s.Errorf(msg)
+				return dferrors.Newf(commonv1.Code_ClientError, msg)
+			}
+
+			nextPieceNum = s.searchNextPieceNum(nextPieceNum)
+			if int32(nextPieceNum) < s.totalPieces {
+				s.Unlock()
+				msg := "task success, but not all pieces are sent out"
 				s.Errorf(msg)
 				return dferrors.Newf(commonv1.Code_ClientError, msg)
 			}

--- a/client/daemon/rpcserver/subscriber.go
+++ b/client/daemon/rpcserver/subscriber.go
@@ -165,7 +165,7 @@ func (s *subscriber) receiveRemainingPieceTaskRequests() {
 	}
 }
 
-// totalPieces is [0, n)
+// totalPieces is -1, 0, n
 func (s *subscriber) isKnownTotalPieces() bool {
 	return s.totalPieces > -1
 }
@@ -176,7 +176,8 @@ func (s *subscriber) isUnknownTotalPieces() bool {
 
 func (s *subscriber) sendRemainingPieceTasks() error {
 	// nextPieceNum is the least piece num which did not send to remote peer
-	// may great then total piece count
+	// available values: [0, n], n is total piece count
+	// when nextPieceNum is n, indicate all pieces done
 	var nextPieceNum uint32
 	s.Lock()
 	for i := int32(s.skipPieceCount); ; i++ {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. One remote peer come with `StartNum > 0`, eg: StartNum = 1
2. Local peer run `sendRemainingPieceTasks` and `s.totalPieces` is -1
3. Local peer start to back source or download from other peers with piece 0
4. For piece 0 from local peer, due to `s.totalPieces` is -1, the following check will be skipped and will be sent to remote peer: `if s.totalPieces > -1 && uint32(info.Num) < nextPieceNum`, then `len(s.sentMap)++`
5. `s.totalPieces` will be updated
6. because the piece 0 which should not be sent in step 4, will hit the following logic to break loop
```
     if s.totalPieces > -1 && len(s.sentMap)+int(s.skipPieceCount) == int(s.totalPieces) {
        s.Unlock()
        break loop
    }
```
7. The subscriber will hang until other peers send more pieces.

Solution:

We should not check completeness via fuzzy `len(s.sentMap)`, and check the next piece num is a better method.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
