### PR TITLE
feat: implement the dfdaemon client pool for reusing.

### DIFF
--- a/pkg/rpc/dfdaemon/client/constants.go
+++ b/pkg/rpc/dfdaemon/client/constants.go
@@ -30,4 +30,10 @@ const (
 	// backoffWaitBetween is waiting for a fixed period of
 	// time between calls in backoff linear.
 	backoffWaitBetween = 500 * time.Millisecond
+
+	// idleTimeout is timeout of idle connection.
+	idleTimeout = 5 * time.Minute
+
+	// gcInterval is the interval of client cleanup.
+	gcInterval = 5 * time.Minute
 )

--- a/pkg/rpc/dfdaemon/client/mocks/client_v2_mock.go
+++ b/pkg/rpc/dfdaemon/client/mocks/client_v2_mock.go
@@ -15,9 +15,78 @@ import (
 
 	common "d7y.io/api/v2/pkg/apis/common/v2"
 	dfdaemon "d7y.io/api/v2/pkg/apis/dfdaemon/v2"
+	client "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/client"
 	gomock "go.uber.org/mock/gomock"
 	grpc "google.golang.org/grpc"
 )
+
+// MockPool is a mock of Pool interface.
+type MockPool struct {
+	ctrl     *gomock.Controller
+	recorder *MockPoolMockRecorder
+	isgomock struct{}
+}
+
+// MockPoolMockRecorder is the mock recorder for MockPool.
+type MockPoolMockRecorder struct {
+	mock *MockPool
+}
+
+// NewMockPool creates a new mock instance.
+func NewMockPool(ctrl *gomock.Controller) *MockPool {
+	mock := &MockPool{ctrl: ctrl}
+	mock.recorder = &MockPoolMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPool) EXPECT() *MockPoolMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method.
+func (m *MockPool) Get(target string, opts ...grpc.DialOption) (client.V2, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{target}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Get", varargs...)
+	ret0, _ := ret[0].(client.V2)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockPoolMockRecorder) Get(target any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{target}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPool)(nil).Get), varargs...)
+}
+
+// Serve mocks base method.
+func (m *MockPool) Serve() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Serve")
+}
+
+// Serve indicates an expected call of Serve.
+func (mr *MockPoolMockRecorder) Serve() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Serve", reflect.TypeOf((*MockPool)(nil).Serve))
+}
+
+// Stop mocks base method.
+func (m *MockPool) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockPoolMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockPool)(nil).Stop))
+}
 
 // MockV2 is a mock of V2 interface.
 type MockV2 struct {

--- a/scheduler/resource/standard/resource_mock.go
+++ b/scheduler/resource/standard/resource_mock.go
@@ -12,6 +12,7 @@ package standard
 import (
 	reflect "reflect"
 
+	client "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/client"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -51,6 +52,20 @@ func (m *MockResource) HostManager() HostManager {
 func (mr *MockResourceMockRecorder) HostManager() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostManager", reflect.TypeOf((*MockResource)(nil).HostManager))
+}
+
+// PeerClientPool mocks base method.
+func (m *MockResource) PeerClientPool() client.Pool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PeerClientPool")
+	ret0, _ := ret[0].(client.Pool)
+	return ret0
+}
+
+// PeerClientPool indicates an expected call of PeerClientPool.
+func (mr *MockResourceMockRecorder) PeerClientPool() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeerClientPool", reflect.TypeOf((*MockResource)(nil).PeerClientPool))
 }
 
 // PeerManager mocks base method.

--- a/scheduler/resource/standard/seed_peer_test.go
+++ b/scheduler/resource/standard/seed_peer_test.go
@@ -27,6 +27,7 @@ import (
 	commonv2 "d7y.io/api/v2/pkg/apis/common/v2"
 	dfdaemonv2 "d7y.io/api/v2/pkg/apis/dfdaemon/v2"
 	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
+	dfdaemonclientmocks "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/client/mocks"
 )
 
 func TestSeedPeer_newSeedPeer(t *testing.T) {
@@ -49,8 +50,9 @@ func TestSeedPeer_newSeedPeer(t *testing.T) {
 			defer ctl.Finish()
 			hostManager := NewMockHostManager(ctl)
 			peerManager := NewMockPeerManager(ctl)
+			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
 
-			tc.expect(t, newSeedPeer(peerManager, hostManager))
+			tc.expect(t, newSeedPeer(peerManager, hostManager, clientPool))
 		})
 	}
 }
@@ -75,8 +77,9 @@ func TestSeedPeer_TriggerDownloadTask(t *testing.T) {
 			defer ctl.Finish()
 			hostManager := NewMockHostManager(ctl)
 			peerManager := NewMockPeerManager(ctl)
+			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
 
-			seedPeer := newSeedPeer(peerManager, hostManager)
+			seedPeer := newSeedPeer(peerManager, hostManager, clientPool)
 			tc.expect(t, seedPeer.TriggerDownloadTask(context.Background(), mockTaskID, &dfdaemonv2.DownloadTaskRequest{}))
 		})
 	}
@@ -102,8 +105,9 @@ func TestSeedPeer_TriggerTask(t *testing.T) {
 			defer ctl.Finish()
 			hostManager := NewMockHostManager(ctl)
 			peerManager := NewMockPeerManager(ctl)
+			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
 
-			seedPeer := newSeedPeer(peerManager, hostManager)
+			seedPeer := newSeedPeer(peerManager, hostManager, clientPool)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer, result, err := seedPeer.TriggerTask(context.Background(), nil, mockTask)
 			tc.expect(t, peer, result, err)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
 	"d7y.io/dragonfly/v2/internal/dynconfig"
@@ -189,6 +190,7 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath) (*Server, err
 	// Initialize job service.
 	if cfg.Job.Enable && rdb != nil {
 		dialOptions := []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 			grpc.WithTransportCredentials(seedPeerClientTransportCredentials),
 		}

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -45,7 +45,6 @@ import (
 	"d7y.io/dragonfly/v2/pkg/idgen"
 	"d7y.io/dragonfly/v2/pkg/net/http"
 	nettls "d7y.io/dragonfly/v2/pkg/net/tls"
-	dfdaemonclient "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/client"
 	pkgtime "d7y.io/dragonfly/v2/pkg/time"
 	"d7y.io/dragonfly/v2/pkg/types"
 	"d7y.io/dragonfly/v2/scheduler/config"
@@ -2475,7 +2474,7 @@ func (v *V2) DeletePersistentCachePeer(_ctx context.Context, req *schedulerv2.De
 	// Delete the persistent cache task from the peer, if delete failed, skip it.
 	addr := fmt.Sprintf("%s:%d", peer.Host.IP, peer.Host.DownloadPort)
 	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	dfdaemonClient, err := dfdaemonclient.GetV2ByAddr(ctx, addr, dialOptions...)
+	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		peer.Log.Errorf("get dfdaemon client failed %s", err)
 		return err
@@ -2682,7 +2681,7 @@ func (v *V2) replicatePersistentCacheTask(ctx context.Context, peer *persistentc
 func (v *V2) downloadPersistentCacheTaskByPeer(ctx context.Context, task *persistentcache.Task, host *persistentcache.Host) error {
 	addr := fmt.Sprintf("%s:%d", host.IP, host.DownloadPort)
 	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	dfdaemonClient, err := dfdaemonclient.GetV2ByAddr(ctx, addr, dialOptions...)
+	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		task.Log.Errorf("get dfdaemon client failed %s", err)
 		return err
@@ -2720,7 +2719,7 @@ func (v *V2) downloadPersistentCacheTaskByPeer(ctx context.Context, task *persis
 func (v *V2) persistPersistentCacheTaskByPeer(ctx context.Context, peer *persistentcache.Peer, cachedParent *persistentcache.Peer) error {
 	addr := fmt.Sprintf("%s:%d", cachedParent.Host.IP, cachedParent.Host.DownloadPort)
 	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	dfdaemonClient, err := dfdaemonclient.GetV2ByAddr(ctx, addr, dialOptions...)
+	dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 	if err != nil {
 		peer.Log.Errorf("get dfdaemon client failed %s", err)
 		return err
@@ -2859,7 +2858,7 @@ func (v *V2) DeletePersistentCacheTask(_ctx context.Context, req *schedulerv2.De
 		// Delete the persistent cache task from the peer, if delete failed, skip it.
 		addr := fmt.Sprintf("%s:%d", peer.Host.IP, peer.Host.DownloadPort)
 		dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-		dfdaemonClient, err := dfdaemonclient.GetV2ByAddr(ctx, addr, dialOptions...)
+		dfdaemonClient, err := v.resource.PeerClientPool().Get(addr, dialOptions...)
 		if err != nil {
 			peer.Log.Errorf("get dfdaemon client failed %s", err)
 			continue


### PR DESCRIPTION
This pull request introduces a new client connection manager for `dfdaemon` gRPC clients, refactors the existing client creation logic to use connection pooling and automatic cleanup, and updates related code across the scheduler and resource packages to leverage the new manager. These changes improve connection reuse, resource management, and testability.

### Client connection management improvements

* Added a new `Manager` interface and implementation in `pkg/rpc/dfdaemon/client/manager.go` to handle pooling, reuse, and cleanup of gRPC client connections, including periodic cleanup of idle connections.
* Updated constants for idle connection timeout and cleanup interval in `pkg/rpc/dfdaemon/client/constants.go`.

### Refactoring client usage across the codebase

* Replaced direct calls to `GetV2ByAddr` with the new manager’s `Get` method in scheduler job and resource code, ensuring clients are reused and managed centrally. This affects multiple methods in `scheduler/job/job.go` and `scheduler/resource/standard/seed_peer.go`. [[1]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL371-L376) [[2]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL459-R468) [[3]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL677-R685) [[4]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL921-R928) [[5]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL996-R1002) [[6]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL1052-R1057) [[7]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2L125-R129)
* Integrated the manager’s lifecycle (`Serve` and `Stop`) into the scheduler job and seed peer service startup/shutdown routines. [[1]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cR185-R191) [[2]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2R368-R373) [[3]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2R391-R394)

### Test and mock support

* Added GoMock-generated mocks for the new `Manager` interface in `pkg/rpc/dfdaemon/client/mocks/manager_mock.go` for improved testability.
* Updated mocks and test utilities for client and job interfaces to support new and changed methods. [[1]](diffhunk://#diff-bd61556771b1e0ec86c0702a043388e871a71fdabbb8ae057fb0e8bad4838f8bR158-R177) [[2]](diffhunk://#diff-c6ad02874aad3971af407aed50387699a8805a8f34b3e99ea471986a0238e987L70-R70)

### Dependency and import updates

* Updated imports throughout the codebase to support the new manager and remove now-unused direct client creation dependencies. [[1]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL34) [[2]](diffhunk://#diff-137f33609f7abea4757e3c73fe20f4659902b71bc4928c7e2168227f609f03c5R28) [[3]](diffhunk://#diff-4941d744e2734dadec552334f209d76d28196a136dc78a0fa26dceb837b45db2L23-L74)

### Resource management enhancements

* Added a `clientManager` field to resource and job structs, ensuring that all gRPC client connections are centrally managed and reused. [[1]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cR86) [[2]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2R86-R88) [[3]](diffhunk://#diff-3a2c4c6ea7497d3cc956eafaf6b9d7434e2db45b76be2baea52cf2ca0f1121a2R107) [[4]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cR129-R139)

These changes collectively improve connection efficiency, reduce resource leaks, and make the codebase easier to maintain and test.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
