### PR TITLE
chore(deps): upgrade retry-go to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3
-	github.com/avast/retry-go/v4 v4.7.0
+	github.com/avast/retry-go/v5 v5.0.0
 	github.com/bits-and-blooms/bitset v1.24.5
 	github.com/casbin/casbin/v2 v2.81.0
 	github.com/casbin/gorm-adapter/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/appleboy/gin-jwt/v2 v2.10.3 h1:KNcPC+XPRNpuoBh+j+rgs5bQxN+SwG/0tHbIqp
 github.com/appleboy/gin-jwt/v2 v2.10.3/go.mod h1:LDUaQ8mF2W6LyXIbd5wqlV2SFebuyYs4RDwqMNgpsp8=
 github.com/appleboy/gofight/v2 v2.1.2 h1:VOy3jow4vIK8BRQJoC/I9muxyYlJ2yb9ht2hZoS3rf4=
 github.com/appleboy/gofight/v2 v2.1.2/go.mod h1:frW+U1QZEdDgixycTj4CygQ48yLTUhplt43+Wczp3rw=
-github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
-github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
+github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
+github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/aws/aws-sdk-go v1.37.16/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=

--- a/manager/service/job.go
+++ b/manager/service/job.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	retry "github.com/avast/retry-go/v4"
+	retry "github.com/avast/retry-go/v5"
 	machineryv1tasks "github.com/dragonflyoss/machinery/v1/tasks"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
@@ -751,7 +751,13 @@ func (s *service) pollingJob(ctx context.Context, name string, id uint, groupUUI
 		job models.Job
 		log = logger.WithGroupAndJobID(groupUUID, fmt.Sprint(id))
 	)
-	if err := retry.Do(func() error {
+	if err := retry.New(
+		retry.Attempts(attempts),
+		retry.DelayType(retry.BackOffDelay),
+		retry.Delay(delay),
+		retry.MaxDelay(maxDelay),
+		retry.Context(ctx),
+	).Do(func() error {
 		groupJob, err := s.job.GetGroupJobState(name, groupUUID)
 		if err != nil {
 			err = fmt.Errorf("get group job state failed: %w", err)
@@ -790,13 +796,7 @@ func (s *service) pollingJob(ctx context.Context, name string, id uint, groupUUI
 			log.Info(msg)
 			return errors.New(msg)
 		}
-	},
-		retry.Attempts(attempts),
-		retry.DelayType(retry.BackOffDelay),
-		retry.Delay(delay),
-		retry.MaxDelay(maxDelay),
-		retry.Context(ctx),
-	); err != nil {
+	}); err != nil {
 		err = fmt.Errorf("polling group job failed: %w", err)
 		log.Error(err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrades the `github.com/avast/retry-go` dependency from `v4` to `v5`.

Because `v5` changes how options are passed (moving from variadic trailing arguments in `retry.Do` to a builder pattern starting with `retry.New`), this PR updates `pollingJob` in `manager/service/job.go`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
