### PR TITLE
feat: add filtered query params of the containerd

### DIFF
--- a/pkg/net/http/header.go
+++ b/pkg/net/http/header.go
@@ -74,8 +74,13 @@ var COSFilteredQueryParams = []string{
 	"x-cos-security-token",
 }
 
+// ContainerdQueryParams is the default filtered query params with containerd to generate the task id.
+var ContainerdQueryParams = []string{
+	"ns",
+}
+
 // DefaultFilteredQueryParams is the default filtered query params to generate the task id.
-var DefaultFilteredQueryParams = pkgstrings.Concat(S3FilteredQueryParams, GCSFilteredQueryParams, OSSFilteredQueryParams, OBSFilteredQueryParams, COSFilteredQueryParams)
+var DefaultFilteredQueryParams = pkgstrings.Concat(S3FilteredQueryParams, GCSFilteredQueryParams, OSSFilteredQueryParams, OBSFilteredQueryParams, COSFilteredQueryParams, ContainerdQueryParams)
 
 // RawDefaultFilteredQueryParams is the raw default filtered query params to generate the task id.
 var RawDefaultFilteredQueryParams = strings.Join(DefaultFilteredQueryParams, idgen.FilteredQueryParamsSeparator)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the `pkg/net/http/header.go` file to enhance the handling of query parameters for generating task IDs. The most important changes include adding a new set of filtered query parameters for `containerd` and updating the default filtered query parameters to include these new parameters.

Enhancements to query parameter handling:

* [`pkg/net/http/header.go`](diffhunk://#diff-0ae93eed228c1b5586b56da501ed24f84ef016f038402cd4f42f1a6b45ce20f1R77-R83): Added `ContainerdQueryParams` to handle `containerd` specific query parameters. (`[pkg/net/http/header.goR77-R83](diffhunk://#diff-0ae93eed228c1b5586b56da501ed24f84ef016f038402cd4f42f1a6b45ce20f1R77-R83)`)
* [`pkg/net/http/header.go`](diffhunk://#diff-0ae93eed228c1b5586b56da501ed24f84ef016f038402cd4f42f1a6b45ce20f1R77-R83): Updated `DefaultFilteredQueryParams` to include `ContainerdQueryParams` for generating task IDs. (`[pkg/net/http/header.goR77-R83](diffhunk://#diff-0ae93eed228c1b5586b56da501ed24f84ef016f038402cd4f42f1a6b45ce20f1R77-R83)`)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
