### PR TITLE
refactor(config): rename rateLimit to bandwidthLimit

### DIFF
--- a/deploy/docker-compose/template/client.template.yaml
+++ b/deploy/docker-compose/template/client.template.yaml
@@ -31,8 +31,10 @@ download:
   server:
     # socketPath is the unix socket path for dfdaemon GRPC service.
     socketPath: /var/run/dragonfly/dfdaemon.sock
-  # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # bandwidthLimit is the default rate limit of the download speed in KB/MB/GB per second, default is 10GB/s.
+  bandwidthLimit: 50GB
+  # backToSourceBandwidthLimit is the default rate limit of the download speed in KB/MB/GB per second, default is 50GB/s.
+  backToSourceBandwidthLimit: 50GB
   # pieceTimeout is the timeout for downloading a piece from source.
   pieceTimeout: 40s
   # concurrentPieceCount is the number of concurrent pieces to download.
@@ -62,8 +64,8 @@ upload:
 #
   # disableShared indicates whether disable to share data for other peers.
   disableShared: false
-  # rateLimit is the default rate limit of the upload speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # bandwidthLimit is the default rate limit of the upload speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
 
 manager:
   # addr is manager addresses.

--- a/deploy/docker-compose/template/seed-client.template.yaml
+++ b/deploy/docker-compose/template/seed-client.template.yaml
@@ -31,8 +31,10 @@ download:
   server:
     # socketPath is the unix socket path for dfdaemon GRPC service.
     socketPath: /var/run/dragonfly/dfdaemon.sock
-  # rateLimit is the default rate limit of the download speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # bandwidthLimit is the default rate limit of the download speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
+  # backToSourceBandwidthLimit is the default rate limit of the download speed from source in KB/MB/GB per second, default is 50GB/s.
+  backToSourceBandwidthLimit: 50GB
   # pieceTimeout is the timeout for downloading a piece from source.
   pieceTimeout: 40s
   # concurrentPieceCount is the number of concurrent pieces to download.
@@ -62,8 +64,8 @@ upload:
 #
   # disableShared indicates whether disable to share data for other peers.
   disableShared: false
-  # rateLimit is the default rate limit of the upload speed in KiB/MiB/GiB per second, default is 10GiB/s.
-  rateLimit: 10GiB
+  # bandwidthLimit is the default rate limit of the upload speed in KB/MB/GB per second, default is 50GB/s.
+  bandwidthLimit: 50GB
 
 manager:
   # addr is manager addresses.


### PR DESCRIPTION
This pull request updates the bandwidth configuration options for both the client and seed-client Docker Compose templates. The main changes replace the old `rateLimit` parameters with new `bandwidthLimit` parameters, increase the default limits to 50GB/s, and introduce a separate `backToSourceBandwidthLimit` for download speeds from the source.

**Configuration changes for bandwidth limits:**

* Replaced `rateLimit` with `bandwidthLimit` for both download and upload sections, changing the unit from KiB/MiB/GiB to KB/MB/GB and increasing the default value from 10GiB/s to 50GB/s in `client.template.yaml`. [[1]](diffhunk://#diff-7eafc0d242243c7242afd56d770e5493e773112d999d4ab7b1321cfd90590efbL34-R37) [[2]](diffhunk://#diff-7eafc0d242243c7242afd56d770e5493e773112d999d4ab7b1321cfd90590efbL65-R68)
* Added a new `backToSourceBandwidthLimit` option for download speed from the source, set to 50GB/s by default in `client.template.yaml`.

* Applied the same changes—replacing `rateLimit` with `bandwidthLimit` (default 50GB/s) and adding `backToSourceBandwidthLimit`—to the `seed-client.template.yaml` file for consistency. [[1]](diffhunk://#diff-5e43b1c71af0df4d8183b1f6c85947894c519215800d9a3d1b3bd5e62cddcadaL34-R37) [[2]](diffhunk://#diff-5e43b1c71af0df4d8183b1f6c85947894c519215800d9a3d1b3bd5e62cddcadaL65-R68)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
