### PR TITLE
fix: choose proper text type in JSONMap.GormDBDataType per DB dialect

### DIFF
--- a/manager/models/models.go
+++ b/manager/models/models.go
@@ -88,7 +88,16 @@ func (m JSONMap) GormDataType() string {
 }
 
 func (JSONMap) GormDBDataType(db *gorm.DB, field *schema.Field) string {
-	return "longtext"
+	switch db.Name() {
+	case "postgres":
+		return "text"
+	case "sqlite":
+		return "TEXT"
+	case "sqlserver":
+		return "NVARCHAR(MAX)"
+	default:
+		return "longtext"
+	}
 }
 
 type Array []string
@@ -137,5 +146,14 @@ func (Array) GormDataType() string {
 }
 
 func (Array) GormDBDataType(db *gorm.DB, field *schema.Field) string {
-	return "longtext"
+	switch db.Name() {
+	case "postgres":
+		return "text"
+	case "sqlite":
+		return "TEXT"
+	case "sqlserver":
+		return "NVARCHAR(MAX)"
+	default:
+		return "longtext"
+	}
 }


### PR DESCRIPTION
PostgreSQL doesn't support the `longtext` type.  
This change updates `JSONMap.GormDBDataType` to return the correct data type depending on the SQL dialect:

- **postgres**: text  
- **mysql**: longtext  
- **sqlite**: TEXT  
- **mssql**: NVARCHAR(MAX)  

This ensures migrations work correctly across all supported databases.

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes incorrect type mapping in `JSONMap.GormDBDataType`.  
Previously, PostgreSQL migrations failed because the ORM attempted to use `longtext`, which is not a valid PostgreSQL type.  
The updated implementation returns dialect-specific types to maintain compatibility across different database engines.

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4362
Fixes migration errors encountered when using PostgreSQL.

## Motivation and Context

This change is required to ensure that schema migrations and model generation work seamlessly on PostgreSQL, MySQL, SQLite, and MSSQL.  
It prevents invalid SQL schema generation and aligns database behavior across supported dialects.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] My change does not require documentation updates.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added or verified tests covering my changes.
- [x] I have tested migrations on PostgreSQL and MySQL.
