### PR TITLE
feat(scheduler): avoid double-stop panic

### DIFF
--- a/scheduler/resource/standard/resource.go
+++ b/scheduler/resource/standard/resource.go
@@ -49,7 +49,7 @@ type Resource interface {
 	Serve() error
 
 	// Stop resource service.
-	Stop() error
+	Stop()
 }
 
 // resource contains content for resource.
@@ -147,12 +147,10 @@ func (r *resource) Serve() error {
 }
 
 // Stop resource service.
-func (r *resource) Stop() error {
-	r.peerClientPool.Stop()
-
+func (r *resource) Stop() {
 	if r.config.SeedPeer.Enable {
-		return r.seedPeer.Stop()
+		r.seedPeer.Stop()
 	}
 
-	return nil
+	r.peerClientPool.Stop()
 }

--- a/scheduler/resource/standard/resource_mock.go
+++ b/scheduler/resource/standard/resource_mock.go
@@ -111,11 +111,9 @@ func (mr *MockResourceMockRecorder) Serve() *gomock.Call {
 }
 
 // Stop mocks base method.
-func (m *MockResource) Stop() error {
+func (m *MockResource) Stop() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stop")
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "Stop")
 }
 
 // Stop indicates an expected call of Stop.

--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -72,7 +72,7 @@ type SeedPeer interface {
 	Serve() error
 
 	// Stop seed peer service.
-	Stop() error
+	Stop()
 }
 
 // seedPeer contains content for seed peer.
@@ -381,9 +381,6 @@ func (s *seedPeer) Serve() error {
 }
 
 // Stop seed peer service.
-func (s *seedPeer) Stop() error {
-	s.clientPool.Stop()
-
+func (s *seedPeer) Stop() {
 	close(s.done)
-	return nil
 }

--- a/scheduler/resource/standard/seed_peer_mock.go
+++ b/scheduler/resource/standard/seed_peer_mock.go
@@ -73,11 +73,9 @@ func (mr *MockSeedPeerMockRecorder) Serve() *gomock.Call {
 }
 
 // Stop mocks base method.
-func (m *MockSeedPeer) Stop() error {
+func (m *MockSeedPeer) Stop() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stop")
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "Stop")
 }
 
 // Stop indicates an expected call of Stop.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -323,11 +323,8 @@ func (s *Server) Stop() {
 	}
 
 	// Stop resource.
-	if err := s.resource.Stop(); err != nil {
-		logger.Errorf("stop resource failed %s", err.Error())
-	} else {
-		logger.Info("stop resource closed")
-	}
+	s.resource.Stop()
+	logger.Info("stop resource closed")
 
 	// Stop GC.
 	s.gc.Stop()


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Change Resource/SeedPeer Stop signatures to no-return and stop services in a safe order. Fix panic caused by calling Stop multiple times by ensuring seed peer shutdown doesn’t re-stop pools and scheduler stop no longer handles Stop errors.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
