### PR TITLE
feat: implement PreheatFile and StatFile for scheduler (#4380)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 require (
 	cloud.google.com/go/storage v1.50.0
-	d7y.io/api/v2 v2.1.79
+	d7y.io/api/v2 v2.1.80
 	github.com/MysteriousPotato/go-lockable v1.0.0
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ cloud.google.com/go/storage v1.50.0 h1:3TbVkzTooBvnZsk7WaAQfOsNrdoM8QHusXA1cpk6Q
 cloud.google.com/go/storage v1.50.0/go.mod h1:l7XeiD//vx5lfqE3RavfmU9yvk5Pp0Zhcv482poyafY=
 cloud.google.com/go/trace v1.11.6 h1:2O2zjPzqPYAHrn3OKl029qlqG6W8ZdYaOWRyr8NgMT4=
 cloud.google.com/go/trace v1.11.6/go.mod h1:GA855OeDEBiBMzcckLPE2kDunIpC72N+Pq8WFieFjnI=
-d7y.io/api/v2 v2.1.79 h1:LUPpjiuhHZgyezHBH7lG42pkqjcdbiTAHtEJ2Z7tUJg=
-d7y.io/api/v2 v2.1.79/go.mod h1:t6k27g8dFyH6sp3y2J1qHyk2YmoySd88qSbsEaqJ2Sw=
+d7y.io/api/v2 v2.1.80 h1:dH4w0dUXLpZ1sdp6QuWUVXkjQaUSX/pAOFFunkrcsUs=
+d7y.io/api/v2 v2.1.80/go.mod h1:t6k27g8dFyH6sp3y2J1qHyk2YmoySd88qSbsEaqJ2Sw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

--- a/internal/dflog/logger.go
+++ b/internal/dflog/logger.go
@@ -256,6 +256,24 @@ func WithStatImageAndTaskID(url, taskID string) *SugaredLoggerOnWith {
 	}
 }
 
+func WithPreheatFile(url string) *SugaredLoggerOnWith {
+	return &SugaredLoggerOnWith{
+		withArgs: []any{"url", url},
+	}
+}
+
+func WithStatFile(url string) *SugaredLoggerOnWith {
+	return &SugaredLoggerOnWith{
+		withArgs: []any{"url", url},
+	}
+}
+
+func WithStatFileAndTaskID(url, taskID string) *SugaredLoggerOnWith {
+	return &SugaredLoggerOnWith{
+		withArgs: []any{"url", url, "taskID", taskID},
+	}
+}
+
 func (log *SugaredLoggerOnWith) With(args ...any) *SugaredLoggerOnWith {
 	args = append(args, log.withArgs...)
 	return &SugaredLoggerOnWith{

--- a/internal/job/types.go
+++ b/internal/job/types.go
@@ -18,6 +18,11 @@ package job
 
 import (
 	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	v2 "d7y.io/api/v2/pkg/apis/common/v2"
+	dfdaemonv2 "d7y.io/api/v2/pkg/apis/dfdaemon/v2"
 )
 
 // PreheatRequest defines the request parameters for preheating.
@@ -81,6 +86,24 @@ type GetTaskRequest struct {
 type GetTaskResponse struct {
 	Peers              []*Peer `json:"peers"`
 	SchedulerClusterID uint    `json:"scheduler_cluster_id"`
+}
+
+// ListTaskEntriesRequest defines the request parameters for listing task entries.
+type ListTaskEntriesRequest struct {
+	TaskID           string               `json:"task_id" validate:"required"`
+	Url              string               `json:"url" validate:"omitempty"`
+	Timeout          *durationpb.Duration `json:"timeout" validate:"omitempty"`
+	Header           map[string]string    `json:"header" validate:"omitempty"`
+	CertificateChain [][]byte             `json:"certificate_chain" validate:"omitempty"`
+	ObjectStorage    *v2.ObjectStorage    `json:"object_storage" validate:"omitempty"`
+	Hdfs             *v2.HDFS             `json:"hdfs" validate:"omitempty"`
+}
+
+// ListTaskEntriesResponse defines the response parameters for listing task entries.
+type ListTaskEntriesResponse struct {
+	Entries     []*dfdaemonv2.Entry `json:"entries"`
+	Recursive   bool                `json:"recursive"`
+	SchedulerID uint                `json:"scheduler_id"`
 }
 
 // Peer represents the peer information.

--- a/pkg/rpc/dfdaemon/client/client_v2.go
+++ b/pkg/rpc/dfdaemon/client/client_v2.go
@@ -89,6 +89,9 @@ type V2 interface {
 	// DeleteTask deletes task from p2p network.
 	DeleteTask(context.Context, *dfdaemonv2.DeleteTaskRequest, ...grpc.CallOption) error
 
+	// ListTaskEntries lists task entries.
+	ListTaskEntries(context.Context, *dfdaemonv2.ListTaskEntriesRequest, ...grpc.CallOption) (*dfdaemonv2.ListTaskEntriesResponse, error)
+
 	// DownloadPersistentCacheTask downloads persistent cache task from p2p network.
 	DownloadPersistentCacheTask(context.Context, *dfdaemonv2.DownloadPersistentCacheTaskRequest, ...grpc.CallOption) (dfdaemonv2.DfdaemonUpload_DownloadPersistentCacheTaskClient, error)
 
@@ -191,4 +194,12 @@ func (v *v2) DeletePersistentCacheTask(ctx context.Context, req *dfdaemonv2.Dele
 
 	_, err := v.DfdaemonUploadClient.DeletePersistentCacheTask(ctx, req, opts...)
 	return err
+}
+
+// ListTaskEntries lists task entries from p2p network.
+func (v *v2) ListTaskEntries(ctx context.Context, req *dfdaemonv2.ListTaskEntriesRequest, opts ...grpc.CallOption) (*dfdaemonv2.ListTaskEntriesResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+
+	return v.DfdaemonUploadClient.ListTaskEntries(ctx, req, opts...)
 }

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -59,6 +59,9 @@ type Job interface {
 	// GetTask retrieves task information from all hosts in the cluster.
 	GetTask(context.Context, *internaljob.GetTaskRequest, *logger.SugaredLoggerOnWith) (*internaljob.GetTaskResponse, error)
 
+	// ListTaskEntries lists all task entries.
+	ListTaskEntries(context.Context, *internaljob.ListTaskEntriesRequest, *logger.SugaredLoggerOnWith) (*internaljob.ListTaskEntriesResponse, error)
+
 	// PreheatSinglePeer preheats job by single seed peer, scheduler will trigger seed peer to download task.
 	PreheatSingleSeedPeer(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error)
 
@@ -1035,4 +1038,48 @@ func (j *job) deleteTask(ctx context.Context, data string) (string, error) {
 		FailureTasks:       failureTasks,
 		SchedulerClusterID: j.config.Manager.SchedulerClusterID,
 	})
+}
+
+func (j *job) ListTaskEntries(ctx context.Context, req *internaljob.ListTaskEntriesRequest, log *logger.SugaredLoggerOnWith) (*internaljob.ListTaskEntriesResponse, error) {
+	advertiseIP := j.config.Server.AdvertiseIP.String()
+
+	selected, err := j.resource.SeedPeer().Select(ctx, req.TaskID)
+	if err != nil {
+		return nil, err
+	}
+
+	addr := fmt.Sprintf("%s:%d", selected.IP, selected.Port)
+	log.Infof("selected seed peer %s for task %s", addr, req.TaskID)
+
+	dfdaemonClient, err := dfdaemonclient.GetV2ByAddr(ctx, addr, j.dialOptions...)
+	if err != nil {
+		log.Errorf("[list-task-entries] get dfdaemon client failed: %s", err)
+		return nil, err
+	}
+
+	res, err := dfdaemonClient.ListTaskEntries(ctx, &dfdaemonv2.ListTaskEntriesRequest{
+		TaskId:           req.TaskID,
+		Url:              req.Url,
+		RequestHeader:    req.Header,
+		Timeout:          req.Timeout,
+		CertificateChain: req.CertificateChain,
+		ObjectStorage:    req.ObjectStorage,
+		Hdfs:             req.Hdfs,
+		RemoteIp:         &advertiseIP,
+	})
+	if err != nil {
+		log.Errorf("[list-task-entries]list task entries failed: %s", err)
+		return nil, err
+	}
+
+	var recursive bool
+	if len(res.Entries) > 1 {
+		recursive = true
+	}
+
+	return &internaljob.ListTaskEntriesResponse{
+		Recursive:   recursive,
+		Entries:     res.Entries,
+		SchedulerID: j.config.Manager.SchedulerClusterID,
+	}, nil
 }

--- a/scheduler/job/mocks/job_mock.go
+++ b/scheduler/job/mocks/job_mock.go
@@ -57,6 +57,21 @@ func (mr *MockJobMockRecorder) GetTask(arg0, arg1, arg2 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTask", reflect.TypeOf((*MockJob)(nil).GetTask), arg0, arg1, arg2)
 }
 
+// ListTaskEntries mocks base method.
+func (m *MockJob) ListTaskEntries(arg0 context.Context, arg1 *job.ListTaskEntriesRequest, arg2 *logger.SugaredLoggerOnWith) (*job.ListTaskEntriesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTaskEntries", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*job.ListTaskEntriesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTaskEntries indicates an expected call of ListTaskEntries.
+func (mr *MockJobMockRecorder) ListTaskEntries(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskEntries", reflect.TypeOf((*MockJob)(nil).ListTaskEntries), arg0, arg1, arg2)
+}
+
 // PreheatAllPeers mocks base method.
 func (m *MockJob) PreheatAllPeers(arg0 context.Context, arg1 *job.PreheatRequest, arg2 *logger.SugaredLoggerOnWith) (*job.PreheatResponse, error) {
 	m.ctrl.T.Helper()

--- a/scheduler/metrics/metrics.go
+++ b/scheduler/metrics/metrics.go
@@ -485,6 +485,34 @@ var (
 		Help:      "Counter of the number of failed of the stating image.",
 	})
 
+	PreheatFileCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.SchedulerMetricsName,
+		Name:      "preheat_file_total",
+		Help:      "Counter of the total preheat file.",
+	})
+
+	PreheatFileFailureCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.SchedulerMetricsName,
+		Name:      "preheat_file_failure_total",
+		Help:      "Counter of the total preheat file failure.",
+	})
+
+	StatFileCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.SchedulerMetricsName,
+		Name:      "stat_file_total",
+		Help:      "Counter of the number of the stating file.",
+	})
+
+	StatFileFailureCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: types.MetricsNamespace,
+		Subsystem: types.SchedulerMetricsName,
+		Name:      "stat_file_failure_total",
+		Help:      "Counter of the number of failed of the stating file.",
+	})
+
 	VersionGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: types.MetricsNamespace,
 		Subsystem: types.SchedulerMetricsName,

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -3150,3 +3150,220 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 	log.Infof("stat image finished, total layers: %d, total peers: %d", len(resp.Image.Layers), len(resp.Peers))
 	return resp, nil
 }
+
+// PreheatFile synchronously triggers an asynchronous preheat task for a file.
+//
+// This is a blocking call. The RPC will not return until the server has completed the
+// initial synchronous work: preparing the file URL.
+//
+// After this call successfully returns, a scheduler on the server begins the actual
+// preheating process, instructing peers to download the file in the background.
+//
+// A successful response (google.protobuf.Empty) confirms that the preparation is complete
+// and the asynchronous download task has been scheduled.
+func (v *V2) PreheatFile(ctx context.Context, req *schedulerv2.PreheatFileRequest) error {
+	log := logger.WithPreheatFile(req.Url)
+
+	if req.Scope == "" {
+		req.Scope = managertypes.SingleSeedPeerScope
+	}
+
+	if req.ConcurrentTaskCount == nil {
+		concurrentTaskCount := int64(managertypes.DefaultPreheatConcurrentTaskCount)
+		req.ConcurrentTaskCount = &concurrentTaskCount
+	}
+
+	if req.ConcurrentPeerCount == nil {
+		concurrentPeerCount := int64(managertypes.DefaultPreheatConcurrentPeerCount)
+		req.ConcurrentPeerCount = &concurrentPeerCount
+	}
+
+	if len(req.FilteredQueryParams) == 0 {
+		req.FilteredQueryParams = http.DefaultFilteredQueryParams
+	}
+
+	if req.Timeout == nil {
+		req.Timeout = durationpb.New(managertypes.DefaultJobTimeout)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, req.GetTimeout().AsDuration())
+	defer cancel()
+
+	// For files preheating, we get entries from client first
+	listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
+		TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams),
+		Url:              req.GetUrl(),
+		Timeout:          req.GetTimeout(),
+		Header:           req.GetHeader(),
+		CertificateChain: req.GetCertificateChain(),
+		ObjectStorage:    req.GetObjectStorage(),
+		Hdfs:             req.GetHdfs(),
+	}, log)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "failed to list task entries: %s", err)
+	}
+
+	var urls []string
+	for _, entry := range listResp.Entries {
+		urls = append(urls, entry.Url)
+	}
+
+	// Create a preheat request for the job queue.
+	preheatRequest := &internaljob.PreheatRequest{
+		URLs:                urls,
+		Application:         req.GetApplication(),
+		FilteredQueryParams: idgen.FormatFilteredQueryParams(req.GetFilteredQueryParams()),
+		Headers:             req.GetHeader(),
+		PieceLength:         req.PieceLength,
+		Priority:            int32(req.GetPriority()),
+		Scope:               req.GetScope(),
+		IPs:                 req.GetIps(),
+		Count:               req.Count,
+		Percentage:          req.Percentage,
+		ConcurrentTaskCount: req.GetConcurrentTaskCount(),
+		ConcurrentPeerCount: req.GetConcurrentPeerCount(),
+		Timeout:             req.GetTimeout().AsDuration(),
+		CertificateChain:    req.GetCertificateChain(),
+		InsecureSkipVerify:  req.GetInsecureSkipVerify(),
+	}
+
+	switch req.GetScope() {
+	case managertypes.SingleSeedPeerScope:
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), req.GetTimeout().AsDuration())
+			defer cancel()
+
+			log.Info("preheat single seed peer")
+			resp, err := v.job.PreheatSingleSeedPeer(ctx, preheatRequest, log)
+			if err != nil {
+				log.Errorf("preheat single seed peer failed: %s", err.Error())
+				return
+			}
+
+			log.Infof("preheat single seed peer finished, response: %#v", resp)
+		}()
+	case managertypes.AllSeedPeersScope:
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), req.GetTimeout().AsDuration())
+			defer cancel()
+
+			log.Info("preheat all seed peers")
+			resp, err := v.job.PreheatAllSeedPeers(ctx, preheatRequest, log)
+			if err != nil {
+				log.Errorf("preheat all seed peers failed: %s", err.Error())
+				return
+			}
+
+			log.Infof("preheat all seed peers finished, success count: %d, failed count: %d", len(resp.SuccessTasks), len(resp.FailureTasks))
+		}()
+	case managertypes.AllPeersScope:
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), req.GetTimeout().AsDuration())
+			defer cancel()
+
+			log.Info("preheat all peers")
+			resp, err := v.job.PreheatAllPeers(ctx, preheatRequest, log)
+			if err != nil {
+				log.Errorf("preheat all peers failed: %s", err.Error())
+				return
+			}
+
+			log.Infof("preheat all peers finished, success count: %d, failed count: %d", len(resp.SuccessTasks), len(resp.FailureTasks))
+		}()
+	default:
+		return status.Errorf(codes.InvalidArgument, "unsupported preheat scope: %s", req.Scope)
+	}
+
+	return nil
+}
+
+// StatFile provides detailed status for files distribution in peers.
+//
+// This is a blocking call that first queries the file/dir entries and then queries
+// all peers to collect the file's download state across the network.
+// The response includes the file status on each peer.
+func (v *V2) StatFile(ctx context.Context, req *schedulerv2.StatFileRequest) (*schedulerv2.StatFileResponse, error) {
+	log := logger.WithStatFile(req.Url)
+
+	if req.ConcurrentPeerCount == nil {
+		concurrentPeerCount := int64(managertypes.DefaultPreheatConcurrentPeerCount)
+		req.ConcurrentPeerCount = &concurrentPeerCount
+	}
+
+	if len(req.FilteredQueryParams) == 0 {
+		req.FilteredQueryParams = http.DefaultFilteredQueryParams
+	}
+
+	if req.Timeout == nil {
+		req.Timeout = durationpb.New(managertypes.DefaultJobTimeout)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, req.GetTimeout().AsDuration())
+	defer cancel()
+
+	listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
+		TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams),
+		Url:              req.GetUrl(),
+		Timeout:          req.GetTimeout(),
+		Header:           req.GetHeader(),
+		CertificateChain: req.GetCertificateChain(),
+		ObjectStorage:    req.GetObjectStorage(),
+		Hdfs:             req.GetHdfs(),
+	}, log)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to list task entries: %s", err)
+	}
+
+	resp := &schedulerv2.StatFileResponse{
+		Peers: make([]*schedulerv2.PeerFile, 0),
+	}
+
+	var mu sync.Mutex
+	peers := map[string]*schedulerv2.PeerFile{}
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, entry := range listResp.Entries {
+		eg.Go(func() error {
+			taskID := idgen.TaskIDV2ByURLBased(entry.Url, req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams)
+			getTaskRequest := &internaljob.GetTaskRequest{
+				TaskID:              taskID,
+				Timeout:             req.GetTimeout().AsDuration(),
+				ConcurrentPeerCount: *req.ConcurrentPeerCount,
+			}
+
+			log := logger.WithStatFileAndTaskID(entry.Url, taskID)
+			log.Infof("get task request: %#v", getTaskRequest)
+			task, err := v.job.GetTask(ctx, getTaskRequest, log)
+			if err != nil {
+				log.Errorf("get task failed: %s", err.Error())
+				return nil
+			}
+			log.Infof("get length of peers: %d", len(task.Peers))
+
+			for _, peer := range task.Peers {
+				hostID := idgen.HostIDV2(peer.IP, peer.Hostname, false)
+				mu.Lock()
+				if _, exists := peers[hostID]; !exists {
+					peers[hostID] = &schedulerv2.PeerFile{
+						Ip:       peer.IP,
+						Hostname: peer.Hostname,
+					}
+				}
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	// If any of the goroutines return an error, ignore it and continue processing.
+	if err := eg.Wait(); err != nil {
+		logger.Errorf("failed to create get task jobs: %w", err)
+	}
+
+	for _, peer := range peers {
+		resp.Peers = append(resp.Peers, peer)
+		log.Infof("stat file for peer %s", peer.Ip)
+	}
+
+	log.Infof("stat file finished, total files: %d, total peers: %d", len(listResp.Entries), len(resp.Peers))
+	return resp, nil
+}


### PR DESCRIPTION
## Description
for scheduler rpc api, add PreheatFile and StatFile, which call listTaskEntries and downloadTask of dfdaemon client to complete preheat 

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/4380

## Motivation and Context
for files on storage like oss, hdfs .etc, it also need preheat to accelerate download. This commit focus on exposing PreheatFile and StatFile on scheduler to be called

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
