### PR TITLE
select all peers in one scheduler_cluster

### DIFF
--- a/manager/job/sync_peers.go
+++ b/manager/job/sync_peers.go
@@ -180,7 +180,7 @@ func (s *syncPeers) mergePeers(ctx context.Context, scheduler models.Scheduler, 
 		syncPeers[result.ID] = result
 	}
 
-	rows, err := s.db.Model(&models.Peer{}).Find(&models.Peer{SchedulerClusterID: scheduler.SchedulerClusterID}).Rows()
+	rows, err := s.db.Model(&models.Peer{}).Where("scheduler_cluster_id = ?",scheduler.SchedulerClusterID).Rows()
 	if err != nil {
 		log.Error(err)
 		return


### PR DESCRIPTION
old sql only select one item


## Description
the old sql only select one item.
Then the peer deleted can not clean in time.The data displaayed in the console(Insight--peer) will be wrong




