### PR TITLE
feat: Update JSON tag for CachedLayers field in Peer struct to "cached_layers"

### DIFF
--- a/manager/types/job.go
+++ b/manager/types/job.go
@@ -330,7 +330,7 @@ type Peer struct {
 	Hostname string `json:"hostname"`
 
 	// CachedLayers is the list of layers that the peer has downloaded.
-	CachedLayers []Layer `json:"layers"`
+	CachedLayers []Layer `json:"cached_layers"`
 
 	// SchedulerClusterID is the scheduler cluster id of the peer.
 	SchedulerClusterID uint `json:"scheduler_cluster_id"`


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a small change to the `Peer` struct in `manager/types/job.go` to improve the clarity and consistency of JSON field naming.

* Renamed the JSON field tag for the `CachedLayers` member from `"layers"` to `"cached_layers"` in the `Peer` struct to better reflect its purpose and improve naming consistency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
