### PR TITLE
refactor(rpcserver): consolidate scheduler cache cleanup logic

### DIFF
--- a/manager/rpcserver/manager_server_v2.go
+++ b/manager/rpcserver/manager_server_v2.go
@@ -879,9 +879,18 @@ func (s *managerServerV2) KeepAlive(stream managerv2.Manager_KeepAliveServer) er
 			return status.Error(codes.Internal, err.Error())
 		}
 
+		// Clean legacy scheduler cache.
 		if err := s.cache.Delete(
 			context.TODO(),
 			pkgredis.MakeSchedulerKeyInManager(clusterID, hostname, ip),
+		); err != nil {
+			log.Warnf("refresh keepalive status failed: %s", err.Error())
+		}
+
+		// Clean scheduler cache.
+		if err := s.cache.Delete(
+			context.TODO(),
+			pkgredis.MakeSchedulersByClusterIDKeyForPeerInManager(uint(clusterID)),
 		); err != nil {
 			log.Warnf("refresh keepalive status failed: %s", err.Error())
 		}
@@ -923,9 +932,18 @@ func (s *managerServerV2) KeepAlive(stream managerv2.Manager_KeepAliveServer) er
 					return status.Error(codes.Internal, err.Error())
 				}
 
+				// Clean legacy scheduler cache.
 				if err := s.cache.Delete(
 					context.TODO(),
 					pkgredis.MakeSchedulerKeyInManager(clusterID, hostname, ip),
+				); err != nil {
+					log.Warnf("refresh keepalive status failed: %s", err.Error())
+				}
+
+				// Clean scheduler cache.
+				if err := s.cache.Delete(
+					context.TODO(),
+					pkgredis.MakeSchedulersByClusterIDKeyForPeerInManager(uint(clusterID)),
 				); err != nil {
 					log.Warnf("refresh keepalive status failed: %s", err.Error())
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This pull request adds additional cache cleanup logic to the `KeepAlive` method in `manager_server_v2.go`, ensuring that both legacy and current scheduler cache entries are properly deleted during the keepalive process. This helps maintain cache consistency and prevents stale scheduler data.

Cache cleanup improvements:

* Added deletion of legacy scheduler cache entries using `pkgredis.MakeSchedulerKeyInManager` when handling keepalive requests. [[1]](diffhunk://#diff-d6cc9560b22b902b815a8aabd758bb6f6127891f1ddb666f462088228a6a860cR882-R896) [[2]](diffhunk://#diff-d6cc9560b22b902b815a8aabd758bb6f6127891f1ddb666f462088228a6a860cR935-R949)
* Added deletion of current scheduler cache entries using `pkgredis.MakeSchedulersByClusterIDKeyForPeerInManager` for both active and inactive seed peer scenarios. [[1]](diffhunk://#diff-d6cc9560b22b902b815a8aabd758bb6f6127891f1ddb666f462088228a6a860cR882-R896) [[2]](diffhunk://#diff-d6cc9560b22b902b815a8aabd758bb6f6127891f1ddb666f462088228a6a860cR935-R949)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
