### PR TITLE
refactor: improve error handling and optimize peer store operations

### DIFF
--- a/scheduler/resource/persistent/host_manager.go
+++ b/scheduler/resource/persistent/host_manager.go
@@ -711,8 +711,7 @@ return true
 	}
 
 	// Execute the script.
-	err := script.Run(ctx, h.rdb, keys, args...).Err()
-	if err != nil {
+	if err := script.Run(ctx, h.rdb, keys, args...).Err(); err != nil {
 		log.Errorf("delete host failed: %v", err)
 		return err
 	}

--- a/scheduler/resource/persistent/peer_manager.go
+++ b/scheduler/resource/persistent/peer_manager.go
@@ -282,8 +282,7 @@ return true
 	}
 
 	// Execute the script.
-	err = script.Run(ctx, p.rdb, keys, args...).Err()
-	if err != nil {
+	if err = script.Run(ctx, p.rdb, keys, args...).Err(); err != nil {
 		peer.Log.Errorf("store peer failed: %v", err)
 		return err
 	}

--- a/scheduler/resource/persistent/task_manager.go
+++ b/scheduler/resource/persistent/task_manager.go
@@ -216,8 +216,7 @@ return true
 	}
 
 	// Execute the script.
-	err := script.Run(ctx, t.rdb, keys, args...).Err()
-	if err != nil {
+	if err := script.Run(ctx, t.rdb, keys, args...).Err(); err != nil {
 		task.Log.Errorf("store task failed: %v", err)
 		return err
 	}

--- a/scheduler/resource/persistentcache/host_manager.go
+++ b/scheduler/resource/persistentcache/host_manager.go
@@ -711,8 +711,7 @@ return true
 	}
 
 	// Execute the script.
-	err := script.Run(ctx, h.rdb, keys, args...).Err()
-	if err != nil {
+	if err := script.Run(ctx, h.rdb, keys, args...).Err(); err != nil {
 		log.Errorf("delete host failed: %v", err)
 		return err
 	}

--- a/scheduler/resource/persistentcache/peer_manager.go
+++ b/scheduler/resource/persistentcache/peer_manager.go
@@ -282,8 +282,7 @@ return true
 	}
 
 	// Execute the script.
-	err = script.Run(ctx, p.rdb, keys, args...).Err()
-	if err != nil {
+	if err = script.Run(ctx, p.rdb, keys, args...).Err(); err != nil {
 		peer.Log.Errorf("store peer failed: %v", err)
 		return err
 	}

--- a/scheduler/resource/persistentcache/task_manager.go
+++ b/scheduler/resource/persistentcache/task_manager.go
@@ -222,8 +222,7 @@ return true
 	}
 
 	// Execute the script.
-	err := script.Run(ctx, t.rdb, keys, args...).Err()
-	if err != nil {
+	if err := script.Run(ctx, t.rdb, keys, args...).Err(); err != nil {
 		task.Log.Errorf("store task failed: %v", err)
 		return err
 	}

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1996,32 +1996,24 @@ func (v *V2) AnnouncePersistentPeer(stream schedulerv2.Scheduler_AnnouncePersist
 			return nil
 		case *schedulerv2.AnnouncePersistentPeerRequest_DownloadPieceFinishedRequest:
 			log.Info("receive DownloadPieceFinishedRequest")
-			go func() {
-				if err := v.handleDownloadPersistentPieceFinishedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceFinishedRequest); err != nil {
-					log.Error(err)
-				}
-			}()
+			if err := v.handleDownloadPersistentPieceFinishedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceFinishedRequest); err != nil {
+				log.Error(err)
+			}
 		case *schedulerv2.AnnouncePersistentPeerRequest_DownloadPieceBackToSourceFinishedRequest:
 			log.Info("receive DownloadPieceBackToSourceFinishedRequest")
-			go func() {
-				if err := v.handleDownloadPersistentPieceBackToSourceFinishedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceBackToSourceFinishedRequest); err != nil {
-					log.Error(err)
-				}
-			}()
+			if err := v.handleDownloadPersistentPieceBackToSourceFinishedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceBackToSourceFinishedRequest); err != nil {
+				log.Error(err)
+			}
 		case *schedulerv2.AnnouncePersistentPeerRequest_DownloadPieceFailedRequest:
 			log.Info("receive DownloadPieceFailedRequest")
-			go func() {
-				if err := v.handleDownloadPersistentPieceFailedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceFailedRequest); err != nil {
-					log.Error(err)
-				}
-			}()
+			if err := v.handleDownloadPersistentPieceFailedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceFailedRequest); err != nil {
+				log.Error(err)
+			}
 		case *schedulerv2.AnnouncePersistentPeerRequest_DownloadPieceBackToSourceFailedRequest:
-			log.Info("receive DownloadPieceFailedRequest")
-			go func() {
-				if err := v.handleDownloadPersistentPieceBackToSourceFailedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceBackToSourceFailedRequest); err != nil {
-					log.Error(err)
-				}
-			}()
+			log.Info("receive DownloadPieceBackToSourceFailedRequest")
+			if err := v.handleDownloadPersistentPieceBackToSourceFailedRequest(context.Background(), req.GetPeerId(), announcePersistentPeerRequest.DownloadPieceBackToSourceFailedRequest); err != nil {
+				log.Error(err)
+			}
 		default:
 			msg := fmt.Sprintf("receive unknow request: %#v", announcePersistentPeerRequest)
 			log.Error(msg)
@@ -2546,17 +2538,17 @@ func (v *V2) handleDownloadPersistentPieceFinishedRequest(ctx context.Context, p
 	peer.FinishedPieces.Set(uint(piece.GetNumber()))
 	peer.UpdatedAt = time.Now()
 
+	// Update metadata of the persistent peer.
+	if err := v.persistentResource.PeerManager().Store(ctx, peer); err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+
 	parent, loadedParent := v.persistentResource.PeerManager().Load(ctx, piece.GetParentId())
 	if !loadedParent {
 		return status.Errorf(codes.NotFound, "parent peer %s not found", piece.GetParentId())
 	}
 	parent.UpdatedAt = time.Now()
 	parent.Host.UpdatedAt = time.Now()
-
-	// Update metadata of the persistent peer.
-	if err := v.persistentResource.PeerManager().Store(ctx, peer); err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
 
 	// Update metadata of the persistent peer's parent.
 	if err := v.persistentResource.PeerManager().Store(ctx, parent); err != nil {
@@ -3288,18 +3280,14 @@ func (v *V2) AnnouncePersistentCachePeer(stream schedulerv2.Scheduler_AnnouncePe
 			return nil
 		case *schedulerv2.AnnouncePersistentCachePeerRequest_DownloadPieceFinishedRequest:
 			log.Info("receive DownloadPieceFinishedRequest")
-			go func() {
-				if err := v.handleDownloadPersistentCachePieceFinishedRequest(context.Background(), req.GetPeerId(), announcePersistentCachePeerRequest.DownloadPieceFinishedRequest); err != nil {
-					log.Error(err)
-				}
-			}()
+			if err := v.handleDownloadPersistentCachePieceFinishedRequest(context.Background(), req.GetPeerId(), announcePersistentCachePeerRequest.DownloadPieceFinishedRequest); err != nil {
+				log.Error(err)
+			}
 		case *schedulerv2.AnnouncePersistentCachePeerRequest_DownloadPieceFailedRequest:
 			log.Info("receive DownloadPieceFailedRequest")
-			go func() {
-				if err := v.handleDownloadPersistentCachePieceFailedRequest(context.Background(), req.GetPeerId(), announcePersistentCachePeerRequest.DownloadPieceFailedRequest); err != nil {
-					log.Error(err)
-				}
-			}()
+			if err := v.handleDownloadPersistentCachePieceFailedRequest(context.Background(), req.GetPeerId(), announcePersistentCachePeerRequest.DownloadPieceFailedRequest); err != nil {
+				log.Error(err)
+			}
 		default:
 			msg := fmt.Sprintf("receive unknow request: %#v", announcePersistentCachePeerRequest)
 			log.Error(msg)
@@ -3784,17 +3772,17 @@ func (v *V2) handleDownloadPersistentCachePieceFinishedRequest(ctx context.Conte
 	peer.FinishedPieces.Set(uint(piece.GetNumber()))
 	peer.UpdatedAt = time.Now()
 
+	// Update metadata of the persistent cache peer.
+	if err := v.persistentCacheResource.PeerManager().Store(ctx, peer); err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+
 	parent, loadedParent := v.persistentCacheResource.PeerManager().Load(ctx, piece.GetParentId())
 	if !loadedParent {
 		return status.Errorf(codes.NotFound, "parent peer %s not found", piece.GetParentId())
 	}
 	parent.UpdatedAt = time.Now()
 	parent.Host.UpdatedAt = time.Now()
-
-	// Update metadata of the persistent cache peer.
-	if err := v.persistentCacheResource.PeerManager().Store(ctx, peer); err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
 
 	// Update metadata of the persistent cache peer's parent.
 	if err := v.persistentCacheResource.PeerManager().Store(ctx, parent); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors several areas of the scheduler service to improve code clarity, error handling, and execution flow. The main changes include simplifying error handling for Redis script execution, adjusting the order of metadata updates for peers and their parents, and removing unnecessary goroutines to make request handling synchronous. These improvements help make the code more readable and maintainable.

**Error handling improvements:**

* Refactored error handling for Redis script execution in `host_manager.go`, `peer_manager.go`, and `task_manager.go` (both in `persistent` and `persistentcache` directories) to use inline error assignment, reducing variable scope and improving readability. [[1]](diffhunk://#diff-3afcd068d15f49725a3af20c7ef92d7de55312744142305b7725d4d4afec95eaL714-R714) [[2]](diffhunk://#diff-435eb255fc9e74f612a1badc908bc0886b8ea3148a910fb50021074305c8224eL285-R285) [[3]](diffhunk://#diff-274bad5ac865184e63a32757fddba4249a613cefbbad675892722c0f21876ec4L219-R219) [[4]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dL714-R714) [[5]](diffhunk://#diff-243b8e8011a1eb5e57b015c90ddff263d31ea40d2123fe67763fd114a6486452L285-R285) [[6]](diffhunk://#diff-76057be354335f231655112ecad644f6c482e712b67d75ab6ed6fc18894e9cd9L225-R225)

**Execution flow and concurrency:**

* Removed unnecessary goroutines in the `AnnouncePersistentPeer` and `AnnouncePersistentCachePeer` handlers in `service_v2.go`, making request processing synchronous and easier to follow. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL1999-L2024) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL3291-L3302)

**Order of metadata updates:**

* Changed the order of updating peer and parent metadata in `handleDownloadPersistentPieceFinishedRequest` and `handleDownloadPersistentCachePieceFinishedRequest` to ensure the peer is updated before its parent, which can help prevent potential inconsistencies. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR2541-L2560) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR3775-L3798)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
