### PR TITLE
fix(scheduler): add output_path option for preheatFile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module d7y.io/dragonfly/v2
 go 1.23.8
 
 require (
-	d7y.io/api/v2 v2.1.83
+	d7y.io/api/v2 v2.1.85
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-d7y.io/api/v2 v2.1.83 h1:MC/RRRaGRsTMBgOOqVRFQsT7/i4ZdV5Zi23NRsUj8Kk=
-d7y.io/api/v2 v2.1.83/go.mod h1:t6k27g8dFyH6sp3y2J1qHyk2YmoySd88qSbsEaqJ2Sw=
+d7y.io/api/v2 v2.1.85 h1:9EYGogAbc1HJfq9+cv3ZtGWM+6PwfRhZpIjfyfj/BLA=
+d7y.io/api/v2 v2.1.85/go.mod h1:t6k27g8dFyH6sp3y2J1qHyk2YmoySd88qSbsEaqJ2Sw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

--- a/internal/job/types.go
+++ b/internal/job/types.go
@@ -51,6 +51,7 @@ type PreheatRequest struct {
 	TaskUUID            string            `json:"task_uuid" validate:"omitempty"`
 	ObjectStorage       *v2.ObjectStorage `json:"object_storage" validate:"omitempty"`
 	Hdfs                *v2.HDFS          `json:"hdfs" validate:"omitempty"`
+	OutputPath          *string           `json:"output_path" validate:"omitempty"`
 }
 
 // PreheatResponse defines the response parameters for preheating.

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -386,6 +386,7 @@ func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req 
 			Timeout:             durationpb.New(req.Timeout),
 			ObjectStorage:       req.ObjectStorage,
 			Hdfs:                req.Hdfs,
+			OutputPath:          req.OutputPath,
 		}})
 	if err != nil {
 		log.Errorf("[preheat]: preheat failed: %s", err.Error())
@@ -486,6 +487,7 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 							RemoteIp:            &advertiseIP,
 							ObjectStorage:       req.ObjectStorage,
 							Hdfs:                req.Hdfs,
+							OutputPath:          req.OutputPath,
 						}})
 					if err != nil {
 						log.Errorf("[preheat]: preheat failed: %s", err.Error())
@@ -705,6 +707,7 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 							RemoteIp:            &advertiseIP,
 							ObjectStorage:       req.ObjectStorage,
 							Hdfs:                req.Hdfs,
+							OutputPath:          req.OutputPath,
 						}})
 					if err != nil {
 						log.Errorf("[preheat]: preheat failed: %s", err.Error())

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -3240,6 +3240,7 @@ func (v *V2) PreheatFile(ctx context.Context, req *schedulerv2.PreheatFileReques
 		InsecureSkipVerify:  req.GetInsecureSkipVerify(),
 		ObjectStorage:       req.GetObjectStorage(),
 		Hdfs:                req.GetHdfs(),
+		OutputPath:          req.OutputPath,
 	}
 
 	switch req.GetScope() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add output_path option when preheat a directory/file, which will hard link to the preheated tasks path. 

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/4473

## Motivation and Context
After preheat directory/file by scheduler, such as model service can use model by output_path without csi plugins and no need to trigger download again.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
