### PR TITLE
reject non-hex encoded value in digest.Parse

### DIFF
--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -123,9 +123,11 @@ func Parse(digest string) (*Digest, error) {
 func isHex(s string) bool {
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return false
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') {
+			continue
 		}
+
+		return false
 	}
 
 	return true

--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -121,13 +121,10 @@ func Parse(digest string) (*Digest, error) {
 
 // isHex reports whether s consists solely of hexadecimal characters.
 func isHex(s string) bool {
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') {
-			continue
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
 		}
-
-		return false
 	}
 
 	return true

--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -105,10 +105,30 @@ func Parse(digest string) (*Digest, error) {
 		return nil, errors.New("invalid algorithm")
 	}
 
+	// The supported algorithms all produce hex-encoded digests. The switch only
+	// checks the length, so reject any encoded value that is not valid
+	// hexadecimal, otherwise a malformed digest such as a 64 character non-hex
+	// string would be accepted as a sha256.
+	if !isHex(encoded) {
+		return nil, errors.New("invalid encoded")
+	}
+
 	return &Digest{
 		Algorithm: algorithm,
 		Encoded:   encoded,
 	}, nil
+}
+
+// isHex reports whether s consists solely of hexadecimal characters.
+func isHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // SHA256FromStrings computes the SHA256 checksum with multiple strings.

--- a/pkg/digest/digest_test.go
+++ b/pkg/digest/digest_test.go
@@ -101,6 +101,22 @@ func TestDigest_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:  "non-hex sha256 encoded",
+			value: "sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+		{
+			name:  "non-hex md5 encoded",
+			value: "md5:5d41402abc4b2a76b9719d911017c59g",
+			expect: func(t *testing.T, d *Digest, err error) {
+				assert := assert.New(t)
+				assert.Error(err)
+			},
+		},
+		{
 			name:  "invalid algorithm",
 			value: "foo:5d41402abc4b2a76b9719d911017c592",
 			expect: func(t *testing.T, d *Digest, err error) {


### PR DESCRIPTION
## Description

`Parse` validates only the length of the encoded portion, not that it is
hexadecimal, so a 64 character non-hex value is accepted as a sha256:

    Parse("sha256:" + strings.Repeat("z", 64)) -> &Digest{...}, nil

Adds a hex check after the length switch so malformed digests are rejected,
covering crc32/blake3/sha1/sha256/sha512/md5.

## Related Issue

None.

## Motivation and Context

The scheduler runs untrusted peer `UrlMeta.Digest` and `Piece.Digest` through
`digest.Parse` (scheduler/service/service_v1.go, service_v2.go) and hands the
parsed value to other peers as the content digest. Accepting a non-hex encoded
value lets a malformed digest pass structural validation. The check matches the
OCI/containerd digest format and the existing length checks.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
