### PR TITLE
Fix Postgres SERIAL after seeding default clusters (#4752)

### DIFF
--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -157,9 +157,6 @@ func seed(db *gorm.DB) error {
 
 	if schedulerClusterCount <= 0 {
 		if err := db.Create(&models.SchedulerCluster{
-			BaseModel: models.BaseModel{
-				ID: uint(1),
-			},
 			Name: DefaultClusterName,
 			Config: map[string]any{
 				"candidate_parent_limit": schedulerconfig.DefaultSchedulerCandidateParentLimit,
@@ -185,9 +182,6 @@ func seed(db *gorm.DB) error {
 
 	if seedPeerClusterCount <= 0 {
 		if err := db.Create(&models.SeedPeerCluster{
-			BaseModel: models.BaseModel{
-				ID: uint(1),
-			},
 			Name: DefaultClusterName,
 			Config: map[string]any{
 				"load_limit": schedulerconfig.DefaultSeedPeerConcurrentUploadLimit,

--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -156,7 +156,10 @@ func seed(db *gorm.DB) error {
 	}
 
 	if schedulerClusterCount <= 0 {
-		if err := db.Create(&models.SchedulerCluster{
+		schedulerCluster := models.SchedulerCluster{
+			BaseModel: models.BaseModel{
+				ID: uint(1),
+			},
 			Name: DefaultClusterName,
 			Config: map[string]any{
 				"candidate_parent_limit": schedulerconfig.DefaultSchedulerCandidateParentLimit,
@@ -169,7 +172,13 @@ func seed(db *gorm.DB) error {
 			SeedClientConfig: map[string]any{},
 			Scopes:           map[string]any{},
 			IsDefault:        true,
-		}).Error; err != nil {
+		}
+
+		if err := db.Create(&schedulerCluster).Error; err != nil {
+			return err
+		}
+
+		if err := setPostgresSequence(db, "seed_peer_cluster", schedulerCluster.ID); err != nil {
 			return err
 		}
 	}
@@ -181,16 +190,25 @@ func seed(db *gorm.DB) error {
 	}
 
 	if seedPeerClusterCount <= 0 {
-		if err := db.Create(&models.SeedPeerCluster{
+		seedPeerCluster := models.SeedPeerCluster{
+			BaseModel: models.BaseModel{
+				ID: uint(1),
+			},
 			Name: DefaultClusterName,
 			Config: map[string]any{
 				"load_limit": schedulerconfig.DefaultSeedPeerConcurrentUploadLimit,
 			},
-		}).Error; err != nil {
+		}
+
+		if err := db.Create(&seedPeerCluster).Error; err != nil {
 			return err
 		}
 
-		seedPeerCluster := models.SeedPeerCluster{}
+		if err := setPostgresSequence(db, "seed_peer_cluster", seedPeerCluster.ID); err != nil {
+			return err
+		}
+
+		seedPeerCluster = models.SeedPeerCluster{}
 		if err := db.First(&seedPeerCluster).Error; err != nil {
 			return err
 		}

--- a/manager/database/postgres.go
+++ b/manager/database/postgres.go
@@ -75,3 +75,16 @@ func formatPostgresDSN(cfg *config.PostgresConfig) string {
 		cfg.Timezone,
 	)
 }
+
+// setPostgresSequence advances the serial sequence of the given table's id
+// column so the next auto-generated row starts after the explicitly inserted value.
+func setPostgresSequence(db *gorm.DB, table string, value uint) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+
+	return db.Exec(
+		"SELECT setval(pg_get_serial_sequence(?, 'id'), ?, true)",
+		table, value,
+	).Error
+}

--- a/manager/database/postgres.go
+++ b/manager/database/postgres.go
@@ -79,7 +79,7 @@ func formatPostgresDSN(cfg *config.PostgresConfig) string {
 // setPostgresSequence advances the serial sequence of the given table's id
 // column so the next auto-generated row starts after the explicitly inserted value.
 func setPostgresSequence(db *gorm.DB, table string, value uint) error {
-	if db.Dialector.Name() != "postgres" {
+	if db.Name() != "postgres" {
 		return nil
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove hardcoded `BaseModel{ID: 1}` from `seed()` when creating the default `SchedulerCluster` and `SeedPeerCluster` in `manager/database/database.go`. Let the database assign primary keys so inserts use the Postgres sequence (`nextval`). On an empty database the first rows still receive `id = 1`; subsequent API-created rows no longer collide with `id = 1`.

## Related Issue

Fixes #4752 — Default seeded scheduler cluster uses ID 1 without incrementing the SERIAL on Postgres.

## Motivation and Context

On PostgreSQL, explicitly inserting `id = 1` does not advance the `SERIAL`/`BIGSERIAL` sequence. The sequence can remain at `1`, so the next insert that relies on the default still tries `id = 1` and hits `23505` unique violation on the primary key. MySQL/MariaDB/PolarDB (MySQL-compatible) advance `AUTO_INCREMENT` on explicit inserts, so the bug is Postgres-specific. Omitting the primary key in seed aligns behavior and removes the spurious first-request failure.

## Screenshots (if appropriate)

N/A.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.