### PR TITLE
clamp preheat percentage to available peers in selectPeers

### DIFF
--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -633,6 +633,12 @@ func (j *job) selectSeedPeers(ips []string, count *uint32, percentage *uint32, l
 	if percentage != nil {
 		seedPeerCount := (len(seedPeers) * int(*percentage)) / 100
 
+		// Clamp to the number of available seed peers, a percentage over 100
+		// would otherwise make the slice bound exceed len(seedPeers) and panic.
+		if seedPeerCount > len(seedPeers) {
+			seedPeerCount = len(seedPeers)
+		}
+
 		// Ensure at least one peer is selected if percentage > 0.
 		if seedPeerCount == 0 && *percentage > 0 {
 			seedPeerCount = 1
@@ -848,6 +854,12 @@ func (j *job) selectPeers(ips []string, count *uint32, percentage *uint32, log *
 
 	if percentage != nil {
 		peerCount := (len(peers) * int(*percentage)) / 100
+
+		// Clamp to the number of available peers, a percentage over 100 would
+		// otherwise make the slice bound exceed len(peers) and panic.
+		if peerCount > len(peers) {
+			peerCount = len(peers)
+		}
 
 		// Ensure at least one peer is selected if percentage > 0.
 		if peerCount == 0 && *percentage > 0 {

--- a/scheduler/job/job.go
+++ b/scheduler/job/job.go
@@ -635,9 +635,7 @@ func (j *job) selectSeedPeers(ips []string, count *uint32, percentage *uint32, l
 
 		// Clamp to the number of available seed peers, a percentage over 100
 		// would otherwise make the slice bound exceed len(seedPeers) and panic.
-		if seedPeerCount > len(seedPeers) {
-			seedPeerCount = len(seedPeers)
-		}
+		seedPeerCount = min(seedPeerCount, len(seedPeers))
 
 		// Ensure at least one peer is selected if percentage > 0.
 		if seedPeerCount == 0 && *percentage > 0 {
@@ -857,9 +855,7 @@ func (j *job) selectPeers(ips []string, count *uint32, percentage *uint32, log *
 
 		// Clamp to the number of available peers, a percentage over 100 would
 		// otherwise make the slice bound exceed len(peers) and panic.
-		if peerCount > len(peers) {
-			peerCount = len(peers)
-		}
+		peerCount = min(peerCount, len(peers))
 
 		// Ensure at least one peer is selected if percentage > 0.
 		if peerCount == 0 && *percentage > 0 {

--- a/scheduler/job/job_test.go
+++ b/scheduler/job/job_test.go
@@ -1,0 +1,124 @@
+/*
+ *     Copyright 2024 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package job
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	logger "d7y.io/dragonfly/v2/internal/dflog"
+	resource "d7y.io/dragonfly/v2/scheduler/resource/standard"
+)
+
+func TestJob_selectPeers(t *testing.T) {
+	tests := []struct {
+		name       string
+		hosts      []*resource.Host
+		percentage uint32
+		expect     func(t *testing.T, hosts []*resource.Host, err error)
+	}{
+		{
+			name:       "percentage over 100 is clamped to available peers",
+			hosts:      []*resource.Host{{}, {}, {}},
+			percentage: 200,
+			expect: func(t *testing.T, hosts []*resource.Host, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Len(hosts, 3)
+			},
+		},
+		{
+			name:       "valid percentage selects a proportional number of peers",
+			hosts:      []*resource.Host{{}, {}, {}, {}},
+			percentage: 50,
+			expect: func(t *testing.T, hosts []*resource.Host, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Len(hosts, 2)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+
+			res := resource.NewMockResource(ctl)
+			hostManager := resource.NewMockHostManager(ctl)
+			res.EXPECT().HostManager().Return(hostManager).Times(1)
+			hostManager.EXPECT().LoadAllNormals().Return(tc.hosts).Times(1)
+
+			j := &job{resource: res}
+			percentage := tc.percentage
+			hosts, err := j.selectPeers(nil, nil, &percentage, logger.WithPeerID("test"))
+			tc.expect(t, hosts, err)
+		})
+	}
+}
+
+func TestJob_selectSeedPeers(t *testing.T) {
+	tests := []struct {
+		name       string
+		seedPeers  []*resource.Host
+		percentage uint32
+		expect     func(t *testing.T, seedPeers []*resource.Host, err error)
+	}{
+		{
+			name:       "percentage over 100 is clamped to available seed peers",
+			seedPeers:  []*resource.Host{{}, {}},
+			percentage: 200,
+			expect: func(t *testing.T, seedPeers []*resource.Host, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Len(seedPeers, 2)
+			},
+		},
+		{
+			name:       "valid percentage selects a proportional number of seed peers",
+			seedPeers:  []*resource.Host{{}, {}, {}, {}},
+			percentage: 50,
+			expect: func(t *testing.T, seedPeers []*resource.Host, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Len(seedPeers, 2)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+
+			res := resource.NewMockResource(ctl)
+			seedPeer := resource.NewMockSeedPeer(ctl)
+			hostManager := resource.NewMockHostManager(ctl)
+			res.EXPECT().SeedPeer().Return(seedPeer).Times(1)
+			seedPeer.EXPECT().HasAvailable().Return(true).Times(1)
+			res.EXPECT().HostManager().Return(hostManager).Times(1)
+			hostManager.EXPECT().LoadAllSeeds().Return(tc.seedPeers).Times(1)
+
+			j := &job{resource: res}
+			percentage := tc.percentage
+			seedPeers, err := j.selectSeedPeers(nil, nil, &percentage, logger.WithPeerID("test"))
+			tc.expect(t, seedPeers, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

`selectPeers` and `selectSeedPeers` in `scheduler/job/job.go` compute the number of peers to preheat from a caller-supplied percentage (`len(peers) * percentage / 100`) and then reslice `peers[:peerCount]` without bounding the result. A percentage over 100 makes the bound exceed `len(peers)`:

    panic: runtime error: slice bounds out of range [:6] with capacity 3
        d7y.io/dragonfly/v2/scheduler/job.(*job).selectPeers  scheduler/job/job.go

The gRPC `PreheatImage` / `PreheatFile` endpoints forward `req.Percentage` unchecked and run the preheat in a detached goroutine, so the panic is not caught by the recovery interceptor and takes down the scheduler. The manager REST path already caps percentage at 1-100 (`manager/types/job.go`, `binding:"omitempty,gte=1,lte=100"`), so the value is bounded there but not on the gRPC path.

Clamp the count to the number of available peers in both functions, mirroring the `count` branch right above.

## Related Issue

N/A

## Motivation and Context

A single preheat request with `scope=all_peers` (or `all_seed_peers`) and `percentage > 100` crashes the scheduler process. Clamping keeps valid 0-100 requests unchanged and makes an out-of-range percentage select all available peers instead of panicking.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
