### PR TITLE
fix: Upgrading grpc_health_probe to 0.4.48 to patch CVE-2025-68121

### DIFF
--- a/build/images/manager/Dockerfile
+++ b/build/images/manager/Dockerfile
@@ -30,7 +30,7 @@ RUN make build-manager-server && make install-manager
 
 FROM ${BASE_IMAGE} AS health
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.24
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.48
 
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \

--- a/build/images/scheduler/Dockerfile
+++ b/build/images/scheduler/Dockerfile
@@ -16,7 +16,7 @@ RUN make build-scheduler && make install-scheduler
 
 FROM ${BASE_IMAGE} AS health
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.24
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.48
 
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \


### PR DESCRIPTION
This PR upgrades grpc_health_probe to patch CVE-2025-68121

## Description

Currently, the latest Dragonfly Manager container images, when scanned for vulns (e.g. using Trivy) will show as containing a number of vulnerabilities including CVE-2025-68121, specifically in grpc_health_probe .

## Related Issue

Fixes #4744 

## Motivation and Context

While the exploitability of the vulns in question is somewhat dubious, it creates a lot of "noise" / toil for security teams to mark that as a "false positive" / "non-exploitable vuln" and upgrading to a non-vulnerable version seems worthwhile.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
