### PR TITLE
fix(scheduler): honor peer concurrency during preheat jobs

### DIFF
--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -443,6 +443,8 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 	eg.SetLimit(int(req.ConcurrentTaskCount))
 	for _, url := range req.URLs {
 		eg.Go(func() error {
+			peg, _ := errgroup.WithContext(ctx)
+			peg.SetLimit(int(req.ConcurrentPeerCount))
 			for _, seedPeer := range seedPeers {
 				var (
 					hostname = seedPeer.Hostname
@@ -451,8 +453,6 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 				)
 
 				addr := net.JoinHostPort(ip, strconv.Itoa(int(port)))
-				peg, _ := errgroup.WithContext(ctx)
-				peg.SetLimit(int(req.ConcurrentPeerCount))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
 					taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
@@ -533,11 +533,11 @@ func (j *job) PreheatAllSeedPeers(ctx context.Context, req *internaljob.PreheatR
 						}
 					}
 				})
+			}
 
-				// Wait for all seed peers to download single task and print the errors.
-				if err := peg.Wait(); err != nil {
-					log.Errorf("[preheat]: preheat failed: %s", err.Error())
-				}
+			// Wait for all seed peers to download single task and print the errors.
+			if err := peg.Wait(); err != nil {
+				log.Errorf("[preheat]: preheat failed: %s", err.Error())
 			}
 
 			return nil
@@ -664,6 +664,8 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 	eg.SetLimit(int(req.ConcurrentTaskCount))
 	for _, url := range req.URLs {
 		eg.Go(func() error {
+			peg, _ := errgroup.WithContext(ctx)
+			peg.SetLimit(int(req.ConcurrentPeerCount))
 			for _, peer := range peers {
 				var (
 					hostname = peer.Hostname
@@ -672,8 +674,6 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 				)
 
 				addr := net.JoinHostPort(ip, strconv.Itoa(int(port)))
-				peg, _ := errgroup.WithContext(ctx)
-				peg.SetLimit(int(req.ConcurrentPeerCount))
 				peg.Go(func() error {
 					filteredQueryParams := idgen.ParseFilteredQueryParams(req.FilteredQueryParams)
 					taskID := idgen.TaskIDV2ByURLBased(url, req.PieceLength, req.Tag, req.Application, filteredQueryParams, "")
@@ -754,11 +754,11 @@ func (j *job) PreheatAllPeers(ctx context.Context, req *internaljob.PreheatReque
 						}
 					}
 				})
+			}
 
-				// Wait for all peers to download single task and print the errors.
-				if err := peg.Wait(); err != nil {
-					log.Errorf("[preheat]: preheat failed: %s", err.Error())
-				}
+			// Wait for all peers to download single task and print the errors.
+			if err := peg.Wait(); err != nil {
+				log.Errorf("[preheat]: preheat failed: %s", err.Error())
 			}
 
 			return nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the concurrency handling in the `PreheatAllSeedPeers` and `PreheatAllPeers` functions within `scheduler/job/job.go`. The main improvement is moving the creation and configuration of the inner error group (`peg`) outside the loop over seed peers and peers, which ensures that concurrent peer downloads for a single task are properly managed and awaited together.

Concurrency management improvements:

* Moved the initialization of the inner error group (`peg`) and its concurrency limit (`SetLimit`) outside the loop over seed peers/peers in both `PreheatAllSeedPeers` and `PreheatAllPeers`. This ensures all peer tasks for a single URL are handled by the same error group, improving synchronization and error collection. [[1]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cR446-R447) [[2]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL454-L455) [[3]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cR667-R668) [[4]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cL675-L676)
* Adjusted the placement of the `peg.Wait()` call to correctly wait for all peer download goroutines to finish before proceeding, and removed redundant closing braces. [[1]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cR536-L541) [[2]](diffhunk://#diff-d9c3b15511ab73786700fed2b761b4e8ef1b73b60183deaab4f8aa5a8130cf8cR757-L762)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
