### PR TITLE
fix(scheduler): delete AnnouncePeer stream reference to prevent transport memory leak

### DIFF
--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -122,6 +122,23 @@ func (v *V2) AnnouncePeer(stream schedulerv2.Scheduler_AnnouncePeerServer) error
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 
+	// Track the registered peer so we can delete its gRPC stream reference
+	// when this handler exits on ANY path (success, error, EOF, context cancel).
+	// Without this, the peer retains a reference to the closed stream, which
+	// retains the underlying gRPC transport (bufio.Reader ~32KB, hpack decoder
+	// table, flate writer) until the peer itself is eventually GC'd, causing
+	// steady memory growth under load. Mirrors V1's ReportPieceResult which
+	// defers peer.DeleteReportPieceResultStream().
+	var registeredPeerID string
+	defer func() {
+		if registeredPeerID == "" {
+			return
+		}
+		if peer, loaded := v.resource.PeerManager().Load(registeredPeerID); loaded {
+			peer.DeleteAnnouncePeerStream()
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -146,6 +163,10 @@ func (v *V2) AnnouncePeer(stream schedulerv2.Scheduler_AnnouncePeerServer) error
 			registerPeerRequest := announcePeerRequest.RegisterPeerRequest
 			log.Infof("receive RegisterPeerRequest, url: %s, range: %#v, header: %#v, need back-to-source: %t",
 				registerPeerRequest.Download.GetUrl(), registerPeerRequest.Download.GetRange(), registerPeerRequest.Download.GetRequestHeader(), registerPeerRequest.Download.GetNeedBackToSource())
+			// Track peer ID before registration so the function-level defer
+			// cleans up the stream even if handleRegisterPeerRequest fails
+			// after handleResource has stored it.
+			registeredPeerID = req.GetPeerId()
 			if err := v.handleRegisterPeerRequest(ctx, stream, req.GetHostId(), req.GetTaskId(), req.GetPeerId(), registerPeerRequest); err != nil {
 				log.Error(err)
 

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -122,23 +122,6 @@ func (v *V2) AnnouncePeer(stream schedulerv2.Scheduler_AnnouncePeerServer) error
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 
-	// Track the registered peer so we can delete its gRPC stream reference
-	// when this handler exits on ANY path (success, error, EOF, context cancel).
-	// Without this, the peer retains a reference to the closed stream, which
-	// retains the underlying gRPC transport (bufio.Reader ~32KB, hpack decoder
-	// table, flate writer) until the peer itself is eventually GC'd, causing
-	// steady memory growth under load. Mirrors V1's ReportPieceResult which
-	// defers peer.DeleteReportPieceResultStream().
-	var registeredPeerID string
-	defer func() {
-		if registeredPeerID == "" {
-			return
-		}
-		if peer, loaded := v.resource.PeerManager().Load(registeredPeerID); loaded {
-			peer.DeleteAnnouncePeerStream()
-		}
-	}()
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -163,10 +146,14 @@ func (v *V2) AnnouncePeer(stream schedulerv2.Scheduler_AnnouncePeerServer) error
 			registerPeerRequest := announcePeerRequest.RegisterPeerRequest
 			log.Infof("receive RegisterPeerRequest, url: %s, range: %#v, header: %#v, need back-to-source: %t",
 				registerPeerRequest.Download.GetUrl(), registerPeerRequest.Download.GetRange(), registerPeerRequest.Download.GetRequestHeader(), registerPeerRequest.Download.GetNeedBackToSource())
-			// Track peer ID before registration so the function-level defer
-			// cleans up the stream even if handleRegisterPeerRequest fails
-			// after handleResource has stored it.
-			registeredPeerID = req.GetPeerId()
+
+			// Reclaim the resource of peer when the stream is closed.
+			defer func(peerID string) {
+				if peer, loaded := v.resource.PeerManager().Load(peerID); loaded {
+					peer.DeleteAnnouncePeerStream()
+				}
+			}(req.GetPeerId())
+
 			if err := v.handleRegisterPeerRequest(ctx, stream, req.GetHostId(), req.GetTaskId(), req.GetPeerId(), registerPeerRequest); err != nil {
 				log.Error(err)
 


### PR DESCRIPTION
## Problem

The scheduler component has a continuous memory leak. Heap profiling shows `bufio.NewReaderSize` growing from 279MB to 295MB (+16.5MB) between two captures, accounting for ~58% of total heap. The root cause is `NewServerTransport` cum growing to 320MB — each gRPC server transport allocates a ~32KB `bufio.Reader`, and they accumulate without being freed.

```
      flat  flat%   sum%        cum   cum%
  295.53MB 58.25% 58.25%   295.53MB 58.25%  bufio.NewReaderSize (inline)
   46.61MB  9.19% 67.43%    46.61MB  9.19%  github.com/looplab/fsm.NewFSM
      16MB  3.15% 70.59%       16MB  3.15%  golang.org/x/net/http2/hpack.(*headerFieldTable).addEntry
   12.50MB  2.46% 73.05%   320.54MB 63.17%  google.golang.org/grpc/internal/transport.NewServerTransport
```

295MB ÷ 32KB ≈ **9,200 leaked stream references**.

## Root Cause

V2 `AnnouncePeer` stores the gRPC stream on the peer object via `peer.StoreAnnouncePeerStream()` (called through `WithAnnouncePeerStream` in `handleResource`), but **never calls `peer.DeleteAnnouncePeerStream()` when the handler exits**. The method exists (`peer.go:409`) but is only called in tests.

This creates a reference chain that prevents GC from reclaiming transport memory:

```
peer.AnnouncePeerStream (atomic.Value)
  └→ gRPC serverStream object
       └→ http2Server transport
            ├→ bufio.Reader (~32KB)     ← pprof: 295MB
            ├→ hpack decoder table      ← pprof: 16MB
            └→ flate.Writer (~30KB)     ← pprof: 7MB
```

Each completed peer retains ~40KB+ of transport memory until the PeerManager TTL GC eventually collects the peer. Under load, peer creation rate exceeds GC rate → memory grows continuously.

### Comparison with V1

V1's `ReportPieceResult` already handles this correctly:

```go
peer.StoreReportPieceResultStream(stream)
defer peer.DeleteReportPieceResultStream()  // ✅ cleanup
```

## Fix

Add a function-level `defer` in `AnnouncePeer` that tracks the registered peer ID and deletes the stream reference on **ALL exit paths** (success, error, EOF, context cancel):

```go
var registeredPeerID string
defer func() {
    if registeredPeerID == "" {
        return
    }
    if peer, loaded := v.resource.PeerManager().Load(registeredPeerID); loaded {
        peer.DeleteAnnouncePeerStream()
    }
}()
```

The `registeredPeerID` is set **before** `handleRegisterPeerRequest` so the defer fires even if registration fails after `handleResource` has already stored the stream (FSM event failures, scheduling failures, seed peer download failures, stream.Send failures, etc.).

## Safety Analysis

- **Scheduling goroutines**: Concurrent callers of `LoadAnnouncePeerStream()` in `scheduling.go` will get `loaded=false` after deletion, which is already handled at all call sites (`scheduling.go:128-130, 152-154, 207-214`). Since the stream is only deleted when `AnnouncePeer` returns (stream is already dead), this is correct behavior.
- **V1 `ReportPieceResult`**: Already has the equivalent `defer peer.DeleteReportPieceResultStream()` — no change needed.
- **`AnnouncePersistentPeer` / `AnnouncePersistentCachePeer`**: Not affected — they use database-backed persistent resources and do not store gRPC streams on peer objects.
- **`looplab/fsm.NewFSM` (46MB)**: Not a leak — proportional to active peer count, freed normally by GC.
- **Multiple `RegisterPeerRequest` in same stream**: Handled — single function-level defer, last peer ID wins.

## Verification

- [x] `go build ./scheduler/...` passes
- [x] `go test ./scheduler/service/...` passes
- [x] `go test ./scheduler/resource/standard/...` passes