### PR TITLE
fix: pass through the headers specified by user to preheat job

### DIFF
--- a/manager/job/preheat.go
+++ b/manager/job/preheat.go
@@ -176,9 +176,7 @@ func (p *preheat) getImageLayers(ctx context.Context, args types.PreheatArgs) ([
 		return nil, err
 	}
 
-	// Init docker auth client.
-	client, err := newImageAuthClient(
-		image,
+	opts := []imageAuthClientOption{
 		withHTTPClient(&http.Client{
 			Timeout: p.registryTimeout,
 			Transport: &http.Transport{
@@ -187,7 +185,17 @@ func (p *preheat) getImageLayers(ctx context.Context, args types.PreheatArgs) ([
 			},
 		}),
 		withBasicAuth(args.Username, args.Password),
-	)
+	}
+	// Background:
+	//   Harbor uses the V1 preheat request and will carry the auth info in the headers.
+	header := nethttp.MapToHeader(args.Headers)
+	if token := header.Get("Authorization"); len(token) > 0 {
+		opts = append(opts, withIssuedToken(token))
+		header.Set("Authorization", token)
+	}
+
+	// Init docker auth client.
+	client, err := newImageAuthClient(image, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +210,6 @@ func (p *preheat) getImageLayers(ctx context.Context, args types.PreheatArgs) ([
 	}
 
 	// Get manifests.
-	header := nethttp.MapToHeader(args.Headers)
 	manifests, err := p.getManifests(ctx, client, image, header.Clone(), platform)
 	if err != nil {
 		return nil, err
@@ -230,6 +237,13 @@ func (p *preheat) getManifests(ctx context.Context, client *imageAuthClient, ima
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, image.manifestURL(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	// Set header from the user request.
+	for key, values := range header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
 	}
 
 	// Set accept header with media types.
@@ -336,8 +350,20 @@ func withHTTPClient(client *http.Client) imageAuthClientOption {
 	}
 }
 
+// withIssuedToken sets the issuedToken for imageAuthClient.
+func withIssuedToken(token string) imageAuthClientOption {
+	return func(c *imageAuthClient) {
+		c.issuedToken = token
+	}
+}
+
 // imageAuthClient is a client for image authentication.
 type imageAuthClient struct {
+	// issuedToken is the issued token specified in header from user request,
+	// there is no need to go through v2 authentication to get a new token
+	// if the token is not empty, just use this token to access v2 API directly.
+	issuedToken string
+
 	// httpClient is the http client.
 	httpClient *http.Client
 
@@ -357,6 +383,11 @@ func newImageAuthClient(image *preheatImage, opts ...imageAuthClientOption) (*im
 
 	for _, opt := range opts {
 		opt(d)
+	}
+
+	// return earlier if issued token is not empty
+	if len(d.issuedToken) > 0 {
+		return d, nil
 	}
 
 	// New a challenge manager for the supported authentication types.
@@ -397,6 +428,10 @@ func (d *imageAuthClient) Do(req *http.Request) (*http.Response, error) {
 
 // GetAuthToken returns the bearer token.
 func (d *imageAuthClient) GetAuthToken() string {
+	if len(d.issuedToken) > 0 {
+		return d.issuedToken
+	}
+
 	return d.interceptorTokenHandler.GetAuthToken()
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Background:
  Harbor utilizes the V1 preheat job, which includes the auth token issued by Harbor in the request body. However, Dragonfly 2.x's auth logic relies on the username and password to exchange tokens, following the v2 auth flow. As a result, when Harbor attempts to preheat to Dragonfly 2.x, it encounters a 401 unauthorized error as Dragonfly tries to pull the manifest from the private project. To maintain backward compatibility, the auth logic should be aligned to be compatible with 1.x.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
