### PR TITLE
fix: call ListTaskEntries only for directory URLs in PreheatFile/StaFile

### DIFF
--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -4713,22 +4713,21 @@ func (v *V2) PreheatFile(ctx context.Context, req *schedulerv2.PreheatFileReques
 	ctx, cancel := context.WithTimeout(ctx, req.GetTimeout().AsDuration())
 	defer cancel()
 
-	// For files preheating, we get entries from client first
-	listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
-		TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, ""),
-		Url:              req.GetUrl(),
-		Timeout:          req.GetTimeout(),
-		Header:           req.GetHeader(),
-		CertificateChain: req.GetCertificateChain(),
-		ObjectStorage:    req.GetObjectStorage(),
-		Hdfs:             req.GetHdfs(),
-	}, log)
-	if err != nil {
-		return status.Errorf(codes.InvalidArgument, "failed to list task entries: %s", err)
-	}
-
 	var urls []string
 	if strings.HasSuffix(req.GetUrl(), "/") {
+		listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
+			TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, ""),
+			Url:              req.GetUrl(),
+			Timeout:          req.GetTimeout(),
+			Header:           req.GetHeader(),
+			CertificateChain: req.GetCertificateChain(),
+			ObjectStorage:    req.GetObjectStorage(),
+			Hdfs:             req.GetHdfs(),
+		}, log)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "failed to list task entries: %s", err)
+		}
+
 		if len(listResp.Entries) == 0 {
 			return status.Errorf(codes.InvalidArgument, "preheat url is a directory, but with no entry: %s", req.GetUrl())
 		}
@@ -4840,21 +4839,21 @@ func (v *V2) StatFile(ctx context.Context, req *schedulerv2.StatFileRequest) (*s
 	ctx, cancel := context.WithTimeout(ctx, req.GetTimeout().AsDuration())
 	defer cancel()
 
-	listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
-		TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, ""),
-		Url:              req.GetUrl(),
-		Timeout:          req.GetTimeout(),
-		Header:           req.GetHeader(),
-		CertificateChain: req.GetCertificateChain(),
-		ObjectStorage:    req.GetObjectStorage(),
-		Hdfs:             req.GetHdfs(),
-	}, log)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "failed to list task entries: %s", err)
-	}
-
 	var urls []string
 	if strings.HasSuffix(req.GetUrl(), "/") {
+		listResp, err := v.job.ListTaskEntries(ctx, &internaljob.ListTaskEntriesRequest{
+			TaskID:           idgen.TaskIDV2ByURLBased(req.GetUrl(), req.PieceLength, req.GetTag(), req.GetApplication(), req.FilteredQueryParams, ""),
+			Url:              req.GetUrl(),
+			Timeout:          req.GetTimeout(),
+			Header:           req.GetHeader(),
+			CertificateChain: req.GetCertificateChain(),
+			ObjectStorage:    req.GetObjectStorage(),
+			Hdfs:             req.GetHdfs(),
+		}, log)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to list task entries: %s", err)
+		}
+
 		if len(listResp.Entries) == 0 {
 			return nil, status.Errorf(codes.InvalidArgument, "stat url is a directory, but with no entry: %s", req.GetUrl())
 		}
@@ -4927,6 +4926,5 @@ func (v *V2) StatFile(ctx context.Context, req *schedulerv2.StatFileRequest) (*s
 		log.Infof("stat file for peer %s", peer.Ip)
 	}
 
-	log.Infof("stat file finished, total files: %d, total peers: %d", len(listResp.Entries), len(resp.Peers))
 	return resp, nil
 }

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -4328,7 +4328,7 @@ func TestServiceV2_StatFile(t *testing.T) {
 		{
 			name: "list task entries failed",
 			req: &schedulerv2.StatFileRequest{
-				Url: "https://example.com/file.txt",
+				Url: "https://example.com/dir/",
 			},
 			run: func(t *testing.T, svc *V2, req *schedulerv2.StatFileRequest, mj *jobmocks.MockJobMockRecorder) {
 				mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("list task entries failed")).Times(1)
@@ -4350,7 +4350,6 @@ func TestServiceV2_StatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.GetTask(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.GetTaskRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(nil, errors.New("get task failed")).Times(1),
 				)
 
@@ -4371,7 +4370,6 @@ func TestServiceV2_StatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.GetTask(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.GetTaskRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(&internaljob.GetTaskResponse{Peers: []*internaljob.Peer{{IP: "127.0.0.1", Hostname: "peer-1"}}}, nil).Times(1),
 				)
 

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -4163,10 +4163,6 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				Scope: "invalid-scope",
 			},
 			run: func(t *testing.T, svc *V2, req *schedulerv2.PreheatFileRequest, mj *jobmocks.MockJobMockRecorder) {
-				mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{
-					Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}},
-				}, nil).Times(1)
-
 				assert := assert.New(t)
 				assert.ErrorIs(svc.PreheatFile(context.Background(), req), status.Errorf(codes.InvalidArgument, "unsupported preheat scope: invalid-scope"))
 			},
@@ -4182,7 +4178,6 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.PreheatSingleSeedPeer(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(nil, nil).Times(1),
 				)
 
@@ -4202,9 +4197,9 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.PreheatSingleSeedPeer(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(nil, nil).Times(1),
 				)
+
 				assert := assert.New(t)
 				assert.NoError(svc.PreheatFile(context.Background(), req))
 			},
@@ -4221,9 +4216,9 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.PreheatSingleSeedPeer(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(nil, nil).Times(1),
 				)
+
 				assert := assert.New(t)
 				assert.NoError(svc.PreheatFile(context.Background(), req))
 			},
@@ -4240,9 +4235,9 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.PreheatAllSeedPeers(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(&internaljob.PreheatResponse{SuccessTasks: make([]*internaljob.PreheatSuccessTask, 0), FailureTasks: make([]*internaljob.PreheatFailureTask, 0)}, nil).Times(1),
 				)
+
 				assert := assert.New(t)
 				assert.NoError(svc.PreheatFile(context.Background(), req))
 			},
@@ -4259,9 +4254,9 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.PreheatAllSeedPeers(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(&internaljob.PreheatResponse{SuccessTasks: make([]*internaljob.PreheatSuccessTask, 0), FailureTasks: make([]*internaljob.PreheatFailureTask, 0)}, nil).Times(1),
 				)
+
 				assert := assert.New(t)
 				assert.NoError(svc.PreheatFile(context.Background(), req))
 			},
@@ -4278,9 +4273,9 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.PreheatAllPeers(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(&internaljob.PreheatResponse{SuccessTasks: make([]*internaljob.PreheatSuccessTask, 0), FailureTasks: make([]*internaljob.PreheatFailureTask, 0)}, nil).Times(1),
 				)
+
 				assert := assert.New(t)
 				assert.NoError(svc.PreheatFile(context.Background(), req))
 			},
@@ -4297,7 +4292,6 @@ func TestServiceV2_PreheatFile(t *testing.T) {
 				defer wg.Wait()
 
 				gomock.InOrder(
-					mj.ListTaskEntries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&internaljob.ListTaskEntriesResponse{Entries: []*dfdaemonv2.Entry{{Url: "https://example.com/file.txt"}}}, nil).Times(1),
 					mj.PreheatAllPeers(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) { wg.Done() }).Return(&internaljob.PreheatResponse{SuccessTasks: make([]*internaljob.PreheatSuccessTask, 0), FailureTasks: make([]*internaljob.PreheatFailureTask, 0)}, nil).Times(1),
 				)
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors how directory URLs are handled in the `PreheatFile` and `StatFile` methods in `scheduler/service/service_v2.go`. The main focus is to streamline the initialization of the `urls` slice and the logic for handling directory URLs, reducing redundant code and improving clarity.

Refactoring directory URL handling:

* Moved the initialization of the `urls` slice and the check for directory URLs (`strings.HasSuffix(req.GetUrl(), "/")`) to occur before calling `ListTaskEntries` in both `PreheatFile` and `StatFile`, eliminating redundant code and improving readability. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL4716-R4717) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cR4842-R4843)
* Removed duplicate declarations of the `urls` slice and the directory check that previously occurred after fetching task entries, further simplifying the logic flow. [[1]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL4730-L4731) [[2]](diffhunk://#diff-53ba821b898fb629c0cdb43d491c544e6b4ffc93aebb1fb05725ede3551de75cL4856-L4857)

Logging cleanup:

* Removed a redundant log statement that reported the total number of files and peers at the end of the `StatFile` method, as this information is no longer necessary.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
