### PR TITLE
perf(rpc): increase default QPS and burst values

### DIFF
--- a/pkg/rpc/scheduler/server/server.go
+++ b/pkg/rpc/scheduler/server/server.go
@@ -43,10 +43,10 @@ import (
 
 const (
 	// DefaultQPS is default qps of grpc server.
-	DefaultQPS = 1000
+	DefaultQPS = 5000
 
 	// DefaultBurst is default burst of grpc server.
-	DefaultBurst = 1000
+	DefaultBurst = 5000
 
 	// DefaultMaxConnectionIdle is default max connection idle of grpc keepalive.
 	DefaultMaxConnectionIdle = 10 * time.Minute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request increases the default limits for gRPC server throughput in `pkg/rpc/scheduler/server/server.go`, allowing the server to handle more requests per second and higher burst rates.

gRPC server configuration updates:

* Increased `DefaultQPS` (queries per second) from 1000 to 5000 to support higher sustained request rates.
* Increased `DefaultBurst` from 1000 to 5000 to allow larger bursts of requests.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
