### PR TITLE
fix(manager): sync postgres sequences after seeding default clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	d7y.io/api/v2 v2.2.30
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9s
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -500,6 +502,7 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=

--- a/manager/database/database.go
+++ b/manager/database/database.go
@@ -156,7 +156,7 @@ func seed(db *gorm.DB) error {
 	}
 
 	if schedulerClusterCount <= 0 {
-		if err := db.Create(&models.SchedulerCluster{
+		schedulerCluster := models.SchedulerCluster{
 			BaseModel: models.BaseModel{
 				ID: uint(1),
 			},
@@ -172,7 +172,13 @@ func seed(db *gorm.DB) error {
 			SeedClientConfig: map[string]any{},
 			Scopes:           map[string]any{},
 			IsDefault:        true,
-		}).Error; err != nil {
+		}
+
+		if err := db.Create(&schedulerCluster).Error; err != nil {
+			return err
+		}
+
+		if err := syncSequenceAfterExplicitInsert(db, "scheduler_cluster", schedulerCluster.ID); err != nil {
 			return err
 		}
 	}
@@ -184,7 +190,7 @@ func seed(db *gorm.DB) error {
 	}
 
 	if seedPeerClusterCount <= 0 {
-		if err := db.Create(&models.SeedPeerCluster{
+		seedPeerCluster := models.SeedPeerCluster{
 			BaseModel: models.BaseModel{
 				ID: uint(1),
 			},
@@ -192,11 +198,17 @@ func seed(db *gorm.DB) error {
 			Config: map[string]any{
 				"load_limit": schedulerconfig.DefaultSeedPeerConcurrentUploadLimit,
 			},
-		}).Error; err != nil {
+		}
+
+		if err := db.Create(&seedPeerCluster).Error; err != nil {
 			return err
 		}
 
-		seedPeerCluster := models.SeedPeerCluster{}
+		if err := syncSequenceAfterExplicitInsert(db, "seed_peer_cluster", seedPeerCluster.ID); err != nil {
+			return err
+		}
+
+		seedPeerCluster = models.SeedPeerCluster{}
 		if err := db.First(&seedPeerCluster).Error; err != nil {
 			return err
 		}

--- a/manager/database/postgres.go
+++ b/manager/database/postgres.go
@@ -75,3 +75,15 @@ func formatPostgresDSN(cfg *config.PostgresConfig) string {
 		cfg.Timezone,
 	)
 }
+
+func syncSequenceAfterExplicitInsert(db *gorm.DB, table string, id uint) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+
+	return db.Exec(
+		"SELECT setval(pg_get_serial_sequence(?, 'id'), ?, true)",
+		table,
+		id,
+	).Error
+}

--- a/manager/database/postgres_test.go
+++ b/manager/database/postgres_test.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestSyncSequenceAfterExplicitInsertPostgres(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta("SELECT setval(pg_get_serial_sequence($1, 'id'), $2, true)")).
+		WithArgs("scheduler_cluster", uint(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		Conn:                 sqlDB,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{
+		DisableAutomaticPing: true,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, syncSequenceAfterExplicitInsert(db, "scheduler_cluster", 1))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSyncSequenceAfterExplicitInsertNonPostgres(t *testing.T) {
+	sqlDB, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{
+		DisableAutomaticPing: true,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, syncSequenceAfterExplicitInsert(db, "scheduler_cluster", 1))
+}


### PR DESCRIPTION
## Description

Bumps the Postgres sequence right after seeding the default scheduler and seed peer clusters with `id = 1`.
Adds a small database test too.

## Related Issue

Fixes #4752

## Motivation and Context

Fresh Postgres installs can trip on the first create after bootstrap. The seed rows use explicit `id = 1`, but the sequence stays behind, so the next insert can hit `SQLSTATE 23505`.
This keeps the default ids as-is and nudges the sequence forward. MySQL style backends stay the same.

Repro:
1. Start manager with an empty Postgres db and `migrate: true`.
2. Create a scheduler cluster or seed peer cluster.
3. Before this patch it blows up with a duplicate key on the primary key.
4. Retry works, which is kinda the tell.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
