### PR TITLE
feat: update the cache key for distinguishing from the old searcher way

### DIFF
--- a/manager/rpcserver/manager_server_v2.go
+++ b/manager/rpcserver/manager_server_v2.go
@@ -722,7 +722,7 @@ func (s *managerServerV2) listSchedulersByClusterID(ctx context.Context, req *ma
 
 	// Cache hit.
 	var pbListSchedulersResponse managerv2.ListSchedulersResponse
-	cacheKey := pkgredis.MakeSchedulersKeyForPeerInManager(req.Hostname, req.Ip, req.Version)
+	cacheKey := pkgredis.MakeSchedulersByClusterIDKeyForPeerInManager(uint(req.SchedulerClusterId))
 
 	if err := s.cache.Get(ctx, cacheKey, &pbListSchedulersResponse); err != nil {
 		log.Warnf("%s cache miss because of %s", cacheKey, err.Error())

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -126,6 +126,11 @@ func MakeSchedulersKeyForPeerInManager(hostname, ip, version string) string {
 	return MakeKeyInManager(PeersNamespace, fmt.Sprintf("%s-%s-%s:schedulers", hostname, ip, version))
 }
 
+// MakeSchedulersByClusterIDKeyForPeerInManager make schedulers by cluster ID key for peer in manager.
+func MakeSchedulersByClusterIDKeyForPeerInManager(schedulerClusterID uint) string {
+	return MakeKeyInManager(SchedulerClustersNamespace, fmt.Sprintf("%d:schedulers", schedulerClusterID))
+}
+
 // MakeSchedulerClusterKeyInManager make distributed rate limiter key in manager.
 func MakeDistributedRateLimiterKeyInManager(key string) string {
 	return MakeKeyInManager(RateLimitersNamespace, key)


### PR DESCRIPTION
## Description
This pull request updates the way cache keys are generated for listing schedulers by cluster ID, improving consistency and maintainability. The main changes involve switching from a hostname/IP/version-based cache key to a cluster ID-based key, and introducing a new helper function for this purpose.

Cache key generation improvements:

* Updated `listSchedulersByClusterID` in `manager_server_v2.go` to use the new `MakeSchedulersByClusterIDKeyForPeerInManager` function for generating cache keys based on `SchedulerClusterId`, instead of using hostname, IP, and version.
* Added the `MakeSchedulersByClusterIDKeyForPeerInManager` function to `redis.go`, which generates cache keys using the scheduler cluster ID for peers in the manager.


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
