### PR TITLE
fix(job): fix data race on slice appends in preheatV2SingleSeedPeer

### DIFF
--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -327,6 +327,7 @@ func (j *job) preheatV1SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 
 // preheatV2SingleSeedPeer preheats job by v2 grpc protocol for single seed peer by multiple URLs.
 func (j *job) preheatV2SingleSeedPeer(ctx context.Context, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {
+	var mu sync.Mutex
 	preheatResp := &internaljob.PreheatResponse{}
 
 	eg, _ := errgroup.WithContext(ctx)
@@ -339,8 +340,10 @@ func (j *job) preheatV2SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 				return err
 			}
 
+			mu.Lock()
 			preheatResp.SuccessTasks = append(preheatResp.SuccessTasks, resp.SuccessTasks...)
 			preheatResp.FailureTasks = append(preheatResp.FailureTasks, resp.FailureTasks...)
+			mu.Unlock()
 			log.Infof("[preheat]: preheat succeeded for %s", url)
 			return nil
 		})


### PR DESCRIPTION
## Description

`preheatV2SingleSeedPeer` runs up to `ConcurrentTaskCount` goroutines (default: 8) concurrently, each appending into shared `preheatResp.SuccessTasks` / `FailureTasks` slices - no lock, data race.

```go
// concurrent, no synchronization:
preheatResp.SuccessTasks = append(preheatResp.SuccessTasks, resp.SuccessTasks...)
preheatResp.FailureTasks = append(preheatResp.FailureTasks, resp.FailureTasks...)
```

`PreheatAllSeedPeers` and `PreheatAllPeers` in the same file already handle this correctly with `sync.Map` - this function was just missed. Fix adds a `sync.Mutex` around the two appends, 3 lines, no behavior change.

## How to reproduce

Trigger a `SingleSeedPeer` preheat job for any multi-layer image with `concurrent_task_count >= 2` under the race detector (`go test -race`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.