### PR TITLE
fix(net): guard HeaderToMap against header keys with empty value slices

### DIFF
--- a/pkg/net/http/http.go
+++ b/pkg/net/http/http.go
@@ -33,7 +33,9 @@ const (
 func HeaderToMap(header http.Header) map[string]string {
 	m := make(map[string]string)
 	for k, v := range header {
-		m[k] = v[0]
+		if len(v) > 0 {
+			m[k] = v[0]
+		}
 	}
 	return m
 }

--- a/pkg/net/http/http_test.go
+++ b/pkg/net/http/http_test.go
@@ -66,6 +66,19 @@ func TestHeaderToMap(t *testing.T) {
 				})
 			},
 		},
+		{
+			name: "header has a key with an empty value slice",
+			header: http.Header{
+				"foo":   {"foo"},
+				"empty": {},
+			},
+			expect: func(t *testing.T, data any) {
+				assert := testifyassert.New(t)
+				assert.EqualValues(data, map[string]string{
+					"foo": "foo",
+				})
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Description

`HeaderToMap` converted an `http.Header` to a `map[string]string` by indexing
`v[0]` for every key. `http.Header` is `map[string][]string`, so a key with an
empty value slice (e.g. `h["X-Empty"] = []string{}`) makes `v[0]` panic with
`index out of range [0] with length 0`. Such empty entries are preserved by
`http.Header.Clone()`. This guards the index with `if len(v) > 0`, mirroring the
defensive style of the sibling `MapToHeader`, and skips valueless keys. A
table-driven test case for a key with an empty value slice is added.

## Related Issue

Fixes #4854

## Motivation and Context

`HeaderToMap` is an exported helper in a reusable package. Indexing `v[0]`
unconditionally panics on a valid `http.Header` whose key has an empty value
slice (legal per the `map[string][]string` shape and kept by `Clone()`). Dropping
those keys instead of crashing keeps the helper safe on any valid input.

The sole production caller currently builds headers via
`MapToHeader(map[string]string)` (`internal/job/image.go`), so every key has at
least one value and cannot trigger the panic today. This is a defensive
correctness fix, not a known live crash.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
