### PR TITLE
feat(config): add request rate limit for gRPC server

### DIFF
--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -306,6 +306,10 @@ type GRPCConfig struct {
 
 	// TLS server configuration.
 	TLS *GRPCTLSServerConfig `yaml:"tls" mapstructure:"tls"`
+
+	// RequestRateLimit is the maximum number of requests per second for the gRPC server.
+	// It limits both the rate of unary gRPC requests and the rate of new stream gRPC connection.
+	RequestRateLimit float64 `yaml:"requestRateLimit" mapstructure:"requestRateLimit"`
 }
 
 type TCPListenPortRange struct {
@@ -384,6 +388,7 @@ func New() *Config {
 					Start: DefaultGRPCPort,
 					End:   DefaultGRPCPort,
 				},
+				RequestRateLimit: DefaultServerGRPCRequestRateLimit,
 			},
 			REST: RESTConfig{
 				Addr: DefaultRESTAddr,
@@ -482,6 +487,10 @@ func (cfg *Config) Validate() error {
 		if cfg.Server.GRPC.TLS.Key == "" {
 			return errors.New("grpc tls requires parameter key")
 		}
+	}
+
+	if cfg.Server.GRPC.RequestRateLimit <= 0 {
+		return errors.New("grpc requires parameter requestRateLimit")
 	}
 
 	if cfg.Server.REST.TLS != nil {

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -102,6 +102,7 @@ func TestConfig_Load(t *testing.T) {
 					Cert:   "foo",
 					Key:    "foo",
 				},
+				RequestRateLimit: 100,
 			},
 			REST: RESTConfig{
 				Addr: ":8080",
@@ -298,6 +299,17 @@ func TestConfig_Validate(t *testing.T) {
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
 				assert.EqualError(err, "grpc tls requires parameter key")
+			},
+		},
+		{
+			name:   "grpc requires parameter requestRateLimit",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Server.GRPC.RequestRateLimit = 0
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "grpc requires parameter requestRateLimit")
 			},
 		},
 		{

--- a/manager/config/constants.go
+++ b/manager/config/constants.go
@@ -41,6 +41,10 @@ const (
 	// DefaultGRPCPort is default port for grpc server.
 	DefaultGRPCPort = 65003
 
+	// DefaultServerGRPCRequestRateLimit is the default number of requests per second for the gRPC server.
+	// It limits both the rate of unary gRPC requests and the rate of new stream gRPC connection.
+	DefaultServerGRPCRequestRateLimit = 4000
+
 	// DefaultRESTAddr is default address for rest server.
 	DefaultRESTAddr = ":8080"
 )

--- a/manager/config/testdata/manager.yaml
+++ b/manager/config/testdata/manager.yaml
@@ -17,6 +17,7 @@ server:
       caCert: foo
       cert: foo
       key: foo
+    requestRateLimit: 100
   rest:
     addr: :8080
     tls:

--- a/manager/rpcserver/rpcserver.go
+++ b/manager/rpcserver/rpcserver.go
@@ -62,6 +62,7 @@ func New(
 	return s, managerserver.New(
 		newManagerServerV1(s.config, database, s.cache, s.searcher),
 		newManagerServerV2(s.config, database, s.cache, s.searcher),
+		cfg.Server.GRPC.RequestRateLimit,
 		opts...), nil
 }
 

--- a/pkg/rpc/manager/server/server.go
+++ b/pkg/rpc/manager/server/server.go
@@ -42,12 +42,6 @@ import (
 )
 
 const (
-	// DefaultQPS is default qps of grpc server.
-	DefaultQPS = 20 * 1000
-
-	// DefaultBurst is default burst of grpc server.
-	DefaultBurst = 30 * 1000
-
 	// DefaultMaxConnectionIdle is default max connection idle of grpc keepalive.
 	DefaultMaxConnectionIdle = 10 * time.Minute
 
@@ -59,8 +53,8 @@ const (
 )
 
 // New returns grpc server instance and register service on grpc server.
-func New(managerServerV1 managerv1.ManagerServer, managerServerV2 managerv2.ManagerServer, opts ...grpc.ServerOption) *grpc.Server {
-	limiter := rpc.NewRateLimiterInterceptor(DefaultQPS, DefaultBurst)
+func New(managerServerV1 managerv1.ManagerServer, managerServerV2 managerv2.ManagerServer, requestRateLimit float64, opts ...grpc.ServerOption) *grpc.Server {
+	limiter := rpc.NewRateLimiterInterceptor(requestRateLimit, int64(requestRateLimit))
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
 		grpc.MaxRecvMsgSize(math.MaxInt32),

--- a/pkg/rpc/scheduler/server/server.go
+++ b/pkg/rpc/scheduler/server/server.go
@@ -42,12 +42,6 @@ import (
 )
 
 const (
-	// DefaultQPS is default qps of grpc server.
-	DefaultQPS = 5000
-
-	// DefaultBurst is default burst of grpc server.
-	DefaultBurst = 5000
-
 	// DefaultMaxConnectionIdle is default max connection idle of grpc keepalive.
 	DefaultMaxConnectionIdle = 10 * time.Minute
 
@@ -59,8 +53,8 @@ const (
 )
 
 // New returns a grpc server instance and register service on grpc server.
-func New(schedulerServerV1 schedulerv1.SchedulerServer, schedulerServerV2 schedulerv2.SchedulerServer, opts ...grpc.ServerOption) *grpc.Server {
-	limiter := rpc.NewRateLimiterInterceptor(DefaultQPS, DefaultBurst)
+func New(schedulerServerV1 schedulerv1.SchedulerServer, schedulerServerV2 schedulerv2.SchedulerServer, requestRateLimit float64, opts ...grpc.ServerOption) *grpc.Server {
+	limiter := rpc.NewRateLimiterInterceptor(requestRateLimit, int64(requestRateLimit))
 
 	grpcServer := grpc.NewServer(append([]grpc.ServerOption{
 		grpc.MaxRecvMsgSize(math.MaxInt32),

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -85,6 +85,10 @@ type ServerConfig struct {
 	// TLS server configuration.
 	TLS *GRPCTLSServerConfig `yaml:"tls" mapstructure:"tls"`
 
+	// RequestRateLimit is the maximum number of requests per second for the gRPC server.
+	// It limits both the rate of unary gRPC requests and the rate of new stream gRPC connection.
+	RequestRateLimit float64 `yaml:"requestRateLimit" mapstructure:"requestRateLimit"`
+
 	// Server dynamic config cache directory.
 	CacheDir string `yaml:"cacheDir" mapstructure:"cacheDir"`
 
@@ -325,13 +329,14 @@ func New() *Config {
 			},
 		},
 		Server: ServerConfig{
-			Port:          DefaultServerPort,
-			AdvertisePort: DefaultServerAdvertisePort,
-			Host:          fqdn.FQDNHostname,
-			LogLevel:      "info",
-			LogMaxSize:    DefaultLogRotateMaxSize,
-			LogMaxAge:     DefaultLogRotateMaxAge,
-			LogMaxBackups: DefaultLogRotateMaxBackups,
+			Port:             DefaultServerPort,
+			AdvertisePort:    DefaultServerAdvertisePort,
+			Host:             fqdn.FQDNHostname,
+			RequestRateLimit: DefaultServerRequestRateLimit,
+			LogLevel:         "info",
+			LogMaxSize:       DefaultLogRotateMaxSize,
+			LogMaxAge:        DefaultLogRotateMaxAge,
+			LogMaxBackups:    DefaultLogRotateMaxBackups,
 		},
 		Scheduler: SchedulerConfig{
 			Algorithm:              DefaultSchedulerAlgorithm,
@@ -421,6 +426,10 @@ func (cfg *Config) Validate() error {
 		if cfg.Server.TLS.Key == "" {
 			return errors.New("server tls requires parameter key")
 		}
+	}
+
+	if cfg.Server.RequestRateLimit <= 0 {
+		return errors.New("server requires parameter requestRateLimit")
 	}
 
 	if cfg.Scheduler.Algorithm == "" {

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -75,11 +75,12 @@ func TestConfig_Load(t *testing.T) {
 			},
 		},
 		Server: ServerConfig{
-			AdvertiseIP:   net.ParseIP("127.0.0.1"),
-			AdvertisePort: 8004,
-			ListenIP:      net.ParseIP("0.0.0.0"),
-			Port:          8002,
-			Host:          "foo",
+			AdvertiseIP:      net.ParseIP("127.0.0.1"),
+			AdvertisePort:    8004,
+			ListenIP:         net.ParseIP("0.0.0.0"),
+			Port:             8002,
+			Host:             "foo",
+			RequestRateLimit: 100,
 			TLS: &GRPCTLSServerConfig{
 				CACert: "foo",
 				Cert:   "foo",
@@ -288,6 +289,19 @@ func TestConfig_Validate(t *testing.T) {
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
 				assert.EqualError(err, "server tls requires parameter key")
+			},
+		},
+		{
+			name:   "server requires parameter requestRateLimit",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Manager = mockManagerConfig
+				cfg.Job = mockJobConfig
+				cfg.Server.RequestRateLimit = 0
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "server requires parameter requestRateLimit")
 			},
 		},
 		{

--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -43,6 +43,10 @@ const (
 
 	// DefaultServerAdvertisePort is default advertise port for server.
 	DefaultServerAdvertisePort = 8002
+
+	// DefaultServerRequestRateLimit is the default number of requests per second for the gRPC server.
+	// It limits both the rate of unary gRPC requests and the rate of new stream gRPC connection.
+	DefaultServerRequestRateLimit = 4000
 )
 
 const (

--- a/scheduler/config/testdata/scheduler.yaml
+++ b/scheduler/config/testdata/scheduler.yaml
@@ -8,6 +8,7 @@ server:
     caCert: foo
     cert: foo
     key: foo
+  requestRateLimit: 100
   cacheDir: foo
   logDir: foo
   pluginDir: foo

--- a/scheduler/rpcserver/rpcserver.go
+++ b/scheduler/rpcserver/rpcserver.go
@@ -42,5 +42,6 @@ func New(
 	return server.New(
 		newSchedulerServerV1(cfg, resource, scheduling, dynconfig),
 		newSchedulerServerV2(cfg, resource, persistentResource, persistentCacheResource, scheduling, job, dynconfig),
+		cfg.Server.RequestRateLimit,
 		opts...)
 }

--- a/scheduler/rpcserver/rpcserver_test.go
+++ b/scheduler/rpcserver/rpcserver_test.go
@@ -67,7 +67,7 @@ func TestRPCServer_New(t *testing.T) {
 			dynconfig := configmocks.NewMockDynconfigInterface(ctl)
 			job := jobmocks.NewMockJob(ctl)
 
-			svr := New(&config.Config{Scheduler: mockSchedulerConfig}, resource, persistentResource, persistentCacheResource, scheduling, job, dynconfig)
+			svr := New(&config.Config{Scheduler: mockSchedulerConfig, Server: config.ServerConfig{RequestRateLimit: 100}}, resource, persistentResource, persistentCacheResource, scheduling, job, dynconfig)
 			tc.expect(t, svr)
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a configurable request rate limit for the gRPC servers in both the manager and scheduler components. The rate limit is now exposed as a configuration parameter, with sensible defaults and validation to ensure it is set. Related tests and documentation are updated to reflect this new configuration option.

**gRPC Rate Limiting Configuration**

* Added a new `RequestRateLimit` field to the gRPC server configuration structs in both `manager` and `scheduler` (`config.go`), allowing administrators to specify the maximum number of requests per second for the gRPC server. This rate limit applies to both unary requests and new streaming connections. [[1]](diffhunk://#diff-38f5db6313cbf867355d056890ad5ca0f1b952eebef92eb70abbafeb1b655c15R309-R312) [[2]](diffhunk://#diff-0c784f71367ad0e2181f892a3fe4ba3529290443b5f3573bfdbd1b231de96a5eR88-R91)
* Introduced default values for `RequestRateLimit` (`4000` requests/sec) in the constants files and set these defaults in the configuration initialization functions. [[1]](diffhunk://#diff-2cba7d0d032cd2e3a3842ed4df38cab999b1e1cf93f1cdf8b1ea3109f4acaaaeR44-R47) [[2]](diffhunk://#diff-00cdd00ccb76ae431f8eabda93bfc7c90620640e8ec5178b5bc77407bbb2d47cR46-R49) [[3]](diffhunk://#diff-38f5db6313cbf867355d056890ad5ca0f1b952eebef92eb70abbafeb1b655c15R391) [[4]](diffhunk://#diff-0c784f71367ad0e2181f892a3fe4ba3529290443b5f3573bfdbd1b231de96a5eR335)
* Updated the configuration validation logic to ensure that `RequestRateLimit` is set to a positive value, returning a clear error message if not. [[1]](diffhunk://#diff-38f5db6313cbf867355d056890ad5ca0f1b952eebef92eb70abbafeb1b655c15R492-R495) [[2]](diffhunk://#diff-0c784f71367ad0e2181f892a3fe4ba3529290443b5f3573bfdbd1b231de96a5eR431-R434)

**gRPC Server Implementation**

* Modified the gRPC server constructors to accept the `RequestRateLimit` as a parameter and use it for rate limiting, replacing previous hardcoded or constant-based QPS/burst values. [[1]](diffhunk://#diff-49dac8d7e88c761ef9129737a92f042bb3f844dcb361380089871965bc8199e7R65) [[2]](diffhunk://#diff-1d2f64fa6ebcc6e7890e6d5536c5926509604bd6de29467db4f854c58959ca58R45) [[3]](diffhunk://#diff-00e212e7e4ca893fd9a01f42d24842d186db8e3dadf3568d6b5c73a132575137L62-R57) [[4]](diffhunk://#diff-410002dd12096c9e570b6307bb563fecb2aae41aec71c6a766d0b8f2da4cfe42L62-R57)
* Removed obsolete QPS and burst constants from the gRPC server implementations, as these are now configurable. [[1]](diffhunk://#diff-00e212e7e4ca893fd9a01f42d24842d186db8e3dadf3568d6b5c73a132575137L45-L50) [[2]](diffhunk://#diff-410002dd12096c9e570b6307bb563fecb2aae41aec71c6a766d0b8f2da4cfe42L45-L50)

**Testing and Example Configuration**

* Updated configuration test files and test cases to include and validate the new `RequestRateLimit` parameter, ensuring correct behavior and error handling. [[1]](diffhunk://#diff-405eec0f5f7741725dca3b1c211b57d66ba7e680600a40314cd6e62bef5d8bcdR105) [[2]](diffhunk://#diff-61e991f4a914812cbd1ea30716c3041b3215d05ebf22c2f21ed788338c4f3684R83) [[3]](diffhunk://#diff-bf97f855ea323413a36a9629e32ab5061eb62671060dd539fe963ebd39fb2945R20) [[4]](diffhunk://#diff-9e000d1abc8fb7b9c964b9569045e4ade5e480187c357f68c1e94afd56dd3465R11) [[5]](diffhunk://#diff-405eec0f5f7741725dca3b1c211b57d66ba7e680600a40314cd6e62bef5d8bcdR304-R314) [[6]](diffhunk://#diff-61e991f4a914812cbd1ea30716c3041b3215d05ebf22c2f21ed788338c4f3684R294-R306)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
