### PR TITLE
feat(scheduler): add Name field to Host struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module d7y.io/dragonfly/v2
 go 1.25.5
 
 require (
-	d7y.io/api/v2 v2.2.8
+	d7y.io/api/v2 v2.2.9
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-d7y.io/api/v2 v2.2.8 h1:XNgIVHgij3VbNRri74cW2eLV4hIkN5v8FE6yB1YQEXs=
-d7y.io/api/v2 v2.2.8/go.mod h1:TtW9UE0CebRB/CWIEbWfRnljmpKf/mNoe2qIUO+PoP0=
+d7y.io/api/v2 v2.2.9 h1:vQ+zmAvCXgIXkssxOSWMRLEAn7ryIdC8/N33aX8vluE=
+d7y.io/api/v2 v2.2.9/go.mod h1:JNKPDQg6BoC06brp7cv8PHbsPbnYelko/IJFuWn6M5M=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

--- a/scheduler/resource/persistent/host.go
+++ b/scheduler/resource/persistent/host.go
@@ -31,6 +31,9 @@ type Host struct {
 	// Type is host type.
 	Type types.HostType
 
+	// Name is the instance name.
+	Name string
+
 	// Hostname is host name.
 	Hostname string
 
@@ -248,13 +251,14 @@ type Disk struct {
 
 // NewHost returns a new host.
 func NewHost(
-	id, hostname, ip, os, platform, platformFamily, platformVersion, kernelVersion string, port, downloadPort, proxyPort int32,
+	id, name, hostname, ip, os, platform, platformFamily, platformVersion, kernelVersion string, port, downloadPort, proxyPort int32,
 	schedulerClusterId uint64, disableShared bool, typ types.HostType, cpu CPU, memory Memory, network Network, disk Disk,
 	build Build, announceInterval time.Duration, createdAt, updatedAt time.Time, log *logger.SugaredLoggerOnWith,
 ) *Host {
 	return &Host{
 		ID:                 id,
 		Type:               types.HostType(typ),
+		Name:               name,
 		Hostname:           hostname,
 		IP:                 ip,
 		Port:               port,

--- a/scheduler/resource/persistent/host_manager.go
+++ b/scheduler/resource/persistent/host_manager.go
@@ -431,6 +431,7 @@ func (h *hostManager) Load(ctx context.Context, hostID string) (*Host, bool) {
 
 	return NewHost(
 		rawHost["id"],
+		rawHost["name"],
 		rawHost["hostname"],
 		rawHost["ip"],
 		rawHost["os"],
@@ -467,68 +468,70 @@ local hosts_set_key = KEYS[2]  -- Key for the set of hosts
 -- Extract host fields from arguments
 local host_id = ARGV[1]
 local host_type = ARGV[2]
-local hostname = ARGV[3]
-local ip = ARGV[4]
-local port = ARGV[5]
-local download_port = ARGV[6]
-local proxy_port = ARGV[7]
-local disable_shared = tonumber(ARGV[8])
-local os = ARGV[9]
-local platform = ARGV[10]
-local platform_family = ARGV[11]
-local platform_version = ARGV[12]
-local kernel_version = ARGV[13]
-local cpu_logical_count = ARGV[14]
-local cpu_physical_count = ARGV[15]
-local cpu_percent = ARGV[16]
-local cpu_process_percent = ARGV[17]
-local cpu_times_user = ARGV[18]
-local cpu_times_system = ARGV[19]
-local cpu_times_idle = ARGV[20]
-local cpu_times_nice = ARGV[21]
-local cpu_times_iowait = ARGV[22]
-local cpu_times_irq = ARGV[23]
-local cpu_times_softirq = ARGV[24]
-local cpu_times_steal = ARGV[25]
-local cpu_times_guest = ARGV[26]
-local cpu_times_guest_nice = ARGV[27]
-local memory_total = ARGV[28]
-local memory_available = ARGV[29]
-local memory_used = ARGV[30]
-local memory_used_percent = ARGV[31]
-local memory_process_used_percent = ARGV[32]
-local memory_free = ARGV[33]
-local network_tcp_connection_count = ARGV[34]
-local network_upload_tcp_connection_count = ARGV[35]
-local network_location = ARGV[36]
-local network_idc = ARGV[37]
-local network_rx_bandwidth = ARGV[38]
-local network_max_rx_bandwidth = ARGV[39]
-local network_tx_bandwidth = ARGV[40]
-local network_max_tx_bandwidth = ARGV[41]
-local disk_total = ARGV[42]
-local disk_free = ARGV[43]
-local disk_used = ARGV[44]
-local disk_used_percent = ARGV[45]
-local disk_inodes_total = ARGV[46]
-local disk_inodes_used = ARGV[47]
-local disk_inodes_free = ARGV[48]
-local disk_inodes_used_percent = ARGV[49]
-local disk_write_bandwidth = ARGV[50]
-local disk_read_bandwidth = ARGV[51]
-local build_git_version = ARGV[52]
-local build_git_commit = ARGV[53]
-local build_go_version = ARGV[54]
-local build_platform = ARGV[55]
-local scheduler_cluster_id = ARGV[56]
-local announce_interval = ARGV[57]
-local created_at = ARGV[58]
-local updated_at = ARGV[59]
+local name = ARGV[3]
+local hostname = ARGV[4]
+local ip = ARGV[5]
+local port = ARGV[6]
+local download_port = ARGV[7]
+local proxy_port = ARGV[8]
+local disable_shared = tonumber(ARGV[9])
+local os = ARGV[10]
+local platform = ARGV[11]
+local platform_family = ARGV[12]
+local platform_version = ARGV[13]
+local kernel_version = ARGV[14]
+local cpu_logical_count = ARGV[15]
+local cpu_physical_count = ARGV[16]
+local cpu_percent = ARGV[17]
+local cpu_process_percent = ARGV[18]
+local cpu_times_user = ARGV[19]
+local cpu_times_system = ARGV[20]
+local cpu_times_idle = ARGV[21]
+local cpu_times_nice = ARGV[22]
+local cpu_times_iowait = ARGV[23]
+local cpu_times_irq = ARGV[24]
+local cpu_times_softirq = ARGV[25]
+local cpu_times_steal = ARGV[26]
+local cpu_times_guest = ARGV[27]
+local cpu_times_guest_nice = ARGV[28]
+local memory_total = ARGV[29]
+local memory_available = ARGV[30]
+local memory_used = ARGV[31]
+local memory_used_percent = ARGV[32]
+local memory_process_used_percent = ARGV[33]
+local memory_free = ARGV[34]
+local network_tcp_connection_count = ARGV[35]
+local network_upload_tcp_connection_count = ARGV[36]
+local network_location = ARGV[37]
+local network_idc = ARGV[38]
+local network_rx_bandwidth = ARGV[39]
+local network_max_rx_bandwidth = ARGV[40]
+local network_tx_bandwidth = ARGV[41]
+local network_max_tx_bandwidth = ARGV[42]
+local disk_total = ARGV[43]
+local disk_free = ARGV[44]
+local disk_used = ARGV[45]
+local disk_used_percent = ARGV[46]
+local disk_inodes_total = ARGV[47]
+local disk_inodes_used = ARGV[48]
+local disk_inodes_free = ARGV[49]
+local disk_inodes_used_percent = ARGV[50]
+local disk_write_bandwidth = ARGV[51]
+local disk_read_bandwidth = ARGV[52]
+local build_git_version = ARGV[53]
+local build_git_commit = ARGV[54]
+local build_go_version = ARGV[55]
+local build_platform = ARGV[56]
+local scheduler_cluster_id = ARGV[57]
+local announce_interval = ARGV[58]
+local created_at = ARGV[59]
+local updated_at = ARGV[60]
 
 -- Perform HSET operation
 redis.call("HSET", host_key,
     "id", host_id,
     "type", host_type,
+    "name", name,
     "hostname", hostname,
     "ip", ip,
     "port", port,
@@ -606,6 +609,7 @@ return true
 	args := []any{
 		host.ID,
 		host.Type.Name(),
+		host.Name,
 		host.Hostname,
 		host.IP,
 		host.Port,

--- a/scheduler/resource/persistent/host_test.go
+++ b/scheduler/resource/persistent/host_test.go
@@ -246,13 +246,14 @@ func TestNewHost(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewHost(
-				tc.id, tc.hostname, tc.ip, tc.os, tc.platform, tc.platformFamily, tc.platformVersion,
+				tc.id, tc.name, tc.hostname, tc.ip, tc.os, tc.platform, tc.platformFamily, tc.platformVersion,
 				tc.kernelVersion, tc.port, tc.downloadPort, tc.proxyPort, tc.schedulerClusterId, tc.disableShared,
 				tc.typ, tc.cpu, tc.memory, tc.network, tc.disk, tc.build, tc.announceInterval,
 				tc.createdAt, tc.updatedAt, tc.log,
 			)
 
 			assert.Equal(t, tc.id, got.ID)
+			assert.Equal(t, tc.name, got.Name)
 			assert.Equal(t, tc.hostname, got.Hostname)
 			assert.Equal(t, tc.ip, got.IP)
 			assert.Equal(t, tc.os, got.OS)

--- a/scheduler/resource/persistentcache/host.go
+++ b/scheduler/resource/persistentcache/host.go
@@ -31,6 +31,9 @@ type Host struct {
 	// Type is host type.
 	Type types.HostType
 
+	// Name is the instance name.
+	Name string
+
 	// Hostname is host name.
 	Hostname string
 
@@ -248,13 +251,14 @@ type Disk struct {
 
 // NewHost returns a new host.
 func NewHost(
-	id, hostname, ip, os, platform, platformFamily, platformVersion, kernelVersion string, port, downloadPort, proxyPort int32,
+	id, name, hostname, ip, os, platform, platformFamily, platformVersion, kernelVersion string, port, downloadPort, proxyPort int32,
 	schedulerClusterId uint64, disableShared bool, typ types.HostType, cpu CPU, memory Memory, network Network, disk Disk,
 	build Build, announceInterval time.Duration, createdAt, updatedAt time.Time, log *logger.SugaredLoggerOnWith,
 ) *Host {
 	return &Host{
 		ID:                 id,
 		Type:               types.HostType(typ),
+		Name:               name,
 		Hostname:           hostname,
 		IP:                 ip,
 		Port:               port,

--- a/scheduler/resource/persistentcache/host_manager.go
+++ b/scheduler/resource/persistentcache/host_manager.go
@@ -431,6 +431,7 @@ func (h *hostManager) Load(ctx context.Context, hostID string) (*Host, bool) {
 
 	return NewHost(
 		rawHost["id"],
+		rawHost["name"],
 		rawHost["hostname"],
 		rawHost["ip"],
 		rawHost["os"],
@@ -467,68 +468,70 @@ local hosts_set_key = KEYS[2]  -- Key for the set of hosts
 -- Extract host fields from arguments
 local host_id = ARGV[1]
 local host_type = ARGV[2]
-local hostname = ARGV[3]
-local ip = ARGV[4]
-local port = ARGV[5]
-local download_port = ARGV[6]
-local proxy_port = ARGV[7]
-local disable_shared = tonumber(ARGV[8])
-local os = ARGV[9]
-local platform = ARGV[10]
-local platform_family = ARGV[11]
-local platform_version = ARGV[12]
-local kernel_version = ARGV[13]
-local cpu_logical_count = ARGV[14]
-local cpu_physical_count = ARGV[15]
-local cpu_percent = ARGV[16]
-local cpu_process_percent = ARGV[17]
-local cpu_times_user = ARGV[18]
-local cpu_times_system = ARGV[19]
-local cpu_times_idle = ARGV[20]
-local cpu_times_nice = ARGV[21]
-local cpu_times_iowait = ARGV[22]
-local cpu_times_irq = ARGV[23]
-local cpu_times_softirq = ARGV[24]
-local cpu_times_steal = ARGV[25]
-local cpu_times_guest = ARGV[26]
-local cpu_times_guest_nice = ARGV[27]
-local memory_total = ARGV[28]
-local memory_available = ARGV[29]
-local memory_used = ARGV[30]
-local memory_used_percent = ARGV[31]
-local memory_process_used_percent = ARGV[32]
-local memory_free = ARGV[33]
-local network_tcp_connection_count = ARGV[34]
-local network_upload_tcp_connection_count = ARGV[35]
-local network_location = ARGV[36]
-local network_idc = ARGV[37]
-local network_rx_bandwidth = ARGV[38]
-local network_max_rx_bandwidth = ARGV[39]
-local network_tx_bandwidth = ARGV[40]
-local network_max_tx_bandwidth = ARGV[41]
-local disk_total = ARGV[42]
-local disk_free = ARGV[43]
-local disk_used = ARGV[44]
-local disk_used_percent = ARGV[45]
-local disk_inodes_total = ARGV[46]
-local disk_inodes_used = ARGV[47]
-local disk_inodes_free = ARGV[48]
-local disk_inodes_used_percent = ARGV[49]
-local disk_write_bandwidth = ARGV[50]
-local disk_read_bandwidth = ARGV[51]
-local build_git_version = ARGV[52]
-local build_git_commit = ARGV[53]
-local build_go_version = ARGV[54]
-local build_platform = ARGV[55]
-local scheduler_cluster_id = ARGV[56]
-local announce_interval = ARGV[57]
-local created_at = ARGV[58]
-local updated_at = ARGV[59]
+local name = ARGV[3]
+local hostname = ARGV[4]
+local ip = ARGV[5]
+local port = ARGV[6]
+local download_port = ARGV[7]
+local proxy_port = ARGV[8]
+local disable_shared = tonumber(ARGV[9])
+local os = ARGV[10]
+local platform = ARGV[11]
+local platform_family = ARGV[12]
+local platform_version = ARGV[13]
+local kernel_version = ARGV[14]
+local cpu_logical_count = ARGV[15]
+local cpu_physical_count = ARGV[16]
+local cpu_percent = ARGV[17]
+local cpu_process_percent = ARGV[18]
+local cpu_times_user = ARGV[19]
+local cpu_times_system = ARGV[20]
+local cpu_times_idle = ARGV[21]
+local cpu_times_nice = ARGV[22]
+local cpu_times_iowait = ARGV[23]
+local cpu_times_irq = ARGV[24]
+local cpu_times_softirq = ARGV[25]
+local cpu_times_steal = ARGV[26]
+local cpu_times_guest = ARGV[27]
+local cpu_times_guest_nice = ARGV[28]
+local memory_total = ARGV[29]
+local memory_available = ARGV[30]
+local memory_used = ARGV[31]
+local memory_used_percent = ARGV[32]
+local memory_process_used_percent = ARGV[33]
+local memory_free = ARGV[34]
+local network_tcp_connection_count = ARGV[35]
+local network_upload_tcp_connection_count = ARGV[36]
+local network_location = ARGV[37]
+local network_idc = ARGV[38]
+local network_rx_bandwidth = ARGV[39]
+local network_max_rx_bandwidth = ARGV[40]
+local network_tx_bandwidth = ARGV[41]
+local network_max_tx_bandwidth = ARGV[42]
+local disk_total = ARGV[43]
+local disk_free = ARGV[44]
+local disk_used = ARGV[45]
+local disk_used_percent = ARGV[46]
+local disk_inodes_total = ARGV[47]
+local disk_inodes_used = ARGV[48]
+local disk_inodes_free = ARGV[49]
+local disk_inodes_used_percent = ARGV[50]
+local disk_write_bandwidth = ARGV[51]
+local disk_read_bandwidth = ARGV[52]
+local build_git_version = ARGV[53]
+local build_git_commit = ARGV[54]
+local build_go_version = ARGV[55]
+local build_platform = ARGV[56]
+local scheduler_cluster_id = ARGV[57]
+local announce_interval = ARGV[58]
+local created_at = ARGV[59]
+local updated_at = ARGV[60]
 
 -- Perform HSET operation
 redis.call("HSET", host_key,
     "id", host_id,
     "type", host_type,
+    "name", name,
     "hostname", hostname,
     "ip", ip,
     "port", port,
@@ -606,6 +609,7 @@ return true
 	args := []any{
 		host.ID,
 		host.Type.Name(),
+		host.Name,
 		host.Hostname,
 		host.IP,
 		host.Port,

--- a/scheduler/resource/persistentcache/host_test.go
+++ b/scheduler/resource/persistentcache/host_test.go
@@ -246,13 +246,14 @@ func TestNewHost(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewHost(
-				tc.id, tc.hostname, tc.ip, tc.os, tc.platform, tc.platformFamily, tc.platformVersion,
+				tc.id, tc.name, tc.hostname, tc.ip, tc.os, tc.platform, tc.platformFamily, tc.platformVersion,
 				tc.kernelVersion, tc.port, tc.downloadPort, tc.proxyPort, tc.schedulerClusterId, tc.disableShared,
 				tc.typ, tc.cpu, tc.memory, tc.network, tc.disk, tc.build, tc.announceInterval,
 				tc.createdAt, tc.updatedAt, tc.log,
 			)
 
 			assert.Equal(t, tc.id, got.ID)
+			assert.Equal(t, tc.name, got.Name)
 			assert.Equal(t, tc.hostname, got.Hostname)
 			assert.Equal(t, tc.ip, got.IP)
 			assert.Equal(t, tc.os, got.OS)

--- a/scheduler/resource/standard/host.go
+++ b/scheduler/resource/standard/host.go
@@ -144,6 +144,9 @@ type Host struct {
 	// Type is host type.
 	Type types.HostType
 
+	// Name is the instance name.
+	Name string
+
 	// Hostname is host name.
 	Hostname string
 
@@ -398,7 +401,7 @@ type Disk struct {
 
 // New host instance.
 func NewHost(
-	id, ip, hostname string, port, downloadPort, proxyPort int32,
+	id, ip, name, hostname string, port, downloadPort, proxyPort int32,
 	typ types.HostType, options ...HostOption,
 ) *Host {
 	// Calculate default of the concurrent upload limit by host type.
@@ -411,6 +414,7 @@ func NewHost(
 		ID:                         id,
 		Type:                       typ,
 		IP:                         ip,
+		Name:                       name,
 		Hostname:                   hostname,
 		Port:                       port,
 		DownloadPort:               downloadPort,

--- a/scheduler/resource/standard/host_manager_test.go
+++ b/scheduler/resource/standard/host_manager_test.go
@@ -134,7 +134,7 @@ func TestHostManager_Load(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			hostManager, err := newHostManager(mockHostGCConfig, gc)
 			if err != nil {
@@ -189,7 +189,7 @@ func TestHostManager_Store(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			hostManager, err := newHostManager(mockHostGCConfig, gc)
 			if err != nil {
@@ -242,7 +242,7 @@ func TestHostManager_LoadOrStore(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			hostManager, err := newHostManager(mockHostGCConfig, gc)
 			if err != nil {
@@ -297,7 +297,7 @@ func TestHostManager_Delete(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			hostManager, err := newHostManager(mockHostGCConfig, gc)
 			if err != nil {
@@ -320,10 +320,10 @@ func TestHostManager_LoadRandom(t *testing.T) {
 			name: "load random hosts",
 			hosts: []*Host{
 				NewHost(
-					mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+					mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 					mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type),
 				NewHost(
-					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 					mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type),
 			},
 			mock: func(m *gc.MockGCMockRecorder) {
@@ -345,10 +345,10 @@ func TestHostManager_LoadRandom(t *testing.T) {
 			name: "load random hosts when the load number is 0",
 			hosts: []*Host{
 				NewHost(
-					mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+					mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 					mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type),
 				NewHost(
-					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 					mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type),
 			},
 			mock: func(m *gc.MockGCMockRecorder) {
@@ -388,10 +388,10 @@ func TestHostManager_LoadRandom(t *testing.T) {
 			name: "the number of hosts in the map is insufficient",
 			hosts: []*Host{
 				NewHost(
-					mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+					mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 					mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type),
 				NewHost(
-					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawHost.Name, mockRawSeedHost.Hostname,
 					mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type),
 			},
 			mock: func(m *gc.MockGCMockRecorder) {
@@ -478,7 +478,7 @@ func TestHostManager_RunGC(t *testing.T) {
 			expect: func(t *testing.T, hostManager HostManager, mockHost *Host, mockPeer *Peer) {
 				assert := assert.New(t)
 				mockSeedHost := NewHost(
-					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+					mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawHost.Name, mockRawSeedHost.Hostname,
 					mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 				hostManager.Store(mockSeedHost)
 				err := hostManager.RunGC(context.Background())
@@ -522,7 +522,7 @@ func TestHostManager_RunGC(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, mockTask, mockHost)

--- a/scheduler/resource/standard/host_test.go
+++ b/scheduler/resource/standard/host_test.go
@@ -34,6 +34,7 @@ var (
 	mockRawHost = Host{
 		ID:              mockHostID,
 		Type:            types.HostTypeNormal,
+		Name:            "default-host",
 		Hostname:        "foo",
 		IP:              "127.0.0.1",
 		Port:            8003,
@@ -56,6 +57,7 @@ var (
 	mockRawSeedHost = Host{
 		ID:              mockSeedHostID,
 		Type:            types.HostTypeSuperSeed,
+		Name:            "default-seed-host",
 		Hostname:        "bar",
 		IP:              "127.0.0.1",
 		Port:            8003,
@@ -154,6 +156,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -180,6 +183,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawSeedHost.ID)
 				assert.Equal(host.Type, mockRawSeedHost.Type)
+				assert.Equal(host.Name, mockRawSeedHost.Name)
 				assert.Equal(host.Hostname, mockRawSeedHost.Hostname)
 				assert.Equal(host.IP, mockRawSeedHost.IP)
 				assert.Equal(host.Port, mockRawSeedHost.Port)
@@ -207,6 +211,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -232,6 +237,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -259,6 +265,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -286,6 +293,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -314,6 +322,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -342,6 +351,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -370,6 +380,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -397,6 +408,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -425,6 +437,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -453,6 +466,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -481,6 +495,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -509,6 +524,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -537,6 +553,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -565,6 +582,7 @@ func TestHost_NewHost(t *testing.T) {
 				assert := assert.New(t)
 				assert.Equal(host.ID, mockRawHost.ID)
 				assert.Equal(host.Type, types.HostTypeNormal)
+				assert.Equal(host.Name, mockRawHost.Name)
 				assert.Equal(host.Hostname, mockRawHost.Hostname)
 				assert.Equal(host.IP, mockRawHost.IP)
 				assert.Equal(host.Port, mockRawHost.Port)
@@ -589,7 +607,7 @@ func TestHost_NewHost(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.expect(t, NewHost(
-				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Hostname,
+				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Name, tc.rawHost.Hostname,
 				tc.rawHost.Port, tc.rawHost.DownloadPort, tc.rawHost.ProxyPort, tc.rawHost.Type,
 				tc.options...))
 		})
@@ -636,7 +654,7 @@ func TestHost_LoadPeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			host := NewHost(
-				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Hostname,
+				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Name, tc.rawHost.Hostname,
 				tc.rawHost.Port, tc.rawHost.DownloadPort, tc.rawHost.ProxyPort, tc.rawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, host)
@@ -681,7 +699,7 @@ func TestHost_StorePeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			host := NewHost(
-				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Hostname,
+				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Name, tc.rawHost.Hostname,
 				tc.rawHost.Port, tc.rawHost.DownloadPort, tc.rawHost.ProxyPort, tc.rawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(tc.peerID, mockTask, host)
@@ -727,7 +745,7 @@ func TestHost_DeletePeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			host := NewHost(
-				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Hostname,
+				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Name, tc.rawHost.Hostname,
 				tc.rawHost.Port, tc.rawHost.DownloadPort, tc.rawHost.ProxyPort, tc.rawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, host)
@@ -779,7 +797,7 @@ func TestHost_LeavePeers(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			host := NewHost(
-				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Hostname,
+				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Name, tc.rawHost.Hostname,
 				tc.rawHost.Port, tc.rawHost.DownloadPort, tc.rawHost.ProxyPort, tc.rawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, host)
@@ -831,7 +849,7 @@ func TestHost_FreeUploadCount(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			host := NewHost(
-				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Hostname,
+				tc.rawHost.ID, tc.rawHost.IP, tc.rawHost.Name, tc.rawHost.Hostname,
 				tc.rawHost.Port, tc.rawHost.DownloadPort, tc.rawHost.ProxyPort, tc.rawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, host)

--- a/scheduler/resource/standard/peer_manager_test.go
+++ b/scheduler/resource/standard/peer_manager_test.go
@@ -135,7 +135,7 @@ func TestPeerManager_Load(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -192,7 +192,7 @@ func TestPeerManager_Store(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -247,7 +247,7 @@ func TestPeerManager_LoadOrStore(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -304,7 +304,7 @@ func TestPeerManager_Delete(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -366,7 +366,7 @@ func TestPeerManager_DeleteAllByHostID(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication,
 				commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader,
@@ -642,7 +642,7 @@ func TestPeerManager_RunGC(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, mockHost)

--- a/scheduler/resource/standard/peer_test.go
+++ b/scheduler/resource/standard/peer_test.go
@@ -192,7 +192,7 @@ func TestPeer_NewPeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			tc.expect(t, NewPeer(tc.id, mockTask, mockHost, tc.options...), mockTask, mockHost)
@@ -227,7 +227,7 @@ func TestPeer_AppendPieceCost(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -264,7 +264,7 @@ func TestPeer_PieceCosts(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -306,7 +306,7 @@ func TestPeer_LoadReportPieceResultStream(t *testing.T) {
 			stream := v1mocks.NewMockScheduler_ReportPieceResultServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -339,7 +339,7 @@ func TestPeer_StoreReportPieceResultStream(t *testing.T) {
 			stream := v1mocks.NewMockScheduler_ReportPieceResultServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -372,7 +372,7 @@ func TestPeer_DeleteReportPieceResultStream(t *testing.T) {
 			stream := v1mocks.NewMockScheduler_ReportPieceResultServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -413,7 +413,7 @@ func TestPeer_LoadAnnouncePeerStream(t *testing.T) {
 			stream := schedulerv2mock.NewMockScheduler_AnnouncePeerServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -446,7 +446,7 @@ func TestPeer_StoreAnnouncePeerStream(t *testing.T) {
 			stream := schedulerv2mock.NewMockScheduler_AnnouncePeerServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -479,7 +479,7 @@ func TestPeer_DeleteAnnouncePeerStream(t *testing.T) {
 			stream := schedulerv2mock.NewMockScheduler_AnnouncePeerServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -524,7 +524,7 @@ func TestPeer_Parents(t *testing.T) {
 			stream := v1mocks.NewMockScheduler_ReportPieceResultServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -570,7 +570,7 @@ func TestPeer_Children(t *testing.T) {
 			stream := v1mocks.NewMockScheduler_ReportPieceResultServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -652,7 +652,7 @@ func TestPeer_DownloadTinyFile(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)
@@ -804,7 +804,7 @@ func TestPeer_CalculatePriority(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer := NewPeer(mockPeerID, mockTask, mockHost)

--- a/scheduler/resource/standard/task_manager_test.go
+++ b/scheduler/resource/standard/task_manager_test.go
@@ -348,7 +348,7 @@ func TestTaskManager_RunGC(t *testing.T) {
 			tc.mock(gc.EXPECT())
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			mockPeer := NewPeer(mockPeerID, mockTask, mockHost)

--- a/scheduler/resource/standard/task_test.go
+++ b/scheduler/resource/standard/task_test.go
@@ -188,7 +188,7 @@ func TestTask_LoadPeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, task, mockHost)
@@ -257,7 +257,7 @@ func TestTask_LoadRandomPeers(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			host := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -295,7 +295,7 @@ func TestTask_StorePeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(tc.peerID, task, mockHost)
@@ -337,7 +337,7 @@ func TestTask_DeletePeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, task, mockHost)
@@ -376,7 +376,7 @@ func TestTask_PeerCount(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, task, mockHost)
@@ -474,7 +474,7 @@ func TestTask_AddPeerEdge(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -578,7 +578,7 @@ func TestTask_DeletePeerInEdges(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -680,7 +680,7 @@ func TestTask_DeletePeerOutEdges(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -767,7 +767,7 @@ func TestTask_CanAddPeerEdge(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -830,7 +830,7 @@ func TestTask_PeerDegree(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -893,7 +893,7 @@ func TestTask_PeerInDegree(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -956,7 +956,7 @@ func TestTask_PeerOutDegree(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 
@@ -1038,7 +1038,7 @@ func TestTask_HasAvailablePeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, task, mockHost)
@@ -1102,10 +1102,10 @@ func TestTask_LoadSeedPeer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockSeedHost := NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, task, mockHost)
@@ -1169,10 +1169,10 @@ func TestTask_IsSeedPeerFailed(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockSeedHost := NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, task, mockHost)
@@ -1559,7 +1559,7 @@ func TestTask_ReportPieceResultToPeers(t *testing.T) {
 			stream := v1mocks.NewMockScheduler_ReportPieceResultServer(ctl)
 
 			mockHost := NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit)
 			mockPeer := NewPeer(mockPeerID, task, mockHost)

--- a/scheduler/scheduling/evaluator/evaluator_default_test.go
+++ b/scheduler/scheduling/evaluator/evaluator_default_test.go
@@ -272,18 +272,18 @@ func TestEvaluatorDefault_EvaluateParents(t *testing.T) {
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			parents := []*standard.Peer{
 				standard.NewPeer(idgen.PeerIDV2(), mockTask, standard.NewHost(
-					idgen.HostIDV2("127.0.0.1", "host1", false), "127.0.0.1", "host1",
+					idgen.HostIDV2("127.0.0.1", "host1", false), "127.0.0.1", "default-pod-1", "host1",
 					8003, 8001, 8004, types.HostTypeNormal)),
 				standard.NewPeer(idgen.PeerIDV2(), mockTask, standard.NewHost(
-					idgen.HostIDV2("127.0.0.2", "host2", false), "127.0.0.2", "host2",
+					idgen.HostIDV2("127.0.0.2", "host2", false), "127.0.0.2", "default-pod-2", "host2",
 					8003, 8001, 8004, types.HostTypeNormal)),
 				standard.NewPeer(idgen.PeerIDV2(), mockTask, standard.NewHost(
-					idgen.HostIDV2("127.0.0.3", "host3", false), "127.0.0.3", "host3",
+					idgen.HostIDV2("127.0.0.3", "host3", false), "127.0.0.3", "default-pod-3", "host3",
 					8003, 8001, 8004, types.HostTypeNormal)),
 			}
 
 			child := standard.NewPeer(mockPeerID, mockTask, standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type))
 
 			e := newEvaluatorDefault()
@@ -386,11 +386,11 @@ func TestEvaluatorDefault_evaluateParents(t *testing.T) {
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 
 			parent := standard.NewPeer(idgen.PeerIDV2(), mockTask, standard.NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type))
 
 			child := standard.NewPeer(mockPeerID, mockTask, standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type))
 
 			e := newEvaluatorDefault()
@@ -477,7 +477,7 @@ func TestEvaluatorDefault_calculateLoadQualityScore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type))
 
 			e := newEvaluatorDefault()
@@ -565,7 +565,7 @@ func TestEvaluatorDefault_calculatePeakBandwidthUsageScore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type))
 
 			e := newEvaluatorDefault()
@@ -642,7 +642,7 @@ func TestEvaluatorDefault_calculateBandwidthDurationScore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type))
 
 			e := newEvaluatorDefault()
@@ -719,7 +719,7 @@ func TestEvaluatorDefault_calculateConcurrencyScore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type))
 
 			e := newEvaluatorDefault()
@@ -770,7 +770,7 @@ func TestEvaluatorDefault_calculateHostTypeScore(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -845,10 +845,10 @@ func TestEvaluatorDefault_calculateIDCAffinityScore(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dstHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			srcHost := standard.NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 			e := newEvaluatorDefault()
 			tc.mock(dstHost, srcHost)
@@ -984,7 +984,7 @@ func TestEvaluatorDefault_calculateLocationAffinityScore(t *testing.T) {
 
 func TestEvaluatorDefault_IsBadParent(t *testing.T) {
 	mockHost := standard.NewHost(
-		mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+		mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 		mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 	mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 

--- a/scheduler/scheduling/scheduling_test.go
+++ b/scheduler/scheduling/scheduling_test.go
@@ -442,12 +442,12 @@ func TestScheduling_ScheduleCandidateParents(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			ctx, cancel := context.WithCancel(context.Background())
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
 			mockSeedHost := standard.NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 			seedPeer := standard.NewPeer(mockSeedPeerID, mockTask, mockSeedHost)
 			blocklist := set.NewSafeSet[string]()
@@ -714,12 +714,12 @@ func TestScheduling_ScheduleParentAndCandidateParents(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			ctx, cancel := context.WithCancel(context.Background())
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
 			mockSeedHost := standard.NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Name, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 			seedPeer := standard.NewPeer(mockSeedPeerID, mockTask, mockSeedHost)
 			blocklist := set.NewSafeSet[string]()
@@ -999,7 +999,7 @@ func TestScheduling_FindCandidateParents(t *testing.T) {
 			persistentResource := persistent.NewMockResource(ctl)
 			persistentCacheResource := persistentcache.NewMockResource(ctl)
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -1007,7 +1007,7 @@ func TestScheduling_FindCandidateParents(t *testing.T) {
 			var mockPeers []*standard.Peer
 			for i := range 11 {
 				mockHost := standard.NewHost(
-					idgen.HostIDV2("127.0.0.1", uuid.New().String(), false), mockRawHost.IP, mockRawHost.Hostname,
+					idgen.HostIDV2("127.0.0.1", uuid.New().String(), false), mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 					mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 				peer := standard.NewPeer(idgen.PeerIDV1(fmt.Sprintf("127.0.0.%d", i)), mockTask, mockHost)
 				mockPeers = append(mockPeers, peer)
@@ -1259,7 +1259,7 @@ func TestScheduling_FindParentAndCandidateParents(t *testing.T) {
 			persistentResource := persistent.NewMockResource(ctl)
 			persistentCacheResource := persistentcache.NewMockResource(ctl)
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -1267,7 +1267,7 @@ func TestScheduling_FindParentAndCandidateParents(t *testing.T) {
 			var mockPeers []*standard.Peer
 			for i := range 11 {
 				mockHost := standard.NewHost(
-					idgen.HostIDV2("127.0.0.1", uuid.New().String(), false), mockRawHost.IP, mockRawHost.Hostname,
+					idgen.HostIDV2("127.0.0.1", uuid.New().String(), false), mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 					mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 				peer := standard.NewPeer(idgen.PeerIDV1(fmt.Sprintf("127.0.0.%d", i)), mockTask, mockHost)
 				mockPeers = append(mockPeers, peer)
@@ -1405,7 +1405,7 @@ func TestScheduling_constructSuccessNormalTaskResponse(t *testing.T) {
 			ctl := gomock.NewController(t)
 			defer ctl.Finish()
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			candidateParents := []*standard.Peer{standard.NewPeer(idgen.PeerIDV1("127.0.0.1"), mockTask, mockHost, standard.WithRange(nethttp.Range{
@@ -1454,7 +1454,7 @@ func TestScheduling_constructSuccessPeerPacket(t *testing.T) {
 			ctl := gomock.NewController(t)
 			defer ctl.Finish()
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 

--- a/scheduler/service/service_v1.go
+++ b/scheduler/service/service_v1.go
@@ -534,7 +534,7 @@ func (v *V1) AnnounceHost(ctx context.Context, req *schedulerv1.AnnounceHostRequ
 		}
 
 		host = resource.NewHost(
-			req.GetId(), req.GetIp(), req.GetHostname(), req.GetPort(), req.GetDownloadPort(), req.GetProxyPort(),
+			req.GetId(), req.GetIp(), req.GetHostname(), req.GetHostname(), req.GetPort(), req.GetDownloadPort(), req.GetProxyPort(),
 			types.ParseHostType(req.GetType()), options...,
 		)
 
@@ -823,7 +823,7 @@ func (v *V1) storeHost(_ context.Context, peerHost *schedulerv1.PeerHost) *resou
 		}
 
 		host := resource.NewHost(
-			peerHost.Id, peerHost.Ip, peerHost.Hostname,
+			peerHost.Id, peerHost.Ip, peerHost.Hostname, peerHost.Hostname,
 			peerHost.RpcPort, peerHost.DownPort, peerHost.ProxyPort, types.HostTypeNormal,
 			options...,
 		)

--- a/scheduler/service/service_v1_test.go
+++ b/scheduler/service/service_v1_test.go
@@ -804,12 +804,12 @@ func TestServiceV1_RegisterPeerTask(t *testing.T) {
 			svc := NewV1(&config.Config{Scheduler: mockSchedulerConfig}, res, scheduling, dynconfig)
 
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			mockPeer := resource.NewPeer(mockPeerID, mockTask, mockHost)
 			mockSeedHost := resource.NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 			mockSeedPeer := resource.NewPeer(mockSeedPeerID, mockTask, mockSeedHost)
 			tc.mock(
@@ -1067,7 +1067,7 @@ func TestServiceV1_ReportPieceResult(t *testing.T) {
 			svc := NewV1(&config.Config{Scheduler: mockSchedulerConfig}, res, scheduling, dynconfig)
 
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			mockPeer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -1216,7 +1216,7 @@ func TestServiceV1_ReportPeerResult(t *testing.T) {
 			svc := NewV1(&config.Config{Scheduler: mockSchedulerConfig}, res, scheduling, dynconfig)
 
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			mockPeer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -1573,7 +1573,7 @@ func TestServiceV1_AnnounceTask(t *testing.T) {
 			peerManager := resource.NewMockPeerManager(ctl)
 			svc := NewV1(&config.Config{Scheduler: mockSchedulerConfig, Metrics: config.MetricsConfig{EnableHost: true}}, res, scheduling, dynconfig)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			mockPeer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -1642,7 +1642,7 @@ func TestServiceV1_LeaveTask(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			peerManager := resource.NewMockPeerManager(ctl)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			peer := resource.NewPeer(mockSeedPeerID, mockTask, mockHost)
@@ -2071,7 +2071,7 @@ func TestServiceV1_AnnounceHost(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			hostManager := resource.NewMockHostManager(ctl)
 			host := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockPeerHost.ProxyPort, mockRawHost.Type)
 			svc := NewV1(&config.Config{Scheduler: mockSchedulerConfig, Metrics: config.MetricsConfig{EnableHost: true}}, res, scheduling, dynconfig)
 
@@ -2147,7 +2147,7 @@ func TestServiceV1_LeaveHost(t *testing.T) {
 			hostManager := resource.NewMockHostManager(ctl)
 			peerManager := resource.NewMockPeerManager(ctl)
 			host := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			mockPeer := resource.NewPeer(mockSeedPeerID, mockTask, host)
@@ -2251,7 +2251,7 @@ func TestServiceV1_prefetchTask(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			seedPeer := resource.NewMockSeedPeer(ctl)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			peer := resource.NewPeer(mockPeerID, task, mockHost)
@@ -2637,10 +2637,10 @@ func TestServiceV1_triggerTask(t *testing.T) {
 			svc := NewV1(tc.config, res, scheduling, dynconfig)
 
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockSeedHost := resource.NewHost(
-				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname,
+				mockRawSeedHost.ID, mockRawSeedHost.IP, mockRawSeedHost.Hostname, mockRawSeedHost.Hostname,
 				mockRawSeedHost.Port, mockRawSeedHost.DownloadPort, mockRawSeedHost.ProxyPort, mockRawSeedHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			mockPeer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2817,7 +2817,7 @@ func TestServiceV1_storeHost(t *testing.T) {
 			svc := NewV1(&config.Config{Scheduler: mockSchedulerConfig}, res, scheduling, dynconfig)
 			hostManager := resource.NewMockHostManager(ctl)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 
 			tc.mock(mockHost, hostManager, res.EXPECT(), hostManager.EXPECT(), dynconfig.EXPECT())
@@ -2836,7 +2836,7 @@ func TestServiceV1_storePeer(t *testing.T) {
 			name: "peer already exists",
 			run: func(t *testing.T, svc *V1, peerManager resource.PeerManager, mr *resource.MockResourceMockRecorder, mp *resource.MockPeerManagerMockRecorder) {
 				mockHost := resource.NewHost(
-					mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+					mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 					mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 				mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 				mockPeer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2856,7 +2856,7 @@ func TestServiceV1_storePeer(t *testing.T) {
 			name: "peer does not exists",
 			run: func(t *testing.T, svc *V1, peerManager resource.PeerManager, mr *resource.MockResourceMockRecorder, mp *resource.MockPeerManagerMockRecorder) {
 				mockHost := resource.NewHost(
-					mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+					mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 					mockRawHost.Port, mockRawHost.DownloadPort, mockPeerHost.ProxyPort, mockRawHost.Type)
 				mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 				gomock.InOrder(
@@ -2956,7 +2956,7 @@ func TestServiceV1_triggerSeedPeerTask(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			seedPeer := resource.NewMockSeedPeer(ctl)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			task := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			peer := resource.NewPeer(mockPeerID, task, mockHost)
@@ -3036,7 +3036,7 @@ func TestServiceV1_handleBeginOfPiece(t *testing.T) {
 			res := resource.NewMockResource(ctl)
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			peer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3051,7 +3051,7 @@ func TestServiceV1_handleBeginOfPiece(t *testing.T) {
 
 func TestServiceV1_handlePieceSuccess(t *testing.T) {
 	mockHost := resource.NewHost(
-		mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+		mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 		mockRawHost.Port, mockRawHost.DownloadPort, mockPeerHost.ProxyPort, mockRawHost.Type)
 	mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 
@@ -3333,7 +3333,7 @@ func TestServiceV1_handlePieceFail(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			peerManager := resource.NewMockPeerManager(ctl)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			peer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3457,7 +3457,7 @@ func TestServiceV1_handlePeerSuccess(t *testing.T) {
 			mockRawHost.IP = ip
 			mockRawHost.DownloadPort = int32(port)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockPeerHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			peer := resource.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3537,7 +3537,7 @@ func TestServiceV1_handlePeerFail(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			svc := NewV1(&config.Config{Scheduler: mockSchedulerConfig, Metrics: config.MetricsConfig{EnableHost: true}}, res, scheduling, dynconfig)
 			mockHost := resource.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockPeerHost.ProxyPort, mockRawHost.Type)
 			mockTask := resource.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, resource.WithDigest(mockTaskDigest))
 			peer := resource.NewPeer(mockSeedPeerID, mockTask, mockHost)

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -362,6 +362,7 @@ func (v *V2) StatPeer(ctx context.Context, req *schedulerv2.StatPeerRequest) (*c
 	resp.Host = &commonv2.Host{
 		Id:              peer.Host.ID,
 		Type:            uint32(peer.Host.Type),
+		Name:            peer.Host.Name,
 		Hostname:        peer.Host.Hostname,
 		Ip:              peer.Host.IP,
 		Port:            peer.Host.Port,
@@ -641,7 +642,7 @@ func (v *V2) AnnounceHost(ctx context.Context, req *schedulerv2.AnnounceHostRequ
 		}
 
 		host = standard.NewHost(
-			req.Host.GetId(), req.Host.GetIp(), req.Host.GetHostname(),
+			req.Host.GetId(), req.Host.GetIp(), req.Host.GetName(), req.Host.GetHostname(),
 			req.Host.GetPort(), req.Host.GetDownloadPort(), req.Host.GetProxyPort(), types.HostType(req.Host.GetType()),
 			options...,
 		)
@@ -745,7 +746,7 @@ func (v *V2) AnnounceHost(ctx context.Context, req *schedulerv2.AnnounceHostRequ
 	if v.persistentResource != nil {
 		persistentHost, loaded := v.persistentResource.HostManager().Load(ctx, req.Host.GetId())
 		if !loaded {
-			persistentHost = persistent.NewHost(req.Host.GetId(), req.Host.GetHostname(), req.Host.GetIp(), req.Host.GetOs(),
+			persistentHost = persistent.NewHost(req.Host.GetId(), req.Host.GetName(), req.Host.GetHostname(), req.Host.GetIp(), req.Host.GetOs(),
 				req.Host.GetPlatform(), req.Host.GetPlatformFamily(), req.Host.GetPlatformVersion(), req.Host.GetKernelVersion(), req.Host.GetPort(),
 				req.Host.GetDownloadPort(), req.Host.GetProxyPort(), req.Host.GetSchedulerClusterId(), req.Host.GetDisableShared(), types.HostType(req.Host.GetType()),
 				persistent.CPU{
@@ -914,7 +915,7 @@ func (v *V2) AnnounceHost(ctx context.Context, req *schedulerv2.AnnounceHostRequ
 	if v.persistentCacheResource != nil {
 		persistentCacheHost, loaded := v.persistentCacheResource.HostManager().Load(ctx, req.Host.GetId())
 		if !loaded {
-			persistentCacheHost = persistentcache.NewHost(req.Host.GetId(), req.Host.GetHostname(), req.Host.GetIp(), req.Host.GetOs(),
+			persistentCacheHost = persistentcache.NewHost(req.Host.GetId(), req.Host.GetName(), req.Host.GetHostname(), req.Host.GetIp(), req.Host.GetOs(),
 				req.Host.GetPlatform(), req.Host.GetPlatformFamily(), req.Host.GetPlatformVersion(), req.Host.GetKernelVersion(), req.Host.GetPort(),
 				req.Host.GetDownloadPort(), req.Host.GetProxyPort(), req.Host.GetSchedulerClusterId(), req.Host.GetDisableShared(), types.HostType(req.Host.GetType()),
 				persistentcache.CPU{
@@ -1095,6 +1096,7 @@ func (v *V2) ListHosts(ctx context.Context, req *schedulerv2.ListHostsRequest) (
 		hosts = append(hosts, &commonv2.Host{
 			Id:              host.ID,
 			Type:            uint32(host.Type),
+			Name:            host.Name,
 			Hostname:        host.Hostname,
 			Ip:              host.IP,
 			Port:            host.Port,
@@ -2186,6 +2188,7 @@ func (v *V2) handleRegisterPersistentPeerRequest(ctx context.Context, stream sch
 				Host: &commonv2.Host{
 					Id:              parent.Host.ID,
 					Type:            uint32(parent.Host.Type),
+					Name:            parent.Host.Name,
 					Hostname:        parent.Host.Hostname,
 					Ip:              parent.Host.IP,
 					Port:            parent.Host.Port,
@@ -2389,6 +2392,7 @@ func (v *V2) handleReschedulePersistentPeerRequest(ctx context.Context, stream s
 			Host: &commonv2.Host{
 				Id:              parent.Host.ID,
 				Type:            uint32(parent.Host.Type),
+				Name:            parent.Host.Name,
 				Hostname:        parent.Host.Hostname,
 				Ip:              parent.Host.IP,
 				Port:            parent.Host.Port,
@@ -2685,6 +2689,7 @@ func (v *V2) StatPersistentPeer(ctx context.Context, req *schedulerv2.StatPersis
 		Host: &commonv2.Host{
 			Id:              peer.Host.ID,
 			Type:            uint32(peer.Host.Type),
+			Name:            peer.Host.Name,
 			Hostname:        peer.Host.Hostname,
 			Ip:              peer.Host.IP,
 			Port:            peer.Host.Port,
@@ -3416,6 +3421,7 @@ func (v *V2) handleRegisterPersistentCachePeerRequest(ctx context.Context, strea
 				Host: &commonv2.Host{
 					Id:              parent.Host.ID,
 					Type:            uint32(parent.Host.Type),
+					Name:            parent.Host.Name,
 					Hostname:        parent.Host.Hostname,
 					Ip:              parent.Host.IP,
 					Port:            parent.Host.Port,
@@ -3623,6 +3629,7 @@ func (v *V2) handleReschedulePersistentCachePeerRequest(ctx context.Context, str
 			Host: &commonv2.Host{
 				Id:              parent.Host.ID,
 				Type:            uint32(parent.Host.Type),
+				Name:            parent.Host.Name,
 				Hostname:        parent.Host.Hostname,
 				Ip:              parent.Host.IP,
 				Port:            parent.Host.Port,
@@ -3888,6 +3895,7 @@ func (v *V2) StatPersistentCachePeer(ctx context.Context, req *schedulerv2.StatP
 		Host: &commonv2.Host{
 			Id:              peer.Host.ID,
 			Type:            uint32(peer.Host.Type),
+			Name:            peer.Host.Name,
 			Hostname:        peer.Host.Hostname,
 			Ip:              peer.Host.IP,
 			Port:            peer.Host.Port,

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -506,7 +506,7 @@ func TestServiceV2_StatPeer(t *testing.T) {
 
 			peerManager := standard.NewMockPeerManager(ctl)
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockSeedPeerID, mockTask, mockHost, standard.WithRange(mockPeerRange), standard.WithConcurrentPieceCount(mockConcurrentPieceCount))
@@ -1553,16 +1553,16 @@ func TestServiceV2_AnnounceHost(t *testing.T) {
 			persistentHostManager := persistent.NewMockHostManager(ctl)
 			persistentCacheHostManager := persistentcache.NewMockHostManager(ctl)
 			host := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			persistentHost := persistent.NewHost(
-				mockRawPersistentHost.ID, mockRawPersistentHost.Hostname, mockRawPersistentHost.IP,
+				mockRawPersistentHost.ID, mockRawPersistentHost.Name, mockRawPersistentHost.Hostname, mockRawPersistentHost.IP,
 				mockRawPersistentHost.OS, mockRawPersistentHost.Platform, mockRawPersistentHost.PlatformFamily, mockRawPersistentHost.PlatformVersion, mockRawPersistentHost.KernelVersion,
 				mockRawPersistentHost.Port, mockRawPersistentHost.DownloadPort, mockRawPersistentHost.ProxyPort, mockRawPersistentHost.SchedulerClusterID, mockRawPersistentHost.DisableShared, pkgtypes.HostType(mockRawPersistentHost.Type),
 				mockRawPersistentHost.CPU, mockRawPersistentHost.Memory, mockRawPersistentHost.Network, mockRawPersistentHost.Disk,
 				mockRawPersistentHost.Build, mockRawPersistentHost.AnnounceInterval, mockRawPersistentHost.CreatedAt, mockRawPersistentHost.UpdatedAt, mockRawHost.Log)
 			persistentCacheHost := persistentcache.NewHost(
-				mockRawPersistentCacheHost.ID, mockRawPersistentCacheHost.Hostname, mockRawPersistentCacheHost.IP,
+				mockRawPersistentCacheHost.ID, mockRawPersistentCacheHost.Name, mockRawPersistentCacheHost.Hostname, mockRawPersistentCacheHost.IP,
 				mockRawPersistentCacheHost.OS, mockRawPersistentCacheHost.Platform, mockRawPersistentCacheHost.PlatformFamily, mockRawPersistentCacheHost.PlatformVersion, mockRawPersistentCacheHost.KernelVersion,
 				mockRawPersistentCacheHost.Port, mockRawPersistentCacheHost.DownloadPort, mockRawPersistentCacheHost.ProxyPort, mockRawPersistentCacheHost.SchedulerClusterID, mockRawPersistentCacheHost.DisableShared, pkgtypes.HostType(mockRawPersistentCacheHost.Type),
 				mockRawPersistentCacheHost.CPU, mockRawPersistentCacheHost.Memory, mockRawPersistentCacheHost.Network, mockRawPersistentCacheHost.Disk,
@@ -1690,7 +1690,7 @@ func TestServiceV2_ListHosts(t *testing.T) {
 
 			hostManager := standard.NewMockHostManager(ctl)
 			host := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname, mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname, mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type,
 				standard.WithCPU(mockCPU), standard.WithMemory(mockMemory), standard.WithNetwork(mockNetwork), standard.WithDisk(mockDisk), standard.WithBuild(mockBuild))
 			svc := NewV2(&config.Config{Scheduler: mockSchedulerConfig, Metrics: config.MetricsConfig{EnableHost: true}}, resource, persistentResource, persistentCacheResource, scheduling, job, internalJobImage, dynconfig)
 
@@ -1771,7 +1771,7 @@ func TestServiceV2_DeleteHost(t *testing.T) {
 			hostManager := standard.NewMockHostManager(ctl)
 			peerManager := standard.NewMockPeerManager(ctl)
 			host := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			mockPeer := standard.NewPeer(mockSeedPeerID, mockTask, host)
@@ -2078,7 +2078,7 @@ func TestServiceV2_handleRegisterPeerRequest(t *testing.T) {
 			stream := schedulerv2mocks.NewMockScheduler_AnnouncePeerServer(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2174,7 +2174,7 @@ func TestServiceV2_handleDownloadPeerStartedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2269,7 +2269,7 @@ func TestServiceV2_handleDownloadPeerBackToSourceStartedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2343,7 +2343,7 @@ func TestServiceV2_handleRescheduleRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2419,7 +2419,7 @@ func TestServiceV2_handleDownloadPeerFinishedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2587,7 +2587,7 @@ func TestServiceV2_handleDownloadPeerBackToSourceFinishedRequest(t *testing.T) {
 			}
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockHost.IP = ip
 			mockHost.DownloadPort = int32(port)
@@ -2665,7 +2665,7 @@ func TestServiceV2_handleDownloadPeerFailedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2787,7 +2787,7 @@ func TestServiceV2_handleDownloadPeerBackToSourceFailedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -2928,7 +2928,7 @@ func TestServiceV2_handleDownloadPieceFinishedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3035,7 +3035,7 @@ func TestServiceV2_handleDownloadPieceBackToSourceFinishedRequest(t *testing.T) 
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3148,7 +3148,7 @@ func TestServiceV2_handleDownloadPieceFailedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3216,7 +3216,7 @@ func TestServiceV2_handleDownloadPieceBackToSourceFailedRequest(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3433,7 +3433,7 @@ func TestServiceV2_handleResource(t *testing.T) {
 			stream := schedulerv2mocks.NewMockScheduler_AnnouncePeerServer(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			mockPeer := standard.NewPeer(mockPeerID, mockTask, mockHost)
@@ -3616,7 +3616,7 @@ func TestServiceV2_downloadTaskBySeedPeer(t *testing.T) {
 			internalJobImage := internaljobmocks.NewMockImage(ctl)
 
 			mockHost := standard.NewHost(
-				mockRawHost.ID, mockRawHost.IP, mockRawHost.Hostname,
+				mockRawHost.ID, mockRawHost.IP, mockRawHost.Name, mockRawHost.Hostname,
 				mockRawHost.Port, mockRawHost.DownloadPort, mockRawHost.ProxyPort, mockRawHost.Type)
 			mockTask := standard.NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, standard.WithDigest(mockTaskDigest))
 			peer := standard.NewPeer(mockPeerID, mockTask, mockHost)


### PR DESCRIPTION
This pull request introduces support for a new `Name` field representing the instance name in the `Host` struct across the persistent, persistentcache, and standard resource layers. The changes ensure that the `Name` field is properly handled in host construction, storage, retrieval, and testing, improving host identification and management.

**Host struct and construction changes:**
- Added a `Name` field to the `Host` struct in `scheduler/resource/persistent/host.go`, `scheduler/resource/persistentcache/host.go`, and `scheduler/resource/standard/host.go`, and updated the `NewHost` constructors to accept and set this field. [[1]](diffhunk://#diff-f0cb584b5b211dc1cb05c328a5abd5235b924cb8e16c9edda8a3514f5d95825eR34-R36) [[2]](diffhunk://#diff-f0cb584b5b211dc1cb05c328a5abd5235b924cb8e16c9edda8a3514f5d95825eL251-R261) [[3]](diffhunk://#diff-b561e3a904580b9bb5f763ac38968d4aad88b25db523bb92a2276e6c8e66640cR34-R36) [[4]](diffhunk://#diff-b561e3a904580b9bb5f763ac38968d4aad88b25db523bb92a2276e6c8e66640cL251-R261) [[5]](diffhunk://#diff-d934f325236951868cc50ccab549c7e2646dd6f4b1e0267708e9807532d5e7acR147-R149) [[6]](diffhunk://#diff-d934f325236951868cc50ccab549c7e2646dd6f4b1e0267708e9807532d5e7acL401-R404) [[7]](diffhunk://#diff-d934f325236951868cc50ccab549c7e2646dd6f4b1e0267708e9807532d5e7acR417)

**Host manager and storage logic:**
- Updated host manager logic to handle the new `Name` field when loading and storing hosts, including changes to argument order and Lua scripts for Redis persistence in both persistent and persistentcache host managers. [[1]](diffhunk://#diff-3afcd068d15f49725a3af20c7ef92d7de55312744142305b7725d4d4afec95eaR434) [[2]](diffhunk://#diff-3afcd068d15f49725a3af20c7ef92d7de55312744142305b7725d4d4afec95eaL470-R534) [[3]](diffhunk://#diff-3afcd068d15f49725a3af20c7ef92d7de55312744142305b7725d4d4afec95eaR612) [[4]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dR434) [[5]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dL470-R534) [[6]](diffhunk://#diff-cab2c0c5532854f2dd2b4557cc339dd396bccb1ea3a66af3ffc13821da7e3a8dR612)

**Testing updates:**
- Modified host-related tests to include the `Name` field in test cases and assertions, ensuring correctness in host creation and management. [[1]](diffhunk://#diff-ab64332fc012bb39e71cf6492d889b2db550a642cd17e6334700980be2f7dd18L249-R256) [[2]](diffhunk://#diff-afcb6469761c0aa8f6f005d609396d88981e640448633c881acd407ef38a3cf6L249-R256) [[3]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL137-R137) [[4]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL192-R192) [[5]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL245-R245) [[6]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL300-R300) [[7]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL323-R326) [[8]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL348-R351) [[9]](diffhunk://#diff-cb7d43d2e11d6ee638107ac352fd666fbdab9f30c1e3bb9ca77c395b2cd2fdfaL391-R394)

**Dependency update:**
- Bumped the dependency on `d7y.io/api/v2` from version `v2.2.8` to `v2.2.9` in `go.mod`.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
