### PR TITLE
fix(peer): update event transition for failed state

### DIFF
--- a/scheduler/resource/persistent/peer.go
+++ b/scheduler/resource/persistent/peer.go
@@ -150,7 +150,7 @@ func NewPeer(id, state string, isPersistent bool, finishedPieces *bitset.BitSet,
 			fsm.EventDesc{Name: PeerEventRegisterNormal, Src: []string{PeerStatePending, PeerStateFailed}, Dst: PeerStateReceivedNormal},
 			fsm.EventDesc{Name: PeerEventDownload, Src: []string{PeerStateReceivedEmpty, PeerStateReceivedNormal}, Dst: PeerStateRunning},
 			fsm.EventDesc{Name: PeerEventSucceeded, Src: []string{PeerStateUploading, PeerStateRunning}, Dst: PeerStateSucceeded},
-			fsm.EventDesc{Name: PeerEventFailed, Src: []string{PeerStateUploading, PeerStateRunning}, Dst: PeerStateFailed},
+			fsm.EventDesc{Name: PeerEventFailed, Src: []string{PeerStatePending, PeerStateReceivedEmpty, PeerStateReceivedNormal, PeerStateUploading, PeerStateRunning}, Dst: PeerStateFailed},
 		},
 		fsm.Callbacks{
 			PeerEventUpload: func(ctx context.Context, e *fsm.Event) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the peer state machine logic to allow the `PeerEventFailed` event to transition from additional states. This change broadens the scenarios under which a peer can enter the failed state, making the peer lifecycle more robust and fault-tolerant.

**Peer state machine improvements:**

* Expanded the allowed source states for the `PeerEventFailed` transition in `NewPeer` (in `peer.go`), so that peers in `PeerStatePending`, `PeerStateReceivedEmpty`, and `PeerStateReceivedNormal` can now also transition to `PeerStateFailed`, in addition to the previously allowed `PeerStateUploading` and `PeerStateRunning` states.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
