### PR TITLE
refactor(types): change priorities from string to int32

### DIFF
--- a/manager/types/scheduler_cluster.go
+++ b/manager/types/scheduler_cluster.go
@@ -92,7 +92,7 @@ type SchedulerClusterConfigDownloadBlockList struct {
 	Applications []string `yaml:"applications" mapstructure:"applications" json:"applications" binding:"omitempty"`
 	URLs         []string `yaml:"urls" mapstructure:"urls" json:"urls" binding:"omitempty"`
 	Tags         []string `yaml:"tags" mapstructure:"tags" json:"tags" binding:"omitempty"`
-	Priorities   []string `yaml:"priorities" mapstructure:"priorities" json:"priorities" binding:"omitempty"`
+	Priorities   []int32  `yaml:"priorities" mapstructure:"priorities" json:"priorities" binding:"omitempty"`
 }
 
 type SchedulerClusterConfigUploadBlockList struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a small change to the `SchedulerClusterConfigDownloadBlockList` struct to improve type safety and clarity.

* Changed the type of the `Priorities` field from `[]string` to `[]int32` in the `SchedulerClusterConfigDownloadBlockList` struct in `manager/types/scheduler_cluster.go`, ensuring priorities are represented as integers instead of strings.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
