### PR TITLE
fix: correct misleading error messages in gc task validation and scheduler log

### DIFF
--- a/pkg/gc/gc_test.go
+++ b/pkg/gc/gc_test.go
@@ -54,7 +54,7 @@ func TestGC_Add(t *testing.T) {
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "Interval value is greater than 0")
+				assert.EqualError(err, "Interval value needs to be greater than 0")
 			},
 		},
 		{
@@ -66,7 +66,7 @@ func TestGC_Add(t *testing.T) {
 			},
 			expect: func(t *testing.T, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "Timeout value is greater than 0")
+				assert.EqualError(err, "Timeout value needs to be greater than 0")
 			},
 		},
 		{

--- a/pkg/gc/task.go
+++ b/pkg/gc/task.go
@@ -39,15 +39,15 @@ type Task struct {
 // Validate task params.
 func (t *Task) validate() error {
 	if t.ID == "" {
-		return errors.New("empty ID is not specified")
+		return errors.New("ID is not specified")
 	}
 
 	if t.Interval <= 0 {
-		return errors.New("Interval value is greater than 0")
+		return errors.New("Interval value needs to be greater than 0")
 	}
 
 	if t.Timeout <= 0 {
-		return errors.New("Timeout value is greater than 0")
+		return errors.New("Timeout value needs to be greater than 0")
 	}
 
 	if t.Timeout > t.Interval {
@@ -55,7 +55,7 @@ func (t *Task) validate() error {
 	}
 
 	if t.Runner == nil {
-		return errors.New("empty Runner is not specified")
+		return errors.New("Runner is not specified")
 	}
 
 	return nil

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -191,7 +191,7 @@ func (v *V2) AnnouncePeer(stream schedulerv2.Scheduler_AnnouncePeerServer) error
 			}
 		case *schedulerv2.AnnouncePeerRequest_ReschedulePeerRequest:
 			reschedulePeerRequest := announcePeerRequest.ReschedulePeerRequest
-			log.Infof("receive ReschedulePeerRequestescription: %s", reschedulePeerRequest.GetDescription())
+			log.Infof("receive ReschedulePeerRequest, description: %s", reschedulePeerRequest.GetDescription())
 			if err := v.handleReschedulePeerRequest(ctx, req.GetPeerId(), reschedulePeerRequest.GetCandidateParents()); err != nil {
 				log.Error(err)
 


### PR DESCRIPTION
## Description

Two message bugs that are lowkey confusing:

- `pkg/gc/task.go`: `validate()` returns `"Interval value is greater than 0"` when `Interval <= 0` - the message literally says the value is fine when its not. same thing for Timeout. Fixed to `"needs to be greater than 0"`, matching the style of the existing Timeout/Interval check on line 54.
- `pkg/gc/task.go`: `"empty ID is not specified"` and `"empty Runner is not specified"` have a weird double-negation thing going on; simplified to `"ID is not specified"` / `"Runner is not specified"`.
- `scheduler/service/service_v2.go:194`: log typo - `ReschedulePeerRequestescription` (`description` got fused into the type name). fixed to `"receive ReschedulePeerRequest, description: %s"`, matching the style of other request log lines.

## Related Issue

N/A - small correctness fix, no prior issue.

## Motivation and Context

Reproduce the confusing gc validation error:

```go
gc.Add(gc.Task{ID: "foo", Interval: 0, Timeout: time.Second, Runner: r})
// returns: "Interval value is greater than 0"
// but its not greater than 0...
```

For the log typo - `grep "ReschedulePeerRequest" scheduler.log` skips that one line since the string doesnt match exactly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.