### PR TITLE
feat(scheduler): Add task completion status tracking for preheatImage/preheatFile

### DIFF
--- a/internal/job/types.go
+++ b/internal/job/types.go
@@ -111,12 +111,13 @@ type ListTaskEntriesResponse struct {
 
 // Peer represents the peer information.
 type Peer struct {
-	ID        string    `json:"id"`
-	Hostname  string    `json:"hostname"`
-	IP        string    `json:"ip"`
-	HostType  string    `json:"host_type"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID         string    `json:"id"`
+	Hostname   string    `json:"hostname"`
+	IP         string    `json:"ip"`
+	HostType   string    `json:"host_type"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	IsFinished bool      `json:"IsFinished"`
 }
 
 // DeleteTaskRequest defines the request parameters for deleting task.

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -929,22 +929,24 @@ func (j *job) GetTask(ctx context.Context, req *internaljob.GetTaskRequest, log 
 			}
 
 			advertiseIP := j.config.Server.AdvertiseIP.String()
-			if _, err = dfdaemonClient.StatLocalTask(ctx, &dfdaemonv2.StatLocalTaskRequest{
+			localTask, err := dfdaemonClient.StatLocalTask(ctx, &dfdaemonv2.StatLocalTaskRequest{
 				TaskId:   req.TaskID,
 				RemoteIp: &advertiseIP,
-			}); err != nil {
+			})
+			if err != nil {
 				log.Errorf("[get-task] stat task failed: %s", err.Error())
 				return nil
 			}
 
 			mu.Lock()
 			resp.Peers = append(resp.Peers, &internaljob.Peer{
-				ID:        host.ID,
-				Hostname:  host.Hostname,
-				IP:        host.IP,
-				HostType:  host.Type.Name(),
-				CreatedAt: host.CreatedAt.Load(),
-				UpdatedAt: host.UpdatedAt.Load(),
+				ID:         host.ID,
+				Hostname:   host.Hostname,
+				IP:         host.IP,
+				HostType:   host.Type.Name(),
+				CreatedAt:  host.CreatedAt.Load(),
+				UpdatedAt:  host.UpdatedAt.Load(),
+				IsFinished: localTask.FinishedAt != nil,
 			})
 			mu.Unlock()
 

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -4642,10 +4642,13 @@ func (v *V2) StatImage(ctx context.Context, req *schedulerv2.StatImageRequest) (
 					peers[hostID] = &schedulerv2.PeerImage{
 						Ip:           peer.IP,
 						Hostname:     peer.Hostname,
-						CachedLayers: []*schedulerv2.Layer{{Url: url}},
+						CachedLayers: []*schedulerv2.Layer{{Url: url, IsFinished: &peer.IsFinished}},
 					}
 				} else {
-					peers[hostID].CachedLayers = append(peers[hostID].CachedLayers, &schedulerv2.Layer{Url: url})
+					peers[hostID].CachedLayers = append(peers[hostID].CachedLayers, &schedulerv2.Layer{
+						Url:        url,
+						IsFinished: &peer.IsFinished,
+					})
 				}
 				mu.Unlock()
 			}
@@ -4882,6 +4885,7 @@ func (v *V2) StatFile(ctx context.Context, req *schedulerv2.StatFileRequest) (*s
 
 			log := logger.WithStatFileAndTaskID(url, taskID)
 			log.Infof("get task request: %#v", getTaskRequest)
+
 			task, err := v.job.GetTask(ctx, getTaskRequest, log)
 			if err != nil {
 				log.Errorf("get task failed: %s", err.Error())
@@ -4894,9 +4898,15 @@ func (v *V2) StatFile(ctx context.Context, req *schedulerv2.StatFileRequest) (*s
 				mu.Lock()
 				if _, exists := peers[hostID]; !exists {
 					peers[hostID] = &schedulerv2.PeerFile{
-						Ip:       peer.IP,
-						Hostname: peer.Hostname,
+						Ip:          peer.IP,
+						Hostname:    peer.Hostname,
+						CachedFiles: []*schedulerv2.File{{Url: url, IsFinished: &peer.IsFinished}},
 					}
+				} else {
+					peers[hostID].CachedFiles = append(peers[hostID].CachedFiles, &schedulerv2.File{
+						Url:        url,
+						IsFinished: &peer.IsFinished,
+					})
 				}
 				mu.Unlock()
 			}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add TaskFinished field to the Peer struct to indicate whether the task is completed
- Modify the GetTask method to get task completion status via dfdaemonClient.StatLocalTask
- Pass task completion status to CachedLayers and CachedFiles in StatImage and StatFile methods of the V2 service
- Refactor code formatting, standardize struct field alignment

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4526

## Motivation and Context

Users can know the preheat completion state by api call and the feature can be integrated by platform

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
