### PR TITLE
ci(docker): remove freebsd/amd64 from build platforms

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,9 @@ jobs:
         module: ['manager', 'scheduler']
         include:
           - module: manager
-            platforms: linux/amd64,linux/arm64,freebsd/amd64
+            platforms: linux/amd64,linux/arm64
           - module: scheduler
-            platforms: linux/amd64,linux/arm64,freebsd/amd64
+            platforms: linux/amd64,linux/arm64
     timeout-minutes: 120
     steps:
       - name: Check out code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to the GitHub Actions workflow configuration by removing support for the FreeBSD/amd64 platform from the Docker build matrix for both the `manager` and `scheduler` modules.

- Removed `freebsd/amd64` from the list of supported platforms for the `manager` and `scheduler` Docker builds in `.github/workflows/docker.yml`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
