### PR TITLE
refractor: fix typo in object storage.go 

### DIFF
--- a/manager/service/model.go
+++ b/manager/service/model.go
@@ -157,7 +157,7 @@ func (s *service) updateModelConfig(ctx context.Context, name string, version in
 
 	objectKey := types.MakeObjectKeyOfModelConfigFile(name)
 	var pbModelConfig inference.ModelConfig
-	reader, err := s.objectStorage.GetOject(ctx, s.config.Trainer.BucketName, objectKey)
+	reader, err := s.objectStorage.GetObject(ctx, s.config.Trainer.BucketName, objectKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/objectstorage/mocks/objectstorage_mock.go
+++ b/pkg/objectstorage/mocks/objectstorage_mock.go
@@ -158,19 +158,19 @@ func (mr *MockObjectStorageMockRecorder) GetObjectMetadatas(ctx, bucketName, pre
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectMetadatas", reflect.TypeOf((*MockObjectStorage)(nil).GetObjectMetadatas), ctx, bucketName, prefix, marker, delimiter, limit)
 }
 
-// GetOject mocks base method.
-func (m *MockObjectStorage) GetOject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
+// GetObject mocks base method.
+func (m *MockObjectStorage) GetObject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOject", ctx, bucketName, objectKey)
+	ret := m.ctrl.Call(m, "GetObject", ctx, bucketName, objectKey)
 	ret0, _ := ret[0].(io.ReadCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetOject indicates an expected call of GetOject.
-func (mr *MockObjectStorageMockRecorder) GetOject(ctx, bucketName, objectKey any) *gomock.Call {
+// GetObject indicates an expected call of GetObject.
+func (mr *MockObjectStorageMockRecorder) GetObject(ctx, bucketName, objectKey any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOject", reflect.TypeOf((*MockObjectStorage)(nil).GetOject), ctx, bucketName, objectKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObject", reflect.TypeOf((*MockObjectStorage)(nil).GetObject), ctx, bucketName, objectKey)
 }
 
 // GetSignURL mocks base method.

--- a/pkg/objectstorage/objectstorage.go
+++ b/pkg/objectstorage/objectstorage.go
@@ -115,8 +115,8 @@ type ObjectStorage interface {
 	// GetObjectMetadatas returns the metadata of the objects.
 	GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker, delimiter string, limit int64) (*ObjectMetadatas, error)
 
-	// GetOject returns data of object.
-	GetOject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error)
+	// GetObject returns data of object.
+	GetObject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error)
 
 	// PutObject puts data of object.
 	PutObject(ctx context.Context, bucketName, objectKey, digest string, reader io.Reader) error

--- a/pkg/objectstorage/obs.go
+++ b/pkg/objectstorage/obs.go
@@ -164,8 +164,8 @@ func (o *obs) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker
 	}, nil
 }
 
-// GetOject returns data of object.
-func (o *obs) GetOject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
+// GetObject returns data of object.
+func (o *obs) GetObject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
 	resp, err := o.client.GetObject(&huaweiobs.GetObjectInput{
 		GetObjectMetadataInput: huaweiobs.GetObjectMetadataInput{
 			Bucket: bucketName,

--- a/pkg/objectstorage/oss.go
+++ b/pkg/objectstorage/oss.go
@@ -170,8 +170,8 @@ func (o *oss) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker
 	}, nil
 }
 
-// GetOject returns data of object.
-func (o *oss) GetOject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
+// GetObject returns data of object.
+func (o *oss) GetObject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
 	bucket, err := o.client.Bucket(bucketName)
 	if err != nil {
 		return nil, err

--- a/pkg/objectstorage/s3.go
+++ b/pkg/objectstorage/s3.go
@@ -179,8 +179,8 @@ func (s *s3) GetObjectMetadatas(ctx context.Context, bucketName, prefix, marker,
 	}, nil
 }
 
-// GetOject returns data of object.
-func (s *s3) GetOject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
+// GetObject returns data of object.
+func (s *s3) GetObject(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
 	resp, err := s.client.GetObjectWithContext(ctx, &awss3.GetObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(objectKey),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix spelling of all occurrences of the getObject() method which was originally misspelled as getOject().

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
no related issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Ensures accuracy and clarity in the codebase. 

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
