### PR TITLE
ci(docker): update runner to ubuntu-latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
   push_image_to_registry:
     name: Push Image
     permissions: write-all
-    runs-on: oracle-vm-24cpu-96gb-x86-64
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         module: ["manager", "scheduler", "dfdaemon"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to the GitHub Actions workflow configuration by changing the runner used for the `push_image_to_registry` job. The runner is switched from a specific Oracle VM to a more general Ubuntu runner with 16 cores.

- Updated the `runs-on` parameter in the `push_image_to_registry` job of `.github/workflows/docker.yml` to use `ubuntu-latest-16-cores` instead of `oracle-vm-24cpu-96gb-x86-64`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
