### PR TITLE
feat(rpcserver): add scheduler configuration marshalling

### DIFF
--- a/manager/rpcserver/manager_server_v2.go
+++ b/manager/rpcserver/manager_server_v2.go
@@ -680,6 +680,30 @@ func (s *managerServerV2) listSchedulersBySearcher(ctx context.Context, req *man
 			return nil, status.Error(codes.DataLoss, err.Error())
 		}
 
+		// Marshal config of scheduler.
+		config, err := scheduler.SchedulerCluster.Config.MarshalJSON()
+		if err != nil {
+			return nil, status.Error(codes.DataLoss, err.Error())
+		}
+
+		// Marshal client config of scheduler.
+		clientConfig, err := scheduler.SchedulerCluster.ClientConfig.MarshalJSON()
+		if err != nil {
+			return nil, status.Error(codes.DataLoss, err.Error())
+		}
+
+		// Marshal seed client config of scheduler.
+		seedClientConfig, err := scheduler.SchedulerCluster.SeedClientConfig.MarshalJSON()
+		if err != nil {
+			return nil, status.Error(codes.DataLoss, err.Error())
+		}
+
+		// Marshal scopes config of scheduler.
+		scopes, err := scheduler.SchedulerCluster.Scopes.MarshalJSON()
+		if err != nil {
+			return nil, status.Error(codes.DataLoss, err.Error())
+		}
+
 		pbListSchedulersResponse.Schedulers = append(pbListSchedulersResponse.Schedulers, &managerv2.Scheduler{
 			Id:                 uint64(scheduler.ID),
 			Hostname:           scheduler.Hostname,
@@ -690,7 +714,16 @@ func (s *managerServerV2) listSchedulersBySearcher(ctx context.Context, req *man
 			State:              scheduler.State,
 			Features:           features,
 			SchedulerClusterId: uint64(scheduler.SchedulerClusterID),
-			SeedPeers:          seedPeers,
+			SchedulerCluster: &managerv2.SchedulerCluster{
+				Id:               uint64(scheduler.SchedulerCluster.ID),
+				Name:             scheduler.SchedulerCluster.Name,
+				Bio:              scheduler.SchedulerCluster.BIO,
+				Config:           config,
+				ClientConfig:     clientConfig,
+				Scopes:           scopes,
+				SeedClientConfig: seedClientConfig,
+			},
+			SeedPeers: seedPeers,
 		})
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request enhances the scheduler listing functionality by including detailed configuration data for each scheduler's cluster in the response. The main focus is on serializing and returning various config objects as part of the `SchedulerCluster` information.

**Improvements to scheduler cluster data serialization:**

* Added marshaling of `Config`, `ClientConfig`, `SeedClientConfig`, and `Scopes` from `SchedulerCluster` to JSON, with error handling for each step.

**Enhancements to API response structure:**

* Updated the `SchedulerCluster` field in the returned scheduler objects to include the marshaled configuration data (`Config`, `ClientConfig`, `SeedClientConfig`, and `Scopes`) as well as basic cluster info (`Id`, `Name`, `Bio`).
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
