### PR TITLE
fix(scheduler): skip exponential delay for super seed peers on register

### DIFF
--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1303,13 +1303,23 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 	metrics.RegisterPeerCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
 		peer.Host.Type.Name()).Inc()
 
-	// Provides a exponential delay to prevent thundering herd problems. When a host has many concurrent registration requests, later requests
-	// are delayed progressively to avoid overwhelming the source with simultaneous back-to-source tasks from a single host.
-	if err := pkgtime.ExponentialDelayWithJitter(ctx, uint(host.ConcurrentRegisterCount.Load()), baseDelayForRegisterPeer, maxDelayForRegisterPeer); err != nil {
-		// Collect RegisterPeerFailureCount metrics.
-		metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
-			peer.Host.Type.Name()).Inc()
-		return status.Error(codes.Internal, err.Error())
+	// Provides an exponential delay with jitter to prevent thundering herd problems. When a host has many
+	// concurrent registration requests, later requests are delayed progressively to avoid overwhelming the
+	// source with simultaneous back-to-source tasks from a single host.
+	//
+	// Note that the delay is skipped for seed peers for the following reasons:
+	//  1. Seed peers serve latency-sensitive workloads such as nydus, which issue large numbers of small
+	//     IO requests. Applying a backoff delay would significantly increase the latency of these requests.
+	//  2. The number of seed peers in a cluster is controlled and limited, and the scheduler can control
+	//     the concurrency of back-to-source tasks for seed peers. Therefore, there is no risk of a
+	//     thundering herd against the source, and the delay is unnecessary.
+	if peer.Host.Type != types.HostTypeSuperSeed {
+		if err := pkgtime.ExponentialDelayWithJitter(ctx, uint(host.ConcurrentRegisterCount.Load()), baseDelayForRegisterPeer, maxDelayForRegisterPeer); err != nil {
+			// Collect RegisterPeerFailureCount metrics.
+			metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
+				peer.Host.Type.Name()).Inc()
+			return status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	blocklist := set.NewSafeSet[string]()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the logic for handling peer registration delays in the `handleRegisterPeerRequest` function to better address the thundering herd problem, particularly by exempting seed peers from the exponential backoff delay. The main change ensures that seed peers, which handle latency-sensitive workloads and are limited in number, do not experience unnecessary registration delays.

Improvements to peer registration delay logic:

* Updated the exponential delay mechanism to skip the delay for seed peers (`HostTypeSuperSeed`), with detailed comments explaining the reasoning—seed peers handle latency-sensitive workloads and are few in number, so delaying their registration is unnecessary and could increase latency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
