### PR TITLE
refactor: Preallocate pieceDigests slice in genMetadata for improved

### DIFF
--- a/client/daemon/storage/local_storage.go
+++ b/client/daemon/storage/local_storage.go
@@ -206,7 +206,7 @@ func (t *localTaskStore) genMetadata(n int64, req *WritePieceRequest) {
 	t.TotalPieces = total
 	t.ContentLength = contentLength
 
-	var pieceDigests []string
+	pieceDigests := make([]string, 0, t.TotalPieces)
 	for i := int32(0); i < t.TotalPieces; i++ {
 		pieceDigests = append(pieceDigests, t.Pieces[i].Md5)
 	}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Optimized the pieceDigests slice initialization in the genMetadata function by preallocating space based on t.TotalPieces. This change avoids dynamic slice resizing during runtime, which enhances the performance especially when handling large data sets.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
