### PR TITLE
fix(preheat): add objectStorage and hdfs params for manager preheat job

### DIFF
--- a/manager/job/preheat.go
+++ b/manager/job/preheat.go
@@ -148,6 +148,8 @@ func (p *preheat) CreatePreheat(ctx context.Context, schedulers []models.Schedul
 			CertificateChain:    certificateChain,
 			InsecureSkipVerify:  p.insecureSkipVerify,
 			Timeout:             json.Timeout,
+			ObjectStorage:       json.ObjectStorage,
+			Hdfs:                json.Hdfs,
 		})
 
 	default:

--- a/manager/types/job.go
+++ b/manager/types/job.go
@@ -16,7 +16,11 @@
 
 package types
 
-import "time"
+import (
+	"time"
+
+	commonv2 "d7y.io/api/v2/pkg/apis/common/v2"
+)
 
 const (
 	// SingleSeedPeerScope represents the scope that only single seed peer will be preheated.
@@ -183,6 +187,12 @@ type PreheatArgs struct {
 
 	// Timeout is the timeout for preheating, default is 60 minutes.
 	Timeout time.Duration `json:"timeout" binding:"omitempty"`
+
+	// ObjectStorage is the object storage configuration for preheating files from object storage backends (e.g. s3, gcs, oss).
+	ObjectStorage *commonv2.ObjectStorage `json:"object_storage" binding:"omitempty"`
+
+	// Hdfs is the hdfs configuration for preheating files from hdfs.
+	Hdfs *commonv2.HDFS `json:"hdfs" binding:"omitempty"`
 }
 
 type CreateSyncPeersJobRequest struct {


### PR DESCRIPTION
## Description

Adds `object_storage` and `hdfs` fields to the manager `PreheatArgs` REST schema and forwards them into `internaljob.PreheatRequest`, so the scheduler can hand them to dfdaemon.

This is the manager-side counterpart to #4456, which plumbed the same two fields through `internal/job`, `scheduler/job`, and `scheduler/service` but did not update the manager REST surface.

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4449

## Motivation and Context

Without this change, posting a preheat job for an `s3://` (or any object-storage / `hdfs://`) URL fails at the seed with:

> rpc error: code = Internal desc = backend error: s3 need object_storage parameter

— because gin silently discards the unmodeled `object_storage` field on `PreheatArgs`, and `manager/job/preheat.go` constructs the downstream `PreheatRequest` without copying it through.

Repro before:

```json
POST /api/v1/jobs
{
  "type": "preheat",
  "args": {
    "type": "file",
    "urls": ["s3://my-bucket/my-object"],
    "object_storage": {
      "region": "us-west-2",
      "endpoint": "https://s3.us-west-2.amazonaws.com",
      "access_key_id": "...",
      "access_key_secret": "..."
    }
  },
  "scheduler_cluster_ids": [1]
}
```


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
