### PR TITLE
refactor(service): update registration delay constants

### DIFF
--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -57,8 +57,11 @@ import (
 )
 
 const (
-	incrementalDelayForRetryRegisterPeer = 10 * time.Millisecond
-	maxDelayForRetryRegisterPeer         = 50 * time.Millisecond
+	// incrementalDelayForRegisterPeer is the incremental delay for registering peer.
+	incrementalDelayForRegisterPeer = 20 * time.Millisecond
+
+	// maxDelayForRegisterPeer is the maximum delay for registering peer.
+	maxDelayForRegisterPeer = 100 * time.Millisecond
 )
 
 // V2 is the interface for v2 version of the service.
@@ -1118,7 +1121,7 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 
 	// Provides a linear backoff delay to prevent thundering herd problems. When a host has many concurrent registration requests, later requests
 	// are delayed progressively to avoid overwhelming the source with simultaneous back-to-source tasks from a single host.
-	if err := pkgtime.LinearDelay(ctx, uint(host.ConcurrentRegisterCount.Load()), incrementalDelayForRetryRegisterPeer, maxDelayForRetryRegisterPeer); err != nil {
+	if err := pkgtime.LinearDelay(ctx, uint(host.ConcurrentRegisterCount.Load()), incrementalDelayForRegisterPeer, maxDelayForRegisterPeer); err != nil {
 		// Collect RegisterPeerFailureCount metrics.
 		metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
 			peer.Host.Type.Name()).Inc()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the peer registration retry logic in the scheduler service to use a longer incremental and maximum delay. This change aims to further reduce the risk of overwhelming the source with simultaneous registration requests from a single host, improving system stability during high concurrency.

Improvements to peer registration backoff:

* Increased the incremental delay for registering peers from 10ms to 20ms and the maximum delay from 50ms to 100ms in `service_v2.go`.
* Updated the call to `pkgtime.LinearDelay` in the peer registration handler to use the new delay constants.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
