### PR TITLE
fix(scheduler): treat missing seed peers in refresh as warning instead of error

### DIFF
--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -345,7 +345,8 @@ func (s *seedPeer) initSeedPeer(ctx context.Context, rg *http.Range, task *Task,
 func (s *seedPeer) refresh(ctx context.Context) error {
 	hosts := s.hostManager.LoadAllSeeds()
 	if len(hosts) == 0 {
-		return fmt.Errorf("no seed peer found in host manager")
+		logger.Warnf("no seed peer found in host manager")
+		return nil
 	}
 
 	healthyHosts := &sync.Map{}

--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -342,11 +342,11 @@ func (s *seedPeer) initSeedPeer(ctx context.Context, rg *http.Range, task *Task,
 	return peer, nil
 }
 
-func (s *seedPeer) refresh(ctx context.Context) error {
+func (s *seedPeer) refresh(ctx context.Context) {
 	hosts := s.hostManager.LoadAllSeeds()
 	if len(hosts) == 0 {
 		logger.Warnf("no seed peer found in host manager")
-		return nil
+		return
 	}
 
 	healthyHosts := &sync.Map{}
@@ -359,7 +359,6 @@ func (s *seedPeer) refresh(ctx context.Context) error {
 			healthyHosts.Store(addr, host)
 		}
 	}
-
 	s.hosts = healthyHosts
 
 	hashring := consistent.New()
@@ -369,7 +368,6 @@ func (s *seedPeer) refresh(ctx context.Context) error {
 	})
 
 	s.hashring = hashring
-	return nil
 }
 
 // Serve serves the seed peer service.
@@ -382,9 +380,7 @@ func (s *seedPeer) Serve() error {
 	for {
 		select {
 		case <-ticker.C:
-			if err := s.refresh(context.Background()); err != nil {
-				logger.Errorf("failed to refresh seed peers: %v", err)
-			}
+			s.refresh(context.Background())
 		case <-s.done:
 			return nil
 		}


### PR DESCRIPTION
## What this PR does

The seed peer `refresh` periodic task returned an error (logged at ERROR level) when no seed peers were registered in the host manager. An empty seed-peer set is a valid transient state (e.g. during startup or before any seed peer announces itself), so it should not be treated as an error.

## Changes

- `scheduler/resource/standard/seed_peer.go`: in `refresh`, log `no seed peer found in host manager` at WARN level and return `nil` instead of returning an error, so the caller no longer logs it as an error.