### PR TITLE
feat: implement Redis Set storage for SyncPeersJob to avoid big key issues

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -33,6 +33,11 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	logger "d7y.io/dragonfly/v2/internal/dflog"
+	pkgredis "d7y.io/dragonfly/v2/pkg/redis"
+)
+
+var (
+	ErrRedisNotInitialized = errors.New("redis client not initialized")
 )
 
 type Config struct {
@@ -48,6 +53,7 @@ type Job struct {
 	Server *machinery.Server
 	Worker *machinery.Worker
 	Queue  Queue
+	rdb    redis.UniversalClient
 }
 
 func New(cfg *Config, queue Queue) (*Job, error) {
@@ -101,6 +107,27 @@ func (t *Job) LaunchWorker(consumerTag string, concurrency int) error {
 	return t.Worker.Launch()
 }
 
+// InitRdb initializes the redis client for job.
+func (t *Job) InitRdb(cfg *Config) error {
+	if t.rdb != nil {
+		return nil
+	}
+	// Initialize redis client.
+	var rdb redis.UniversalClient
+	rdb, err := pkgredis.NewRedis(&redis.UniversalOptions{
+		Addrs:      cfg.Addrs,
+		MasterName: cfg.MasterName,
+		Username:   cfg.Username,
+		Password:   cfg.Password,
+		DB:         cfg.BackendDB,
+	})
+	if err != nil {
+		return err
+	}
+	t.rdb = rdb
+	return nil
+}
+
 type GroupJobState struct {
 	GroupUUID string
 	State     string
@@ -148,6 +175,61 @@ func (t *Job) GetGroupJobState(groupID string) (*GroupJobState, error) {
 		CreatedAt: taskStates[0].CreatedAt,
 		JobStates: taskStates,
 	}, nil
+}
+
+// SetTaskResults sets task results to redis by key.
+func (t *Job) SetTaskResults(data []string, jobName string) (string, error) {
+	if t.rdb == nil {
+		return "", ErrRedisNotInitialized
+	}
+
+	if len(data) == 0 {
+		return "", nil
+	}
+
+	key := fmt.Sprintf("%s_results:%s:%d", jobName, t.Queue.String(), time.Now().Unix())
+
+	ctx := context.Background()
+
+	// save results to redis set
+	for _, val := range data {
+		if err := t.rdb.SAdd(ctx, key, val).Err(); err != nil {
+			logger.Errorf("Failed to SAdd: %v", err)
+			return "", err
+		}
+	}
+
+	// set expire time for the results
+	if err := t.rdb.Expire(ctx, key, time.Duration(DefaultResultsExpireIn)*time.Second).Err(); err != nil {
+		logger.Errorf("Failed to set expire: %v", err)
+		return "", err
+	}
+
+	return key, nil
+}
+
+// GetTaskResults gets task results from redis by key.
+// results is not sorted, caller should sort it if needed.
+func (t *Job) GetTaskResults(key string) ([]string, error) {
+	if t.rdb == nil {
+		return nil, ErrRedisNotInitialized
+	}
+	var cursor uint64 = 0
+	var results []string
+	for {
+		items, nextCursor, err := t.rdb.SScan(context.Background(), key, cursor, "", 50).Result()
+		if err != nil {
+			break
+		}
+		for _, item := range items {
+			results = append(results, item)
+		}
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+	return results, nil
 }
 
 func MarshalResponse(v any) (string, error) {

--- a/manager/job/job.go
+++ b/manager/job/job.go
@@ -55,6 +55,17 @@ func New(cfg *config.Config, gdb *gorm.DB) (*Job, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = j.InitRdb(&internaljob.Config{
+		Addrs:      cfg.Database.Redis.Addrs,
+		MasterName: cfg.Database.Redis.MasterName,
+		Username:   cfg.Database.Redis.Username,
+		Password:   cfg.Database.Redis.Password,
+		BrokerDB:   cfg.Database.Redis.BrokerDB,
+		BackendDB:  cfg.Database.Redis.BackendDB,
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	var certPool *x509.CertPool
 	if cfg.Job.Preheat.TLS != nil {

--- a/manager/job/sync_peers.go
+++ b/manager/job/sync_peers.go
@@ -163,10 +163,28 @@ func (s *syncPeers) createSyncPeers(ctx context.Context, scheduler models.Schedu
 		return nil, err
 	}
 
-	// Unmarshal sync peer task result.
-	var hosts []*resource.Host
-	if err := internaljob.UnmarshalResponse(results, &hosts); err != nil {
+	if len(results) == 0 || results[0].String() == "" {
+		logger.Infof("sync peers task %s result is empty", task.UUID)
+		return nil, fmt.Errorf("sync peers task result is empty")
+	}
+
+	res_key := results[0].String()
+
+	hostStringList, err := s.job.GetTaskResults(res_key)
+	if err != nil {
+		logger.Errorf("failed to get sync peer data: %v", err)
 		return nil, err
+	}
+
+	var hosts []*resource.Host
+
+	for _, item := range hostStringList {
+		var host resource.Host
+		if err := internaljob.UnmarshalRequest(item, &host); err != nil {
+			logger.Errorf("Unmarshal sync peer item fail. item: %s, err: %v", item, err)
+			continue
+		}
+		hosts = append(hosts, &host)
 	}
 
 	return hosts, nil

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -117,6 +117,11 @@ func New(cfg *config.Config, resource resource.Resource) (Job, error) {
 		logger.Errorf("register preheat job to local queue error: %s", err.Error())
 		return nil, err
 	}
+	err = localJob.InitRdb(redisConfig)
+	if err != nil {
+		logger.Errorf("initialize redis for local job error: %s", err.Error())
+		return nil, err
+	}
 
 	return t, nil
 }
@@ -283,17 +288,25 @@ func (j *job) preheatV2(ctx context.Context, req *internaljob.PreheatRequest) er
 
 // syncPeers is a job to sync peers.
 func (j *job) syncPeers() (string, error) {
-	var hosts []*resource.Host
+	var hosts []string
 	j.resource.HostManager().Range(func(key, value any) bool {
 		host, ok := value.(*resource.Host)
 		if !ok {
 			logger.Errorf("invalid host %v %v", key, value)
 			return true
 		}
-
-		hosts = append(hosts, host)
+		json, err := internaljob.MarshalResponse(host)
+		if err != nil {
+			logger.Errorf("Marshal host fail. host: %s, err: %v", host, err)
+			return true
+		}
+		hosts = append(hosts, json)
 		return true
 	})
-
-	return internaljob.MarshalResponse(hosts)
+	key, errors := j.localJob.SetTaskResults(hosts, internaljob.SyncPeersJob)
+	if errors != nil {
+		logger.Errorf("Failed to set sync peers task results: %v", errors)
+		return "", errors
+	}
+	return key, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Dragonfly syncPeer job has the potential to cause a Redis Big Key Problem （value > 100k）when the number of peer nodes is excessive, which poses a risk of degrading Redis performance.

This PR updates the logic to store SyncPeersJob results in a Redis set instead of storing them as a single string.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4379

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Instead of serializing the entire result into a large JSON string (which could lead to Redis big key issues), this PR serializes individual host objects and stores them into a Redis Set. The task then returns the key of this Set. During retrieval, the results are fetched directly from Redis via this key.



<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
