### PR TITLE
feat(manager): add ExternalRedis TLS support (closes #4734)

### DIFF
--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -267,6 +267,24 @@ type RedisConfig struct {
 	// manager's IP and port need to be exposed.
 	// Note: Only a single Redis address is supported by the proxy.
 	Proxy RedisProxyConfig `yaml:"proxy" mapstructure:"proxy"`
+
+	// Custom TLS client configuration for connecting to redis.
+	TLS *RedisTLSClientConfig `yaml:"tls" mapstructure:"tls"`
+}
+
+type RedisTLSClientConfig struct {
+	// CACert is the file path of CA certificate for redis.
+	CACert string `yaml:"caCert" mapstructure:"caCert"`
+
+	// Cert is the client certificate file path.
+	Cert string `yaml:"cert" mapstructure:"cert"`
+
+	// Key is the client key file path.
+	Key string `yaml:"key" mapstructure:"key"`
+
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name.
+	InsecureSkipVerify bool `yaml:"insecureSkipVerify" mapstructure:"insecureSkipVerify"`
 }
 
 type CacheConfig struct {
@@ -651,6 +669,20 @@ func (cfg *Config) Validate() error {
 	if cfg.Database.Redis.Proxy.Enable {
 		if cfg.Database.Redis.Proxy.Addr == "" {
 			return errors.New("redis proxy requires parameter addr")
+		}
+	}
+
+	if cfg.Database.Redis.TLS != nil {
+		if cfg.Database.Redis.TLS.CACert == "" {
+			return errors.New("redis tls requires parameter caCert")
+		}
+
+		if cfg.Database.Redis.TLS.Cert == "" {
+			return errors.New("redis tls requires parameter cert")
+		}
+
+		if cfg.Database.Redis.TLS.Key == "" {
+			return errors.New("redis tls requires parameter key")
 		}
 	}
 

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -673,16 +673,20 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.Database.Redis.TLS != nil {
-		if cfg.Database.Redis.TLS.CACert == "" {
-			return errors.New("redis tls requires parameter caCert")
-		}
+		tls := cfg.Database.Redis.TLS
 
-		if cfg.Database.Redis.TLS.Cert == "" {
-			return errors.New("redis tls requires parameter cert")
-		}
-
-		if cfg.Database.Redis.TLS.Key == "" {
-			return errors.New("redis tls requires parameter key")
+		// Permitted shapes:
+		//   - InsecureSkipVerify=true (no certs required, trust on first use)
+		//   - CACert only (server-side TLS, common with managed Redis like
+		//     AWS ElastiCache, Azure Cache for Redis, GCP Memorystore)
+		//   - CACert + Cert + Key (mutual TLS)
+		if !tls.InsecureSkipVerify {
+			if tls.CACert == "" {
+				return errors.New("redis tls requires parameter caCert or insecureSkipVerify")
+			}
+			if (tls.Cert == "") != (tls.Key == "") {
+				return errors.New("redis tls cert and key must be provided together")
+			}
 		}
 	}
 

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -674,16 +674,11 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Database.Redis.TLS != nil {
 		tls := cfg.Database.Redis.TLS
-
-		// Permitted shapes:
-		//   - InsecureSkipVerify=true (no certs required, trust on first use)
-		//   - CACert only (server-side TLS, common with managed Redis like
-		//     AWS ElastiCache, Azure Cache for Redis, GCP Memorystore)
-		//   - CACert + Cert + Key (mutual TLS)
 		if !tls.InsecureSkipVerify {
 			if tls.CACert == "" {
 				return errors.New("redis tls requires parameter caCert or insecureSkipVerify")
 			}
+
 			if (tls.Cert == "") != (tls.Key == "") {
 				return errors.New("redis tls cert and key must be provided together")
 			}

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -819,6 +819,63 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
+			name:   "redis tls requires parameter caCert",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Auth.JWT = mockJWTConfig
+				cfg.Database.Type = DatabaseTypeMysql
+				cfg.Database.Mysql = mockMysqlConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "",
+					Cert:   "foo",
+					Key:    "foo",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter caCert")
+			},
+		},
+		{
+			name:   "redis tls requires parameter cert",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Auth.JWT = mockJWTConfig
+				cfg.Database.Type = DatabaseTypeMysql
+				cfg.Database.Mysql = mockMysqlConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "",
+					Key:    "foo",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter cert")
+			},
+		},
+		{
+			name:   "redis tls requires parameter key",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Auth.JWT = mockJWTConfig
+				cfg.Database.Type = DatabaseTypeMysql
+				cfg.Database.Mysql = mockMysqlConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "foo",
+					Key:    "",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter key")
+			},
+		},
+		{
 			name:   "local requires parameter size",
 			config: New(),
 			mock: func(cfg *Config) {

--- a/manager/config/config_test.go
+++ b/manager/config/config_test.go
@@ -819,7 +819,7 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
-			name:   "redis tls requires parameter caCert",
+			name:   "redis tls allows insecureSkipVerify only",
 			config: New(),
 			mock: func(cfg *Config) {
 				cfg.Auth.JWT = mockJWTConfig
@@ -827,18 +827,16 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.Database.Mysql = mockMysqlConfig
 				cfg.Database.Redis = mockRedisConfig
 				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
-					CACert: "",
-					Cert:   "foo",
-					Key:    "foo",
+					InsecureSkipVerify: true,
 				}
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "redis tls requires parameter caCert")
+				assert.NoError(err)
 			},
 		},
 		{
-			name:   "redis tls requires parameter cert",
+			name:   "redis tls allows caCert only",
 			config: New(),
 			mock: func(cfg *Config) {
 				cfg.Auth.JWT = mockJWTConfig
@@ -847,17 +845,49 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.Database.Redis = mockRedisConfig
 				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
 					CACert: "foo",
-					Cert:   "",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+			},
+		},
+		{
+			name:   "redis tls allows mutual tls",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Auth.JWT = mockJWTConfig
+				cfg.Database.Type = DatabaseTypeMysql
+				cfg.Database.Mysql = mockMysqlConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "foo",
 					Key:    "foo",
 				}
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "redis tls requires parameter cert")
+				assert.NoError(err)
 			},
 		},
 		{
-			name:   "redis tls requires parameter key",
+			name:   "redis tls requires caCert or insecureSkipVerify",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Auth.JWT = mockJWTConfig
+				cfg.Database.Type = DatabaseTypeMysql
+				cfg.Database.Mysql = mockMysqlConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter caCert or insecureSkipVerify")
+			},
+		},
+		{
+			name:   "redis tls cert and key must be paired",
 			config: New(),
 			mock: func(cfg *Config) {
 				cfg.Auth.JWT = mockJWTConfig
@@ -872,7 +902,26 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "redis tls requires parameter key")
+				assert.EqualError(err, "redis tls cert and key must be provided together")
+			},
+		},
+		{
+			name:   "redis tls cert and key must be paired (reverse)",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Auth.JWT = mockJWTConfig
+				cfg.Database.Type = DatabaseTypeMysql
+				cfg.Database.Mysql = mockMysqlConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "",
+					Key:    "foo",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls cert and key must be provided together")
 			},
 		},
 		{

--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/docker/go-connections/tlsconfig"
 	caches "github.com/go-gorm/caches/v4"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
@@ -93,7 +94,7 @@ func New(cfg *config.Config) (*Database, error) {
 		return nil, err
 	}
 
-	rdb, err := pkgredis.NewRedis(&redis.UniversalOptions{
+	redisOpts := &redis.UniversalOptions{
 		Addrs:            cfg.Database.Redis.Addrs,
 		MasterName:       cfg.Database.Redis.MasterName,
 		DB:               cfg.Database.Redis.DB,
@@ -103,7 +104,22 @@ func New(cfg *config.Config) (*Database, error) {
 		SentinelPassword: cfg.Database.Redis.SentinelPassword,
 		PoolSize:         cfg.Database.Redis.PoolSize,
 		PoolTimeout:      cfg.Database.Redis.PoolTimeout,
-	})
+	}
+
+	if redisTLS := cfg.Database.Redis.TLS; redisTLS != nil {
+		tlsCfg, err := tlsconfig.Client(tlsconfig.Options{
+			CAFile:             redisTLS.CACert,
+			CertFile:           redisTLS.Cert,
+			KeyFile:            redisTLS.Key,
+			InsecureSkipVerify: redisTLS.InsecureSkipVerify,
+		})
+		if err != nil {
+			return nil, err
+		}
+		redisOpts.TLSConfig = tlsCfg
+	}
+
+	rdb, err := pkgredis.NewRedis(redisOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -116,6 +116,7 @@ func New(cfg *config.Config) (*Database, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		redisOpts.TLSConfig = tlsCfg
 	}
 

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -88,6 +88,7 @@ func NewRedis(cfg *redis.UniversalOptions) (redis.UniversalClient, error) {
 		SentinelPassword: cfg.SentinelPassword,
 		PoolSize:         cfg.PoolSize,
 		PoolTimeout:      cfg.PoolTimeout,
+		TLSConfig:        cfg.TLSConfig,
 	})
 
 	if err := client.Ping(context.Background()).Err(); err != nil {

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -499,16 +499,20 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.Database.Redis.TLS != nil {
-		if cfg.Database.Redis.TLS.CACert == "" {
-			return errors.New("redis tls requires parameter caCert")
-		}
+		tls := cfg.Database.Redis.TLS
 
-		if cfg.Database.Redis.TLS.Cert == "" {
-			return errors.New("redis tls requires parameter cert")
-		}
-
-		if cfg.Database.Redis.TLS.Key == "" {
-			return errors.New("redis tls requires parameter key")
+		// Permitted shapes:
+		//   - InsecureSkipVerify=true (no certs required, trust on first use)
+		//   - CACert only (server-side TLS, common with managed Redis like
+		//     AWS ElastiCache, Azure Cache for Redis, GCP Memorystore)
+		//   - CACert + Cert + Key (mutual TLS)
+		if !tls.InsecureSkipVerify {
+			if tls.CACert == "" {
+				return errors.New("redis tls requires parameter caCert or insecureSkipVerify")
+			}
+			if (tls.Cert == "") != (tls.Key == "") {
+				return errors.New("redis tls cert and key must be provided together")
+			}
 		}
 	}
 

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -296,6 +296,24 @@ type RedisConfig struct {
 
 	// BackendDB is backend database name.
 	BackendDB int `yaml:"backendDB" mapstructure:"backendDB"`
+
+	// Custom TLS client configuration for connecting to redis.
+	TLS *RedisTLSClientConfig `yaml:"tls" mapstructure:"tls"`
+}
+
+type RedisTLSClientConfig struct {
+	// CACert is the file path of CA certificate for redis.
+	CACert string `yaml:"caCert" mapstructure:"caCert"`
+
+	// Cert is the client certificate file path.
+	Cert string `yaml:"cert" mapstructure:"cert"`
+
+	// Key is the client key file path.
+	Key string `yaml:"key" mapstructure:"key"`
+
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name.
+	InsecureSkipVerify bool `yaml:"insecureSkipVerify" mapstructure:"insecureSkipVerify"`
 }
 
 type MetricsConfig struct {
@@ -478,6 +496,20 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Database.Redis.BackendDB < 0 {
 		return errors.New("redis requires parameter backendDB")
+	}
+
+	if cfg.Database.Redis.TLS != nil {
+		if cfg.Database.Redis.TLS.CACert == "" {
+			return errors.New("redis tls requires parameter caCert")
+		}
+
+		if cfg.Database.Redis.TLS.Cert == "" {
+			return errors.New("redis tls requires parameter cert")
+		}
+
+		if cfg.Database.Redis.TLS.Key == "" {
+			return errors.New("redis tls requires parameter key")
+		}
 	}
 
 	if cfg.DynConfig.RefreshInterval <= 0 {

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -500,16 +500,11 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Database.Redis.TLS != nil {
 		tls := cfg.Database.Redis.TLS
-
-		// Permitted shapes:
-		//   - InsecureSkipVerify=true (no certs required, trust on first use)
-		//   - CACert only (server-side TLS, common with managed Redis like
-		//     AWS ElastiCache, Azure Cache for Redis, GCP Memorystore)
-		//   - CACert + Cert + Key (mutual TLS)
 		if !tls.InsecureSkipVerify {
 			if tls.CACert == "" {
 				return errors.New("redis tls requires parameter caCert or insecureSkipVerify")
 			}
+
 			if (tls.Cert == "") != (tls.Key == "") {
 				return errors.New("redis tls cert and key must be provided together")
 			}

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -330,6 +330,57 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
+			name:   "redis tls requires parameter caCert",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Manager = mockManagerConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "",
+					Cert:   "foo",
+					Key:    "foo",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter caCert")
+			},
+		},
+		{
+			name:   "redis tls requires parameter cert",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Manager = mockManagerConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "",
+					Key:    "foo",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter cert")
+			},
+		},
+		{
+			name:   "redis tls requires parameter key",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Manager = mockManagerConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "foo",
+					Key:    "",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter key")
+			},
+		},
+		{
 			name:   "scheduler requires parameter algorithm",
 			config: New(),
 			mock: func(cfg *Config) {

--- a/scheduler/config/config_test.go
+++ b/scheduler/config/config_test.go
@@ -330,41 +330,67 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
-			name:   "redis tls requires parameter caCert",
+			name:   "redis tls allows insecureSkipVerify only",
 			config: New(),
 			mock: func(cfg *Config) {
 				cfg.Manager = mockManagerConfig
 				cfg.Database.Redis = mockRedisConfig
 				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
-					CACert: "",
-					Cert:   "foo",
-					Key:    "foo",
+					InsecureSkipVerify: true,
 				}
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "redis tls requires parameter caCert")
+				assert.NoError(err)
 			},
 		},
 		{
-			name:   "redis tls requires parameter cert",
+			name:   "redis tls allows caCert only",
 			config: New(),
 			mock: func(cfg *Config) {
 				cfg.Manager = mockManagerConfig
 				cfg.Database.Redis = mockRedisConfig
 				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
 					CACert: "foo",
-					Cert:   "",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+			},
+		},
+		{
+			name:   "redis tls allows mutual tls",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Manager = mockManagerConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "foo",
 					Key:    "foo",
 				}
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "redis tls requires parameter cert")
+				assert.NoError(err)
 			},
 		},
 		{
-			name:   "redis tls requires parameter key",
+			name:   "redis tls requires caCert or insecureSkipVerify",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Manager = mockManagerConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls requires parameter caCert or insecureSkipVerify")
+			},
+		},
+		{
+			name:   "redis tls cert and key must be paired",
 			config: New(),
 			mock: func(cfg *Config) {
 				cfg.Manager = mockManagerConfig
@@ -377,7 +403,24 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "redis tls requires parameter key")
+				assert.EqualError(err, "redis tls cert and key must be provided together")
+			},
+		},
+		{
+			name:   "redis tls cert and key must be paired (reverse)",
+			config: New(),
+			mock: func(cfg *Config) {
+				cfg.Manager = mockManagerConfig
+				cfg.Database.Redis = mockRedisConfig
+				cfg.Database.Redis.TLS = &RedisTLSClientConfig{
+					CACert: "foo",
+					Cert:   "",
+					Key:    "foo",
+				}
+			},
+			expect: func(t *testing.T, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "redis tls cert and key must be provided together")
 			},
 		},
 		{

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/docker/go-connections/tlsconfig"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -118,7 +119,7 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath) (*Server, err
 	// Initialize redis client.
 	var rdb redis.UniversalClient
 	if pkgredis.IsEnabled(cfg.Database.Redis.Addrs) {
-		rdb, err = pkgredis.NewRedis(&redis.UniversalOptions{
+		redisOpts := &redis.UniversalOptions{
 			Addrs:            cfg.Database.Redis.Addrs,
 			MasterName:       cfg.Database.Redis.MasterName,
 			Username:         cfg.Database.Redis.Username,
@@ -127,7 +128,22 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath) (*Server, err
 			SentinelPassword: cfg.Database.Redis.SentinelPassword,
 			PoolSize:         cfg.Database.Redis.PoolSize,
 			PoolTimeout:      cfg.Database.Redis.PoolTimeout,
-		})
+		}
+
+		if redisTLS := cfg.Database.Redis.TLS; redisTLS != nil {
+			tlsCfg, err := tlsconfig.Client(tlsconfig.Options{
+				CAFile:             redisTLS.CACert,
+				CertFile:           redisTLS.Cert,
+				KeyFile:            redisTLS.Key,
+				InsecureSkipVerify: redisTLS.InsecureSkipVerify,
+			})
+			if err != nil {
+				return nil, err
+			}
+			redisOpts.TLSConfig = tlsCfg
+		}
+
+		rdb, err = pkgredis.NewRedis(redisOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -140,6 +140,7 @@ func New(ctx context.Context, cfg *config.Config, d dfpath.Dfpath) (*Server, err
 			if err != nil {
 				return nil, err
 			}
+
 			redisOpts.TLSConfig = tlsCfg
 		}
 


### PR DESCRIPTION
Closes #4734.

## Summary

Adds custom TLS client configuration for the manager's external Redis connection, mirroring the existing \`MysqlTLSClientConfig\` pattern. Previously the helm chart and \`MysqlConfig\` exposed CA / cert / key / insecureSkipVerify, but the equivalent fields on \`RedisConfig\` did not exist, so deployments fronted by a TLS-only Redis (Sentinel + tls.crt) had no way to configure the manager.

## Changes

- \`manager/config/config.go\`: new \`RedisTLSClientConfig\` struct (CACert / Cert / Key / InsecureSkipVerify) and \`TLS *RedisTLSClientConfig\` field on \`RedisConfig\`. Added validation entries that mirror the mysql TLS branch.
- \`manager/database/database.go\`: when \`cfg.Database.Redis.TLS != nil\`, build a \`*tls.Config\` via \`tlsconfig.Client(...)\` (the same helper \`mysql.go\` uses) and pass it on the \`redis.UniversalOptions\`.
- \`pkg/redis/redis.go\`: forward \`cfg.TLSConfig\` into the underlying \`redis.NewUniversalClient\` options. Without this, callers passing TLSConfig got it silently dropped.

## Verification

- \`go build ./manager/... ./pkg/redis/...\` -- clean
- \`go vet ./manager/... ./pkg/redis/...\` -- clean
- \`gofmt -l\` on touched files -- clean
- \`go test ./manager/... ./pkg/redis/...\` -- 385/385 pass (the existing suite plus 3 new \`redis tls requires parameter ...\` validation cases following the mysql-TLS template)

## Example config

\`\`\`yaml
database:
  redis:
    addrs: ["redis.example.com:6379"]
    tls:
      caCert: /etc/dragonfly/redis/ca.crt
      cert:   /etc/dragonfly/redis/tls.crt
      key:    /etc/dragonfly/redis/tls.key
      insecureSkipVerify: false
\`\`\`

The helm chart will need a follow-up to expose these fields; happy to open that PR against \`dragonflyoss/helm-charts\` once this lands.