### PR TITLE
fix SECURITY-INSIGHTS.yml (missing #)

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,4 +1,4 @@
- Security Insights for DragonflyOSS/Dragonfly
+# Security Insights for DragonflyOSS/Dragonfly
 # This file adheres to the OSSF Security Insights Specification v2.0.0
 
 header:


### PR DESCRIPTION
Add missing `#` to the first line.  I noticed it when trying to parse it.

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4396

## Motivation and Context

I'm building tools as part of https://github.com/cncf/toc/issues/1709 and noticed that wasn't parsing.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
