### PR TITLE
feat: delete the host after host leave peers during host manager gc

### DIFF
--- a/scheduler/resource/host_manager.go
+++ b/scheduler/resource/host_manager.go
@@ -158,6 +158,10 @@ func (h *hostManager) RunGC() error {
 		if host.AnnounceInterval > 0 && elapsed > host.AnnounceInterval*2 {
 			host.Log.Info("host elapsed exceeds twice the announce interval, causing the host to leave peers")
 			host.LeavePeers()
+			// Directly reclaim the host,
+			// as host's ConcurrentUploadCount may not be 0 when the host exits abnormally.
+			host.Log.Info("host has been reclaimed")
+			h.Delete(host.ID)
 			return true
 		}
 

--- a/scheduler/resource/host_manager_test.go
+++ b/scheduler/resource/host_manager_test.go
@@ -522,9 +522,8 @@ func TestHostManager_RunGC(t *testing.T) {
 					return true
 				})
 
-				host, loaded := hostManager.Load(mockHost.ID)
-				assert.Equal(loaded, true)
-				assert.Equal(host.ID, mockHost.ID)
+				_, loaded := hostManager.Load(mockHost.ID)
+				assert.Equal(loaded, false)
 			},
 		},
 	}


### PR DESCRIPTION
## Description

During host manager `RunGC()`, reclaim the host directly after host leave peers, as host's `ConcurrentUploadCount` may not be 0 when the host exits abnormally.

## Related Issue

#3350 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
