### PR TITLE
perf(scheduler): reduce peer registration delays

### DIFF
--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -57,10 +57,10 @@ import (
 
 const (
 	// incrementalDelayForRegisterPeer is the incremental delay for registering peer.
-	incrementalDelayForRegisterPeer = 20 * time.Millisecond
+	incrementalDelayForRegisterPeer = 10 * time.Millisecond
 
 	// maxDelayForRegisterPeer is the maximum delay for registering peer.
-	maxDelayForRegisterPeer = 100 * time.Millisecond
+	maxDelayForRegisterPeer = 70 * time.Millisecond
 )
 
 // V2 is the interface for v2 version of the service.
@@ -1119,7 +1119,7 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 			!task.HasAvailablePeer(hostID, blocklist):
 
 		// If HostType is normal, trigger seed peer download back-to-source.
-		if host.Type == types.HostTypeNormal {
+		if host.Type == types.HostTypeNormal && v.config.SeedPeer.Enable {
 			// If trigger the seed peer download back-to-source,
 			// the need back-to-source flag should be true.
 			download.NeedBackToSource = true
@@ -1611,7 +1611,7 @@ func (v *V2) downloadTaskBySeedPeer(ctx context.Context, taskID string, download
 	switch priority {
 	case commonv2.Priority_LEVEL6, commonv2.Priority_LEVEL0:
 		// Super peer is first triggered to download back-to-source.
-		if v.config.SeedPeer.Enable && !peer.Task.IsSeedPeerFailed() {
+		if !peer.Task.IsSeedPeerFailed() {
 			go func(ctx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
 				peer.Log.Infof("%s seed peer triggers download task", hostType.Name())
 				if err := v.resource.SeedPeer().TriggerDownloadTask(context.Background(), taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
@@ -1628,7 +1628,7 @@ func (v *V2) downloadTaskBySeedPeer(ctx context.Context, taskID string, download
 		fallthrough
 	case commonv2.Priority_LEVEL5:
 		// Super peer is first triggered to download back-to-source.
-		if v.config.SeedPeer.Enable && !peer.Task.IsSeedPeerFailed() {
+		if !peer.Task.IsSeedPeerFailed() {
 			go func(ctx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
 				peer.Log.Infof("%s seed peer triggers download task", hostType.Name())
 				if err := v.resource.SeedPeer().TriggerDownloadTask(context.Background(), taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {
@@ -1645,7 +1645,7 @@ func (v *V2) downloadTaskBySeedPeer(ctx context.Context, taskID string, download
 		fallthrough
 	case commonv2.Priority_LEVEL4:
 		// Super peer is first triggered to download back-to-source.
-		if v.config.SeedPeer.Enable && !peer.Task.IsSeedPeerFailed() {
+		if !peer.Task.IsSeedPeerFailed() {
 			go func(ctx context.Context, taskID string, download *commonv2.Download, hostType types.HostType) {
 				peer.Log.Infof("%s seed peer triggers download task", hostType.Name())
 				if err := v.resource.SeedPeer().TriggerDownloadTask(context.Background(), taskID, &dfdaemonv2.DownloadTaskRequest{Download: download}); err != nil {

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -1608,6 +1608,7 @@ func TestServiceV2_handleRegisterPeerRequest(t *testing.T) {
 				)
 
 				peer.Priority = commonv2.Priority_LEVEL1
+				svc.config.SeedPeer.Enable = true
 
 				assert := assert.New(t)
 				assert.ErrorIs(svc.handleRegisterPeerRequest(context.Background(), stream, peer.Host.ID, peer.Task.ID, peer.ID, req),
@@ -1638,6 +1639,7 @@ func TestServiceV2_handleRegisterPeerRequest(t *testing.T) {
 				peer.Task.StorePeer(peer)
 				peer.Task.StorePeer(seedPeer)
 				seedPeer.FSM.SetState(standard.PeerStateRunning)
+				svc.config.SeedPeer.Enable = true
 
 				assert := assert.New(t)
 				assert.ErrorIs(svc.handleRegisterPeerRequest(context.Background(), stream, peer.Host.ID, peer.Task.ID, peer.ID, req),
@@ -3210,17 +3212,11 @@ func TestServiceV2_handleResource(t *testing.T) {
 
 func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 	tests := []struct {
-		name   string
-		config config.Config
-		run    func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder)
+		name string
+		run  func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder)
 	}{
 		{
-			name: "priority is Priority_LEVEL6 and enable seed peer",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
+			name: "priority is Priority_LEVEL6",
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				var wg sync.WaitGroup
 				wg.Add(1)
@@ -3239,12 +3235,7 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 			},
 		},
 		{
-			name: "priority is Priority_LEVEL6, enable seed peer and download task failed",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
+			name: "priority is Priority_LEVEL6 and download task failed",
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				var wg sync.WaitGroup
 				wg.Add(1)
@@ -3263,27 +3254,7 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 			},
 		},
 		{
-			name: "priority is Priority_LEVEL6 and disable seed peer",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: false,
-				},
-			},
-			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
-				peer.Priority = commonv2.Priority_LEVEL6
-
-				assert := assert.New(t)
-				assert.NoError(svc.downloadTaskBySeedPeer(context.Background(), mockTaskID, &commonv2.Download{}, peer))
-				assert.True(peer.NeedBackToSource.Load())
-			},
-		},
-		{
-			name: "priority is Priority_LEVEL5 and enable seed peer",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
+			name: "priority is Priority_LEVEL5",
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				var wg sync.WaitGroup
 				wg.Add(1)
@@ -3302,12 +3273,7 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 			},
 		},
 		{
-			name: "priority is Priority_LEVEL5, enable seed peer and download task failed",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
+			name: "priority is Priority_LEVEL5 and download task failed",
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				var wg sync.WaitGroup
 				wg.Add(1)
@@ -3326,27 +3292,7 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 			},
 		},
 		{
-			name: "priority is Priority_LEVEL5 and disable seed peer",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: false,
-				},
-			},
-			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
-				peer.Priority = commonv2.Priority_LEVEL5
-
-				assert := assert.New(t)
-				assert.NoError(svc.downloadTaskBySeedPeer(context.Background(), mockTaskID, &commonv2.Download{}, peer))
-				assert.True(peer.NeedBackToSource.Load())
-			},
-		},
-		{
-			name: "priority is Priority_LEVEL4 and enable seed peer",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
+			name: "priority is Priority_LEVEL4",
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				var wg sync.WaitGroup
 				wg.Add(1)
@@ -3365,12 +3311,7 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 			},
 		},
 		{
-			name: "priority is Priority_LEVEL4, enable seed peer and download task failed",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
+			name: "priority is Priority_LEVEL4 and download task failed",
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				var wg sync.WaitGroup
 				wg.Add(1)
@@ -3386,30 +3327,10 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 				assert := assert.New(t)
 				assert.NoError(svc.downloadTaskBySeedPeer(context.Background(), mockTaskID, &commonv2.Download{}, peer))
 				assert.False(peer.NeedBackToSource.Load())
-			},
-		},
-		{
-			name: "priority is Priority_LEVEL4 and disable seed peer",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: false,
-				},
-			},
-			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
-				peer.Priority = commonv2.Priority_LEVEL4
-
-				assert := assert.New(t)
-				assert.NoError(svc.downloadTaskBySeedPeer(context.Background(), mockTaskID, &commonv2.Download{}, peer))
-				assert.True(peer.NeedBackToSource.Load())
 			},
 		},
 		{
 			name: "priority is Priority_LEVEL3",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				peer.Priority = commonv2.Priority_LEVEL3
 
@@ -3420,11 +3341,6 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 		},
 		{
 			name: "priority is Priority_LEVEL2",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				peer.Priority = commonv2.Priority_LEVEL2
 
@@ -3434,11 +3350,6 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 		},
 		{
 			name: "priority is Priority_LEVEL1",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				peer.Priority = commonv2.Priority_LEVEL1
 
@@ -3448,11 +3359,6 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 		},
 		{
 			name: "priority is Priority_LEVEL0",
-			config: config.Config{
-				SeedPeer: config.SeedPeerConfig{
-					Enable: true,
-				},
-			},
 			run: func(t *testing.T, svc *V2, peer *standard.Peer, seedPeerClient standard.SeedPeer, mr *standard.MockResourceMockRecorder, ms *standard.MockSeedPeerMockRecorder) {
 				peer.Priority = commonv2.Priority(100)
 
@@ -3479,7 +3385,7 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
-			svc := NewV2(&tc.config, resource, persistentCacheResource, scheduling, job, internalJobImage, dynconfig)
+			svc := NewV2(&config.Config{}, resource, persistentCacheResource, scheduling, job, internalJobImage, dynconfig)
 
 			tc.run(t, svc, peer, seedPeerClient, resource.EXPECT(), seedPeerClient.EXPECT())
 		})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refines the logic for triggering seed peer downloads and simplifies related configuration handling in both the main service and its tests. The key changes focus on removing unnecessary checks for the seed peer enable flag in some code paths, updating delay timings, and streamlining test setup by eliminating redundant configuration fields.

**Seed peer download logic updates:**

* Removed checks for the `SeedPeer.Enable` flag when triggering seed peer downloads for priorities LEVEL6, LEVEL5, and LEVEL4 in `downloadTaskBySeedPeer`, so downloads are triggered based solely on the task's state. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1614-R1614) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1631-R1631) [[3]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1648-R1648)
* In `handleRegisterPeerRequest`, now only triggers seed peer download for normal hosts if the seed peer feature is enabled, making this check more explicit and centralized.

**Configuration and timing adjustments:**

* Reduced the incremental and maximum delays for registering peers, which should improve responsiveness.

**Test suite simplification:**

* Removed the `config` field from most test cases in `TestServiceV2_downloadTaskBySeedPeer`, relying on default configuration instead and eliminating redundant checks for seed peer enablement. [[1]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3214-R3219) [[2]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3242-R3238) [[3]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3266-R3257) [[4]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3305-R3276) [[5]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3329-R3295) [[6]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3368-R3314) [[7]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3391-L3412) [[8]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3423-L3427) [[9]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3437-L3441) [[10]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0L3451-L3455)
* Updated test setup to use a default config object instead of custom configurations for each test case, further simplifying the test code.
* Explicitly enables the seed peer feature in certain test scenarios for clarity and correctness. [[1]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0R1611) [[2]](diffhunk://#diff-f058982d2b4f91b2025ecf0681503734a5e3b3f07a78321bfa26d4a3096783b0R1642)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
