### PR TITLE
feat(router): remove deprecated preheat API endpoints

### DIFF
--- a/manager/router/router.go
+++ b/manager/router/router.go
@@ -255,13 +255,6 @@ func Init(cfg *config.Config, logDir string, service service.Service, database *
 	oc.GET(":id", h.GetCluster)
 	oc.GET("", h.GetClusters)
 
-	// TODO Remove this api.
-	// Compatible with the V1 preheat.
-	pv1 := r.Group("/preheats")
-	r.GET("_ping", h.GetHealth)
-	pv1.POST("", h.CreateV1Preheat)
-	pv1.GET(":id", h.GetV1Preheat)
-
 	// Health Check.
 	r.GET("/healthy", h.GetHealth)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request removes deprecated API endpoints related to the V1 preheat functionality from the router initialization code. The main focus is on cleaning up old routes that are no longer needed, making the codebase simpler and reducing maintenance overhead.

API cleanup:

* Removed the `/preheats` V1 API group and its associated endpoints (`POST /preheats`, `GET /preheats/:id`) that were kept for compatibility with the V1 preheat feature.
* Removed the `_ping` health check route, consolidating health checks to the `/healthy` endpoint.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
