### PR TITLE
ci: add Docker credentials env vars and skip test if not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           sudo ip addr
 
       - name: Run Unit tests
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |-
           # switch to installed go
           sudo ln -sf `which go` `sudo which go`

--- a/internal/job/image_test.go
+++ b/internal/job/image_test.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -25,6 +26,12 @@ import (
 )
 
 func TestPreheat_CreatePreheatRequestsByManifestURL(t *testing.T) {
+	username := os.Getenv("DOCKER_USERNAME")
+	password := os.Getenv("DOCKER_PASSWORD")
+	if username == "" || password == "" {
+		t.Skip("DOCKER_USERNAME or DOCKER_PASSWORD is not set, skipping test")
+	}
+
 	tests := []struct {
 		name   string
 		req    *ManifestRequest
@@ -34,6 +41,8 @@ func TestPreheat_CreatePreheatRequestsByManifestURL(t *testing.T) {
 			name: "get image layers with manifest url",
 			req: &ManifestRequest{
 				URL:                "https://registry-1.docker.io/v2/dragonflyoss/busybox/manifests/1.35.0",
+				Username:           username,
+				Password:           password,
 				Timeout:            30 * time.Second,
 				InsecureSkipVerify: true,
 			},
@@ -47,6 +56,8 @@ func TestPreheat_CreatePreheatRequestsByManifestURL(t *testing.T) {
 			req: &ManifestRequest{
 				URL:                "https://registry-1.docker.io/v2/dragonflyoss/scheduler/manifests/v2.1.0",
 				Platform:           "linux/amd64",
+				Username:           username,
+				Password:           password,
 				Timeout:            30 * time.Second,
 				InsecureSkipVerify: true,
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request improves the way Docker credentials are handled in both the CI workflow and the image preheat unit tests. The main changes ensure that Docker Hub credentials are securely passed to the test environment and that tests requiring authentication are skipped if credentials are missing.

**CI/CD and Testing Improvements:**

* The CI workflow (`.github/workflows/ci.yml`) now sets `DOCKER_USERNAME` and `DOCKER_PASSWORD` environment variables for the unit test step, allowing tests to authenticate with Docker Hub.

* The image preheat unit test (`internal/job/image_test.go`) now reads Docker credentials from environment variables and skips tests if they are not set, preventing authentication errors in environments without secrets configured.

* The `ManifestRequest` objects in the test cases are updated to include the Docker credentials, enabling authenticated requests to Docker Hub during testing. [[1]](diffhunk://#diff-f06cc5ebbb99cc886de8adbfd0b0d914de5f2fefcc2adb9de0690325e979861fR44-R45) [[2]](diffhunk://#diff-f06cc5ebbb99cc886de8adbfd0b0d914de5f2fefcc2adb9de0690325e979861fR59-R60)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
