### PR TITLE
fix(evaluator): update normal distribution threshold

### DIFF
--- a/scheduler/scheduling/evaluator/evaluator.go
+++ b/scheduler/scheduling/evaluator/evaluator.go
@@ -46,9 +46,9 @@ const (
 	// Maximum number of elements.
 	maxElementLen = 5
 
-	// If the number of samples is greater than or equal to 30,
+	// If the number of samples is greater than or equal to 2000,
 	// it is close to the normal distribution.
-	normalDistributionLen = 30
+	normalDistributionLen = 2000
 
 	// When costs len is greater than or equal to 2,
 	// the last cost can be compared and calculated.

--- a/scheduler/scheduling/evaluator/evaluator_default_test.go
+++ b/scheduler/scheduling/evaluator/evaluator_default_test.go
@@ -1101,10 +1101,10 @@ func TestEvaluatorDefault_IsBadParent(t *testing.T) {
 			totalPieceCount: 1,
 			mock: func(peer *standard.Peer) {
 				peer.FSM.SetState(standard.PeerStateRunning)
-				for i := range 30 {
+				for i := range 2000 {
 					peer.AppendPieceCost(time.Duration(i))
 				}
-				peer.AppendPieceCost(50)
+				peer.AppendPieceCost(5000)
 			},
 			expect: func(t *testing.T, isBadParent bool) {
 				assert := assert.New(t)
@@ -1117,10 +1117,10 @@ func TestEvaluatorDefault_IsBadParent(t *testing.T) {
 			totalPieceCount: 1,
 			mock: func(peer *standard.Peer) {
 				peer.FSM.SetState(standard.PeerStateRunning)
-				for i := range 30 {
+				for i := range 2000 {
 					peer.AppendPieceCost(time.Duration(i))
 				}
-				peer.AppendPieceCost(18)
+				peer.AppendPieceCost(20)
 			},
 			expect: func(t *testing.T, isBadParent bool) {
 				assert := assert.New(t)
@@ -1133,7 +1133,7 @@ func TestEvaluatorDefault_IsBadParent(t *testing.T) {
 			totalPieceCount: 1,
 			mock: func(peer *standard.Peer) {
 				peer.FSM.SetState(standard.PeerStateRunning)
-				for i := 20; i < 50; i++ {
+				for i := 20; i < 2020; i++ {
 					peer.AppendPieceCost(time.Duration(i))
 				}
 				peer.AppendPieceCost(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a small but important adjustment to the scheduling evaluator logic. The threshold for considering a sample set "close to the normal distribution" has been increased from 30 to 1000, which will affect how statistical assumptions are made in the evaluator.

- Increased the `normalDistributionLen` constant in `evaluator.go` from 30 to 1000, meaning the evaluator now requires at least 1000 samples before treating the distribution as approximately normal.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
