### PR TITLE
feat(manager): add seed client configuration support

### DIFF
--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -139,8 +139,9 @@ func seed(db *gorm.DB) error {
 			ClientConfig: map[string]any{
 				"load_limit": schedulerconfig.DefaultPeerConcurrentUploadLimit,
 			},
-			Scopes:    map[string]any{},
-			IsDefault: true,
+			SeedClientConfig: map[string]any{},
+			Scopes:           map[string]any{},
+			IsDefault:        true,
 		}).Error; err != nil {
 			return err
 		}

--- a/manager/handlers/scheduler_cluster_test.go
+++ b/manager/handlers/scheduler_cluster_test.go
@@ -39,6 +39,16 @@ var (
 		   "client_config": {
 			  "load_limit": 1
 		   },
+		   "seed_client_config": {
+		        "block_list": {
+				    "task": {
+					    "download": {
+						    "urls": ["https://example.com/foo.zip"],
+							"tags": ["test-block"]
+						}
+					}
+				}
+		   },
 		   "config": {
 			  "candidate_parent_limit": 1,
 			  "filter_parent_limit": 10
@@ -54,6 +64,14 @@ var (
 		IsDefault:    false,
 		Config:       models.JSONMap{"CandidateParentLimit": 1, "FilterParentLimit": 10},
 		ClientConfig: models.JSONMap{"LoadLimit": 1},
+		SeedClientConfig: models.JSONMap{"BlockList": models.JSONMap{
+			"Task": models.JSONMap{
+				"Download": models.JSONMap{
+					"URLs": []string{"https://example.com/foo.zip"},
+					"Tags": []string{"test-block"},
+				},
+			},
+		}},
 	}
 	mockUnmarshalSchedulerClusterModel = &models.SchedulerCluster{
 		BaseModel:    mockBaseModel,
@@ -62,6 +80,14 @@ var (
 		IsDefault:    false,
 		Config:       models.JSONMap{"CandidateParentLimit": float64(1), "FilterParentLimit": float64(10)},
 		ClientConfig: models.JSONMap{"LoadLimit": float64(1)},
+		SeedClientConfig: models.JSONMap{"BlockList": map[string]any{
+			"Task": map[string]any{
+				"Download": map[string]any{
+					"URLs": []any{"https://example.com/foo.zip"},
+					"Tags": []any{"test-block"},
+				},
+			},
+		}},
 	}
 )
 

--- a/manager/models/models.go
+++ b/manager/models/models.go
@@ -46,13 +46,18 @@ type JSONMap map[string]any
 
 func (m JSONMap) Value() (driver.Value, error) {
 	if m == nil {
-		return nil, nil
+		return "{}", nil
 	}
 	ba, err := m.MarshalJSON()
 	return string(ba), err
 }
 
 func (m *JSONMap) Scan(val any) error {
+	if val == nil {
+		*m = JSONMap(map[string]any{})
+		return nil
+	}
+
 	var ba []byte
 	switch v := val.(type) {
 	case []byte:
@@ -62,6 +67,12 @@ func (m *JSONMap) Scan(val any) error {
 	default:
 		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", val))
 	}
+
+	if len(ba) == 0 || string(ba) == "null" {
+		*m = JSONMap(map[string]any{})
+		return nil
+	}
+
 	t := map[string]any{}
 	err := json.Unmarshal(ba, &t)
 	*m = JSONMap(t)
@@ -111,6 +122,11 @@ func (a Array) Value() (driver.Value, error) {
 }
 
 func (a *Array) Scan(val any) error {
+	if val == nil {
+		*a = Array([]string{})
+		return nil
+	}
+
 	var ba []byte
 	switch v := val.(type) {
 	case []byte:
@@ -120,6 +136,12 @@ func (a *Array) Scan(val any) error {
 	default:
 		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", val))
 	}
+
+	if len(ba) == 0 || string(ba) == "null" {
+		*a = Array([]string{})
+		return nil
+	}
+
 	t := []string{}
 	err := json.Unmarshal(ba, &t)
 	*a = Array(t)

--- a/manager/models/scheduler_cluster.go
+++ b/manager/models/scheduler_cluster.go
@@ -22,6 +22,7 @@ type SchedulerCluster struct {
 	BIO              string            `gorm:"column:bio;type:varchar(1024);comment:biography" json:"bio"`
 	Config           JSONMap           `gorm:"column:config;not null;comment:configuration" json:"config"`
 	ClientConfig     JSONMap           `gorm:"column:client_config;not null;comment:client configuration" json:"client_config"`
+	SeedClientConfig JSONMap           `gorm:"column:seed_client_config;not null;comment:seed client configuration" json:"seed_client_config"`
 	Scopes           JSONMap           `gorm:"column:scopes;comment:match scopes" json:"scopes"`
 	IsDefault        bool              `gorm:"column:is_default;not null;default:false;comment:default scheduler cluster" json:"is_default"`
 	SeedPeerClusters []SeedPeerCluster `gorm:"many2many:seed_peer_cluster_scheduler_cluster;" json:"seed_peer_clusters"`

--- a/manager/service/cluster.go
+++ b/manager/service/cluster.go
@@ -59,12 +59,13 @@ func (s *service) CreateCluster(ctx context.Context, json types.CreateClusterReq
 	}
 
 	schedulerCluster := models.SchedulerCluster{
-		Name:         json.Name,
-		BIO:          json.BIO,
-		Config:       schedulerClusterConfig,
-		ClientConfig: peerClusterConfig,
-		Scopes:       scopes,
-		IsDefault:    json.IsDefault,
+		Name:             json.Name,
+		BIO:              json.BIO,
+		Config:           schedulerClusterConfig,
+		ClientConfig:     peerClusterConfig,
+		SeedClientConfig: seedPeerClusterConfig,
+		Scopes:           scopes,
+		IsDefault:        json.IsDefault,
 	}
 
 	if err := tx.WithContext(ctx).Create(&schedulerCluster).Error; err != nil {
@@ -210,11 +211,12 @@ func (s *service) UpdateCluster(ctx context.Context, id uint, json types.UpdateC
 
 	schedulerCluster := models.SchedulerCluster{}
 	if err := tx.WithContext(ctx).Preload("SeedPeerClusters").First(&schedulerCluster, id).Updates(models.SchedulerCluster{
-		Name:         json.Name,
-		BIO:          json.BIO,
-		Config:       schedulerClusterConfig,
-		ClientConfig: peerClusterConfig,
-		Scopes:       scopes,
+		Name:             json.Name,
+		BIO:              json.BIO,
+		Config:           schedulerClusterConfig,
+		ClientConfig:     peerClusterConfig,
+		SeedClientConfig: seedPeerClusterConfig,
+		Scopes:           scopes,
 	}).Error; err != nil {
 		tx.Rollback()
 		return nil, err

--- a/manager/service/scheduler_cluster.go
+++ b/manager/service/scheduler_cluster.go
@@ -36,18 +36,24 @@ func (s *service) CreateSchedulerCluster(ctx context.Context, json types.CreateS
 		return nil, err
 	}
 
+	seedClientConfig, err := structure.StructToMap(json.SeedClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	scopes, err := structure.StructToMap(json.Scopes)
 	if err != nil {
 		return nil, err
 	}
 
 	schedulerCluster := models.SchedulerCluster{
-		Name:         json.Name,
-		BIO:          json.BIO,
-		Config:       config,
-		ClientConfig: clientConfig,
-		Scopes:       scopes,
-		IsDefault:    json.IsDefault,
+		Name:             json.Name,
+		BIO:              json.BIO,
+		Config:           config,
+		ClientConfig:     clientConfig,
+		SeedClientConfig: seedClientConfig,
+		Scopes:           scopes,
+		IsDefault:        json.IsDefault,
 	}
 
 	if err := s.db.WithContext(ctx).Create(&schedulerCluster).Error; err != nil {
@@ -100,6 +106,14 @@ func (s *service) UpdateSchedulerCluster(ctx context.Context, id uint, json type
 		}
 	}
 
+	var seedClientConfig map[string]any
+	if json.SeedClientConfig != nil {
+		seedClientConfig, err = structure.StructToMap(json.SeedClientConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var scopes map[string]any
 	if json.Scopes != nil {
 		scopes, err = structure.StructToMap(json.Scopes)
@@ -110,11 +124,12 @@ func (s *service) UpdateSchedulerCluster(ctx context.Context, id uint, json type
 
 	schedulerCluster := models.SchedulerCluster{}
 	if err := s.db.WithContext(ctx).First(&schedulerCluster, id).Updates(models.SchedulerCluster{
-		Name:         json.Name,
-		BIO:          json.BIO,
-		Config:       config,
-		ClientConfig: clientConfig,
-		Scopes:       scopes,
+		Name:             json.Name,
+		BIO:              json.BIO,
+		Config:           config,
+		ClientConfig:     clientConfig,
+		SeedClientConfig: seedClientConfig,
+		Scopes:           scopes,
 	}).Error; err != nil {
 		return nil, err
 	}

--- a/manager/types/scheduler_cluster.go
+++ b/manager/types/scheduler_cluster.go
@@ -26,23 +26,25 @@ type AddSchedulerToSchedulerClusterParams struct {
 }
 
 type CreateSchedulerClusterRequest struct {
-	Name              string                        `json:"name" binding:"required"`
-	BIO               string                        `json:"bio" binding:"omitempty"`
-	Config            *SchedulerClusterConfig       `json:"config" binding:"required"`
-	ClientConfig      *SchedulerClusterClientConfig `json:"client_config" binding:"required"`
-	Scopes            *SchedulerClusterScopes       `json:"scopes" binding:"omitempty"`
-	IsDefault         bool                          `json:"is_default" binding:"omitempty"`
-	SeedPeerClusterID uint                          `json:"seed_peer_cluster_id" binding:"omitempty"`
+	Name              string                            `json:"name" binding:"required"`
+	BIO               string                            `json:"bio" binding:"omitempty"`
+	Config            *SchedulerClusterConfig           `json:"config" binding:"required"`
+	ClientConfig      *SchedulerClusterClientConfig     `json:"client_config" binding:"required"`
+	SeedClientConfig  *SchedulerClusterSeedClientConfig `json:"seed_client_config" binding:"required"`
+	Scopes            *SchedulerClusterScopes           `json:"scopes" binding:"omitempty"`
+	IsDefault         bool                              `json:"is_default" binding:"omitempty"`
+	SeedPeerClusterID uint                              `json:"seed_peer_cluster_id" binding:"omitempty"`
 }
 
 type UpdateSchedulerClusterRequest struct {
-	Name              string                        `json:"name" binding:"omitempty"`
-	BIO               string                        `json:"bio" binding:"omitempty"`
-	Config            *SchedulerClusterConfig       `json:"config" binding:"omitempty"`
-	ClientConfig      *SchedulerClusterClientConfig `json:"client_config" binding:"omitempty"`
-	Scopes            *SchedulerClusterScopes       `json:"scopes" binding:"omitempty"`
-	IsDefault         bool                          `json:"is_default" binding:"omitempty"`
-	SeedPeerClusterID uint                          `json:"seed_peer_cluster_id" binding:"omitempty"`
+	Name              string                            `json:"name" binding:"omitempty"`
+	BIO               string                            `json:"bio" binding:"omitempty"`
+	Config            *SchedulerClusterConfig           `json:"config" binding:"omitempty"`
+	ClientConfig      *SchedulerClusterClientConfig     `json:"client_config" binding:"omitempty"`
+	SeedClientConfig  *SchedulerClusterSeedClientConfig `json:"seed_client_config" binding:"omitempty"`
+	Scopes            *SchedulerClusterScopes           `json:"scopes" binding:"omitempty"`
+	IsDefault         bool                              `json:"is_default" binding:"omitempty"`
+	SeedPeerClusterID uint                              `json:"seed_peer_cluster_id" binding:"omitempty"`
 }
 
 type GetSchedulerClustersQuery struct {
@@ -58,7 +60,45 @@ type SchedulerClusterConfig struct {
 }
 
 type SchedulerClusterClientConfig struct {
-	LoadLimit uint32 `yaml:"loadLimit" mapstructure:"loadLimit" json:"load_limit" binding:"omitempty,gte=1,lte=2000"`
+	LoadLimit uint32                          `yaml:"loadLimit" mapstructure:"loadLimit" json:"load_limit" binding:"omitempty,gte=1,lte=2000"`
+	BlockList SchedulerClusterConfigBlockList `yaml:"blockList" mapstructure:"blockList" json:"block_list" binding:"omitempty"`
+}
+
+type SchedulerClusterSeedClientConfig struct {
+	BlockList SchedulerClusterConfigBlockList `yaml:"blockList" mapstructure:"blockList" json:"block_list" binding:"omitempty"`
+}
+
+type SchedulerClusterConfigBlockList struct {
+	Task                *SchedulerClusterConfigTaskBlockList                `yaml:"task" mapstructure:"task" json:"task" binding:"omitempty"`
+	PersistentTask      *SchedulerClusterConfigPersistentTaskBlockList      `yaml:"persistent_task" mapstructure:"persistent_task" json:"persistent_task" binding:"omitempty"`
+	PersistentCacheTask *SchedulerClusterConfigPersistentCacheTaskBlockList `yaml:"persistent_cache_task" mapstructure:"persistent_cache_task" json:"persistent_cache_task" binding:"omitempty"`
+}
+
+type SchedulerClusterConfigTaskBlockList struct {
+	Download *SchedulerClusterConfigDownloadBlockList `yaml:"download" mapstructure:"download" json:"download" binding:"omitempty"`
+}
+
+type SchedulerClusterConfigPersistentTaskBlockList struct {
+	Download *SchedulerClusterConfigDownloadBlockList `yaml:"download" mapstructure:"download" json:"download" binding:"omitempty"`
+	Upload   *SchedulerClusterConfigUploadBlockList   `yaml:"upload" mapstructure:"upload" json:"upload" binding:"omitempty"`
+}
+
+type SchedulerClusterConfigPersistentCacheTaskBlockList struct {
+	Download *SchedulerClusterConfigDownloadBlockList `yaml:"download" mapstructure:"download" json:"download" binding:"omitempty"`
+	Upload   *SchedulerClusterConfigUploadBlockList   `yaml:"upload" mapstructure:"upload" json:"upload" binding:"omitempty"`
+}
+
+type SchedulerClusterConfigDownloadBlockList struct {
+	Applications []string `yaml:"applications" mapstructure:"applications" json:"applications" binding:"omitempty"`
+	URLs         []string `yaml:"urls" mapstructure:"urls" json:"urls" binding:"omitempty"`
+	Tags         []string `yaml:"tags" mapstructure:"tags" json:"tags" binding:"omitempty"`
+	Priorities   []string `yaml:"priorities" mapstructure:"priorities" json:"priorities" binding:"omitempty"`
+}
+
+type SchedulerClusterConfigUploadBlockList struct {
+	Applications []string `yaml:"applications" mapstructure:"applications" json:"applications" binding:"omitempty"`
+	URLs         []string `yaml:"urls" mapstructure:"urls" json:"urls" binding:"omitempty"`
+	Tags         []string `yaml:"tags" mapstructure:"tags" json:"tags" binding:"omitempty"`
 }
 
 type SchedulerClusterScopes struct {

--- a/manager/types/seed_peer_cluster.go
+++ b/manager/types/seed_peer_cluster.go
@@ -49,5 +49,6 @@ type GetSeedPeerClustersQuery struct {
 }
 
 type SeedPeerClusterConfig struct {
-	LoadLimit uint32 `yaml:"loadLimit" mapstructure:"loadLimit" json:"load_limit" binding:"omitempty,gte=1,lte=50000"`
+	LoadLimit uint32                          `yaml:"loadLimit" mapstructure:"loadLimit" json:"load_limit" binding:"omitempty,gte=1,lte=50000"`
+	BlockList SchedulerClusterConfigBlockList `yaml:"blockList" mapstructure:"blockList" json:"block_list" binding:"omitempty"`
 }


### PR DESCRIPTION
This pull request introduces support for a new `SeedClientConfig` field in scheduler cluster management, ensuring that seed client configuration is handled distinctly from regular client configuration across the data model, API types, and service logic. Additionally, it improves the robustness of custom JSON and array types by ensuring they default to empty values when encountering `nil` or empty database values, preventing potential runtime errors.

**Scheduler Cluster Seed Client Configuration:**

* Added a new `SeedClientConfig` field to the `SchedulerCluster` model, its API request types, and service logic, allowing for separate configuration of seed clients (`manager/models/scheduler_cluster.go`, `manager/types/scheduler_cluster.go`, `manager/service/scheduler_cluster.go`, `manager/database/database.go`). [[1]](diffhunk://#diff-6cbd4ebbbbf00046df67c26f2457eac73a5511bd55b5630fbfc550339d49b9f2R25) [[2]](diffhunk://#diff-28da1b368330704d051ef5595b6655c1216e8fe556032bce511dad3a2ea702b5R33) [[3]](diffhunk://#diff-28da1b368330704d051ef5595b6655c1216e8fe556032bce511dad3a2ea702b5R44) [[4]](diffhunk://#diff-28da1b368330704d051ef5595b6655c1216e8fe556032bce511dad3a2ea702b5R64-R74) [[5]](diffhunk://#diff-41e9ccf12314df0d2625b76157239165da5e698c473ac058cc20a30ece790264R39-R43) [[6]](diffhunk://#diff-41e9ccf12314df0d2625b76157239165da5e698c473ac058cc20a30ece790264R54) [[7]](diffhunk://#diff-41e9ccf12314df0d2625b76157239165da5e698c473ac058cc20a30ece790264R109-R116) [[8]](diffhunk://#diff-41e9ccf12314df0d2625b76157239165da5e698c473ac058cc20a30ece790264R131) [[9]](diffhunk://#diff-ec3993c2c1033e912870893c0da883551c7c46171de1fc6ceefd5ba8762618cdR142)
* Updated cluster creation and update logic to handle the new `SeedClientConfig` field, ensuring it is properly mapped and persisted (`manager/service/cluster.go`). [[1]](diffhunk://#diff-774f1b8bc9572fa725b80de111d5c7f439c92cb9d9b66e0e58adf38d02bc5acbR66) [[2]](diffhunk://#diff-774f1b8bc9572fa725b80de111d5c7f439c92cb9d9b66e0e58adf38d02bc5acbR218)

**Improvements to Custom Types Handling:**

* Modified the `JSONMap` and `Array` custom types to default to empty objects/arrays when scanning `nil`, empty, or `"null"` values from the database, preventing panics and ensuring consistent behavior (`manager/models/models.go`). [[1]](diffhunk://#diff-f0ba3380214024f46eceeacea13b1848d224da336ff53494564553b368a6566eL49-R60) [[2]](diffhunk://#diff-f0ba3380214024f46eceeacea13b1848d224da336ff53494564553b368a6566eR70-R75) [[3]](diffhunk://#diff-f0ba3380214024f46eceeacea13b1848d224da336ff53494564553b368a6566eR125-R129) [[4]](diffhunk://#diff-f0ba3380214024f46eceeacea13b1848d224da336ff53494564553b368a6566eR139-R144)

**Configuration Structure Enhancements:**

* Introduced a `SchedulerClusterSeedClientConfig` struct and a shared `SchedulerClusterConfigBlockList` struct for consistent handling of `downloadBlockList` and related configuration fields in both peer and seed client configs (`manager/types/scheduler_cluster.go`, `manager/types/seed_peer_cluster.go`). [[1]](diffhunk://#diff-28da1b368330704d051ef5595b6655c1216e8fe556032bce511dad3a2ea702b5R64-R74) [[2]](diffhunk://#diff-31caaabe12d83796fb1f4cb9198888293c062dd877bfa58979c7828e2943f90fR53)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
