### PR TITLE
refactor(job): rename `blobsURL` to `blobURL` for grammatical accuracy

### DIFF
--- a/internal/job/image.go
+++ b/internal/job/image.go
@@ -74,7 +74,7 @@ func (p *preheatImage) manifestURL() string {
 	return fmt.Sprintf("%s://%s/v2/%s/manifests/%s", p.protocol, p.domain, p.name, p.tag)
 }
 
-func (p *preheatImage) blobsURL(digest string) string {
+func (p *preheatImage) blobURL(digest string) string {
 	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", p.protocol, p.domain, p.name, digest)
 }
 
@@ -348,7 +348,7 @@ func buildPreheatRequestFromManifests(manifests []distribution.Manifest, req *Ma
 	for _, m := range manifests {
 		for _, v := range m.References() {
 			header.Set("Accept", v.MediaType)
-			layerURLs = append(layerURLs, image.blobsURL(v.Digest.String()))
+			layerURLs = append(layerURLs, image.blobURL(v.Digest.String()))
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to the `internal/job/image.go` file, focusing on improving naming consistency. The method previously named `blobsURL` has been renamed to `blobURL`, and all usages have been updated accordingly. This change helps clarify that the method returns the URL for a single blob, not multiple blobs.

- Naming consistency:
  * Renamed the `blobsURL` method to `blobURL` in the `preheatImage` struct and updated all references to use the new name. [[1]](diffhunk://#diff-22a5bcad344ea63756fb45bc319583e0360ac40472799e4fb03eca4bb91103fbL77-R77) [[2]](diffhunk://#diff-22a5bcad344ea63756fb45bc319583e0360ac40472799e4fb03eca4bb91103fbL351-R351)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
