### PR TITLE
feat: support persistent peer back-to-source and improve error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module d7y.io/dragonfly/v2
 go 1.23.8
 
 require (
-	d7y.io/api/v2 v2.2.6
+	d7y.io/api/v2 v2.2.8
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-d7y.io/api/v2 v2.2.6 h1:hUYJRG4SSjJkRaliOCLjqfOdxqq5OsAYSC+3ZfXkJgA=
-d7y.io/api/v2 v2.2.6/go.mod h1:TtW9UE0CebRB/CWIEbWfRnljmpKf/mNoe2qIUO+PoP0=
+d7y.io/api/v2 v2.2.8 h1:XNgIVHgij3VbNRri74cW2eLV4hIkN5v8FE6yB1YQEXs=
+d7y.io/api/v2 v2.2.8/go.mod h1:TtW9UE0CebRB/CWIEbWfRnljmpKf/mNoe2qIUO+PoP0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

--- a/scheduler/resource/persistent/peer_manager.go
+++ b/scheduler/resource/persistent/peer_manager.go
@@ -217,8 +217,8 @@ local host_id = ARGV[7]
 local cost = ARGV[8]
 local created_at = ARGV[9]
 local updated_at = ARGV[10]
-local ttl_seconds = tonumber(ARGV[11])
-local concurrent_piece_count = ARGV[12]
+local concurrent_piece_count = ARGV[11]
+local ttl_seconds = tonumber(ARGV[12])
 
 -- Store peer information
 redis.call("HSET", peer_key,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces several improvements and bug fixes to the persistent peer management and scheduling logic, with a focus on enhancing metrics collection, error handling, and support for back-to-source download scenarios. It also updates dependencies and cleans up some parameter handling in the code.

**Metrics and Error Handling Improvements:**

- Added extensive metrics collection for failure cases in both regular and persistent peer registration, as well as during scheduling and storage operations. This will help with monitoring and diagnosing issues in production. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR1371-R1380) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR1390-R1403) [[3]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR1423-R1425) [[4]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR2054-R2101) [[5]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR2111-R2126) [[6]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR2136-R2156) [[7]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR2273-R2281) [[8]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR2293-R2302)

**Persistent Peer Registration and Back-to-Source Enhancements:**

- Refactored `handleRegisterPersistentPeerRequest` to better determine when a peer needs to download back-to-source, considering task state and available peers, and to send the appropriate response. Also, improved error handling and state transitions.
- Updated the persistent peer registration handler to accept a `needBackToSource` parameter, enabling more flexible control over download source selection. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1919-R1935) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL2009-R2034)

**Support for New gRPC Request Types:**

- Added support for new gRPC request types related to back-to-source downloads in the persistent peer announcement handler, including handling of started, finished, and failed events for both peers and pieces. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1930-R1947) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1957-R1973) [[3]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1973-R1989) [[4]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1983-R2021)
- Implemented `handleDownloadPersistentPieceBackToSourceFinishedRequest` to correctly process and update state for pieces downloaded back-to-source.

**Bug Fixes and Code Quality:**

- Fixed a bug in `handleDownloadPersistentPieceFinishedRequest` where the parent peer existence check was inverted, ensuring proper error reporting if the parent peer is not found.
- Cleaned up parameter order in Lua script argument handling for peer manager.

**Dependency Update:**

- Updated the dependency on `d7y.io/api/v2` from version `v2.2.6` to `v2.2.8`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
