### PR TITLE
fix: prevent ticker resource leak in GC task lifecycle

### DIFF
--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -117,6 +117,7 @@ func (g gc) Start(ctx context.Context) {
 		go func() {
 			task := v.(Task)
 			tick := time.NewTicker(task.Interval)
+			defer tick.Stop()
 			for {
 				select {
 				case <-tick.C:


### PR DESCRIPTION
e leak in GC task manager by adding `defer tick.Stop()` to properly clean up ticker when goroutines exit.

## Related Issue

Preventive fix for resource leak discovered during code review.

## Motivation and Context

When `gc.Start()` creates goroutines with `time.NewTicker`, the tickers were never stopped, causing resource leaks in long-running services. Go documentation requires calling `Stop()` to release ticker resources.

This one-line fix adds `defer tick.Stop()` after ticker creation, ensuring cleanup when goroutines exit via the `<-g.done` channel.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the **CONTRIBUTING** document.