### PR TITLE
fix: correct typos in scheduler log messages and preheat response fields

### DIFF
--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -65,12 +65,12 @@ type Job interface {
 	// PreheatSinglePeer preheats job by single seed peer, scheduler will trigger seed peer to download task.
 	PreheatSingleSeedPeer(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error)
 
-	// PreheatAllSeedPeers preheats job by all peer seed peers, only suoported by v2 protocol. Scheduler will trigger all seed peers to download task.
+	// PreheatAllSeedPeers preheats job by all peer seed peers, only supported by v2 protocol. Scheduler will trigger all seed peers to download task.
 	// If all the seed peers download task failed, return error. If some of the seed peers download task failed, return success tasks and failure tasks.
 	// Notify the client that the preheat is successful.
 	PreheatAllSeedPeers(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error)
 
-	// PreheatAllPeers preheats job by all peers, only suoported by v2 protocol. Scheduler will trigger all peers to download task.
+	// PreheatAllPeers preheats job by all peers, only supported by v2 protocol. Scheduler will trigger all peers to download task.
 	// If all the peers download task failed, return error. If some of the peers download task failed, return success tasks and
 	// failure tasks. Notify the client that the preheat is successful.
 	PreheatAllPeers(context.Context, *internaljob.PreheatRequest, *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error)
@@ -305,7 +305,7 @@ func (j *job) preheatV1SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 	for {
 		piece, err := stream.Recv()
 		if err != nil {
-			log.Errorf("[preheat]: recive piece failed: %s", err.Error())
+			log.Errorf("[preheat]: receive piece failed: %s", err.Error())
 			return nil, err
 		}
 
@@ -319,7 +319,7 @@ func (j *job) preheatV1SingleSeedPeer(ctx context.Context, req *internaljob.Preh
 
 			log.Warnf("[preheat]: host %s not found", piece.HostId)
 			return &internaljob.PreheatResponse{
-				SuccessTasks: []*internaljob.PreheatSuccessTask{{URL: req.URL, Hostname: "unknow", IP: "unknow"}},
+				SuccessTasks: []*internaljob.PreheatSuccessTask{{URL: req.URL, Hostname: "unknown", IP: "unknown"}},
 			}, nil
 		}
 	}
@@ -413,11 +413,11 @@ func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req 
 
 				log.Warnf("[preheat]: host %s not found", hostID)
 				return &internaljob.PreheatResponse{
-					SuccessTasks: []*internaljob.PreheatSuccessTask{{URL: url, Hostname: "unknow", IP: "unknow"}},
+					SuccessTasks: []*internaljob.PreheatSuccessTask{{URL: url, Hostname: "unknown", IP: "unknown"}},
 				}, nil
 			}
 
-			log.Errorf("[preheat]: recive piece failed: %s", err.Error())
+			log.Errorf("[preheat]: receive piece failed: %s", err.Error())
 			return nil, err
 		}
 
@@ -425,7 +425,7 @@ func (j *job) preheatV2SingleSeedPeerByURL(ctx context.Context, url string, req 
 	}
 }
 
-// PreheatAllSeedPeers preheats job by all peer seed peers, only suoported by v2 protocol. Scheduler will trigger all seed peers to download task.
+// PreheatAllSeedPeers preheats job by all peer seed peers, only supported by v2 protocol. Scheduler will trigger all seed peers to download task.
 // If all the seed peers download task failed, return error. If some of the seed peers download task failed, return success tasks and failure tasks.
 // Notify the client that the preheat is successful.
 func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {
@@ -646,7 +646,7 @@ func (j *job) selectSeedPeers(ips []string, count *uint32, percentage *uint32, l
 	return seedPeers, nil
 }
 
-// PreheatAllPeers preheats job by all peers, only suoported by v2 protocol. Scheduler will trigger all peers to download task.
+// PreheatAllPeers preheats job by all peers, only supported by v2 protocol. Scheduler will trigger all peers to download task.
 // If all the peers download task failed, return error. If some of the peers download task failed, return success tasks and
 // failure tasks. Notify the client that the preheat is successful.
 func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatRequest, log *logger.SugaredLoggerOnWith) (*internaljob.PreheatResponse, error) {

--- a/scheduler/service/service_v1.go
+++ b/scheduler/service/service_v1.go
@@ -274,7 +274,7 @@ func (v *V1) ReportPieceResult(stream schedulerv1.Scheduler_ReportPieceResultSer
 			continue
 		}
 
-		peer.Log.Warnf("receive unknow piece: %#v %#v", piece, piece.PieceInfo)
+		peer.Log.Warnf("receive unknown piece: %#v %#v", piece, piece.PieceInfo)
 	}
 }
 

--- a/scheduler/service/service_v1_test.go
+++ b/scheduler/service/service_v1_test.go
@@ -3287,7 +3287,7 @@ func TestServiceV1_handlePieceFail(t *testing.T) {
 			},
 		},
 		{
-			name: "piece result code is unknow",
+			name: "piece result code is unknown",
 			config: &config.Config{
 				Scheduler: mockSchedulerConfig,
 				Metrics:   config.MetricsConfig{EnableHost: true},

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -275,7 +275,7 @@ func (v *V2) AnnouncePeer(stream schedulerv2.Scheduler_AnnouncePeerServer) error
 				log.Error(err)
 			}
 		default:
-			msg := fmt.Sprintf("receive unknow request: %#v", announcePeerRequest)
+			msg := fmt.Sprintf("receive unknown request: %#v", announcePeerRequest)
 			log.Error(msg)
 			return status.Error(codes.FailedPrecondition, msg)
 		}
@@ -2019,7 +2019,7 @@ func (v *V2) AnnouncePersistentPeer(stream schedulerv2.Scheduler_AnnouncePersist
 				log.Error(err)
 			}
 		default:
-			msg := fmt.Sprintf("receive unknow request: %#v", announcePersistentPeerRequest)
+			msg := fmt.Sprintf("receive unknown request: %#v", announcePersistentPeerRequest)
 			log.Error(msg)
 			return status.Error(codes.FailedPrecondition, msg)
 		}
@@ -3296,7 +3296,7 @@ func (v *V2) AnnouncePersistentCachePeer(stream schedulerv2.Scheduler_AnnouncePe
 				log.Error(err)
 			}
 		default:
-			msg := fmt.Sprintf("receive unknow request: %#v", announcePersistentCachePeerRequest)
+			msg := fmt.Sprintf("receive unknown request: %#v", announcePersistentCachePeerRequest)
 			log.Error(msg)
 			return status.Error(codes.FailedPrecondition, msg)
 		}


### PR DESCRIPTION
## Description

Few typos scattered across the scheduler that slipped in at some point. Most are just in log strings, but two of them end up in actual API response data - `PreheatSuccessTask.Hostname` and `PreheatSuccessTask.IP` get set to `"unknow"` instead of `"unknown"` when the host lookup misses, which is the part that actually matters.

Full list of what's fixed:

- `"unknow"` -> `"unknown"` in `PreheatSuccessTask` fields (job.go:322, 416) - these are returned over the API to callers
- `"recive"` -> `"receive"` in preheat error log (job.go:308, 420)
- `"suoported"` -> `"supported"` in interface comments (job.go:68, 73, 428, 649)
- `"receive unknow piece"` -> `"receive unknown piece"` (service_v1.go:277)
- `"receive unknow request"` -> `"receive unknown request"` (service_v2.go:278, 2022, 3299)
- test name updated to match (service_v1_test.go:3290)

## Related Issue

N/A - typo cleanup, no issue needed.

## Motivation and Context

The `Hostname: "unknow"` in the preheat success response is the one that bites - anyone parsing that field to display or log host info gets garbage. Rest are just noise in the logs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.