### PR TITLE
reject negative suffix-length in ParseRange

### DIFF
--- a/pkg/net/http/range.go
+++ b/pkg/net/http/range.go
@@ -88,9 +88,15 @@ func ParseRange(s string, size int64) ([]Range, error) {
 		var r Range
 		if start == "" {
 			// If no Serve is specified, end specifies the
-			// range Serve relative to the end of the file.
+			// range Serve relative to the end of the file, and the
+			// suffix-length must be a non-negative integer as per
+			// RFC 7233 Section 2.1.
+			if end == "" || end[0] == '-' {
+				return nil, errors.New("invalid range")
+			}
+
 			i, err := strconv.ParseInt(end, 10, 64)
-			if err != nil {
+			if i < 0 || err != nil {
 				return nil, errors.New("invalid range")
 			}
 

--- a/pkg/net/http/range_test.go
+++ b/pkg/net/http/range_test.go
@@ -17,6 +17,7 @@
 package http
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -157,6 +158,10 @@ func TestParseRange(t *testing.T) {
 		{"bytes=0-2,5-4", 10, nil},
 		{"bytes=2-5,4-3", 10, nil},
 		{"bytes=--5,4--3", 10, nil},
+		{"bytes=--5", 10, nil},
+		{"bytes=--1", 10, nil},
+		{"bytes=--5", math.MaxInt64, nil},
+		{"bytes=-", 10, nil},
 		{"bytes=A-", 10, nil},
 		{"bytes=A- ", 10, nil},
 		{"bytes=A-Z", 10, nil},


### PR DESCRIPTION
## Description

    ParseRange("bytes=--5", 10)                  = [{Start:15 Length:-5}], err=<nil>
    ParseRange("bytes=--5", math.MaxInt64)        = [{Start:-9223372036854775804 Length:-5}], err=<nil>

`ParseRange` (copied from go 1.15.2 `net/http` `parseRange`) doesn't validate the suffix-length form `bytes=-N`. A negative suffix like `bytes=--5` parses `end` to a negative int, so it returns a Range with negative `Length` and an out-of-range `Start` (`size - (-5)`); at `size=math.MaxInt64` the `Start` wraps past int64. The existing `bytes=--5,4--3` case only passes because the second segment trips a separate check, so the single-segment input slips through.

The scheduler parses the peer-supplied `UrlMeta.Range` with `size=math.MaxInt64` in `scheduler/service/service_v1.go` and passes the parsed range into the seed-peer back-to-source download, so a malformed value reaches the range request.

Reject an empty or negative suffix-length per RFC 7233 Section 2.1, matching the upstream `net/http` parser. `ParseOneRange`, `ParseURLMetaRange` and `MustParseRange` all delegate to `ParseRange`, so this covers them too.

## Related Issue

Found while reviewing the range header parser. No existing tracking issue.

## Motivation and Context

Aligns suffix-length handling with RFC 7233 and the upstream parser this code was copied from, so malformed `bytes=-N` ranges are rejected instead of producing a negative-length or overflowed range.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added tests to cover my changes.
