### PR TITLE
feat: add client version for MakeSchedulersKeyForPeerInManager

### DIFF
--- a/manager/rpcserver/manager_server_v1.go
+++ b/manager/rpcserver/manager_server_v1.go
@@ -535,7 +535,7 @@ func (s *managerServerV1) ListSchedulers(ctx context.Context, req *managerv1.Lis
 
 	// Cache hit.
 	var pbListSchedulersResponse managerv1.ListSchedulersResponse
-	cacheKey := pkgredis.MakeSchedulersKeyForPeerInManager(req.Hostname, req.Ip)
+	cacheKey := pkgredis.MakeSchedulersKeyForPeerInManager(req.Hostname, req.Ip, req.Version)
 
 	if err := s.cache.Get(ctx, cacheKey, &pbListSchedulersResponse); err != nil {
 		log.Warnf("%s cache miss because of %s", cacheKey, err.Error())

--- a/manager/rpcserver/manager_server_v2.go
+++ b/manager/rpcserver/manager_server_v2.go
@@ -555,7 +555,7 @@ func (s *managerServerV2) ListSchedulers(ctx context.Context, req *managerv2.Lis
 
 	// Cache hit.
 	var pbListSchedulersResponse managerv2.ListSchedulersResponse
-	cacheKey := pkgredis.MakeSchedulersKeyForPeerInManager(req.Hostname, req.Ip)
+	cacheKey := pkgredis.MakeSchedulersKeyForPeerInManager(req.Hostname, req.Ip, req.Version)
 
 	if err := s.cache.Get(ctx, cacheKey, &pbListSchedulersResponse); err != nil {
 		log.Warnf("%s cache miss because of %s", cacheKey, err.Error())

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -118,8 +118,8 @@ func MakeSeedPeersKeyForPeerInManager(hostname, ip string) string {
 }
 
 // MakeSchedulersKeyForPeerInManager make schedulers key for peer in manager.
-func MakeSchedulersKeyForPeerInManager(hostname, ip string) string {
-	return MakeKeyInManager(PeersNamespace, fmt.Sprintf("%s-%s:schedulers", hostname, ip))
+func MakeSchedulersKeyForPeerInManager(hostname, ip, version string) string {
+	return MakeKeyInManager(PeersNamespace, fmt.Sprintf("%s-%s-%s:schedulers", hostname, ip, version))
 }
 
 // MakeSchedulerClusterKeyInManager make distributed rate limiter key in manager.

--- a/pkg/redis/redis_test.go
+++ b/pkg/redis/redis_test.go
@@ -352,48 +352,63 @@ func Test_MakeSchedulersKeyForPeerInManager(t *testing.T) {
 		name     string
 		hostname string
 		ip       string
+		version  string
 		expect   func(t *testing.T, s string)
 	}{
 		{
 			name:     "make scheduler key for peer in manager",
 			hostname: "bar",
 			ip:       "127.0.0.1",
+			version:  "0.1.0",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:bar-127.0.0.1:schedulers")
+				assert.Equal(s, "manager:peers:bar-127.0.0.1-0.1.0:schedulers")
 			},
 		},
 		{
 			name:     "hostname is empty",
 			hostname: "",
 			ip:       "127.0.0.1",
+			version:  "0.1.0",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:-127.0.0.1:schedulers")
+				assert.Equal(s, "manager:peers:-127.0.0.1-0.1.0:schedulers")
 			},
 		},
 		{
 			name:     "ip is empty",
 			hostname: "bar",
 			ip:       "",
+			version:  "0.1.0",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:bar-:schedulers")
+				assert.Equal(s, "manager:peers:bar--0.1.0:schedulers")
 			},
 		},
 		{
-			name:     "hostname and ip are empty",
-			hostname: "",
-			ip:       "",
+			name:     "version is empty",
+			hostname: "bar",
+			ip:       "127.0.0.1",
+			version:  "",
 			expect: func(t *testing.T, s string) {
 				assert := assert.New(t)
-				assert.Equal(s, "manager:peers:-:schedulers")
+				assert.Equal(s, "manager:peers:bar-127.0.0.1-:schedulers")
+			},
+		},
+		{
+			name:     "hostname, ip and version are empty",
+			hostname: "",
+			ip:       "",
+			version:  "",
+			expect: func(t *testing.T, s string) {
+				assert := assert.New(t)
+				assert.Equal(s, "manager:peers:--:schedulers")
 			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.expect(t, MakeSchedulersKeyForPeerInManager(tc.hostname, tc.ip))
+			tc.expect(t, MakeSchedulersKeyForPeerInManager(tc.hostname, tc.ip, tc.version))
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the `manager/rpcserver` and `pkg/redis` files to improve the caching mechanism by incorporating the `version` parameter into the cache key generation. This ensures that different versions of the same peer can be cached and retrieved correctly.

Changes to cache key generation:

* [`manager/rpcserver/manager_server_v1.go`](diffhunk://#diff-a487908dde55011dac11580dbde0d5753af67553c8d71caeef2c04d2f72872d9L538-R538): Updated the `cacheKey` in the `ListSchedulers` function to include the `version` parameter.
* [`manager/rpcserver/manager_server_v2.go`](diffhunk://#diff-d6cc9560b22b902b815a8aabd758bb6f6127891f1ddb666f462088228a6a860cL558-R558): Updated the `cacheKey` in the `ListSchedulers` function to include the `version` parameter.
* [`pkg/redis/redis.go`](diffhunk://#diff-62a192412b31ee11bcbde71447ebec0a32a59f31e3e720e4dd62ee39a577cd33L121-R122): Modified the `MakeSchedulersKeyForPeerInManager` function to accept and incorporate the `version` parameter into the cache key.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
