### PR TITLE
fix(manager): make redis proxy Stop idempotent to prevent double-close panic

### DIFF
--- a/pkg/redis/proxy.go
+++ b/pkg/redis/proxy.go
@@ -31,9 +31,10 @@ type Proxy interface {
 }
 
 type proxy struct {
-	from string
-	to   string
-	done chan struct{}
+	from      string
+	to        string
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // NewProxy creates a new proxy instance for redirecting traffic to redis.
@@ -70,11 +71,9 @@ func (p *proxy) Serve() error {
 
 // Stop stops the proxy server and closes all connections.
 func (p *proxy) Stop() {
-	if p.done == nil {
-		return
-	}
-	close(p.done)
-	p.done = nil
+	p.closeOnce.Do(func() {
+		close(p.done)
+	})
 }
 
 // handleConn handles the incoming connection and establishes a connection to the remote host.

--- a/pkg/redis/proxy_test.go
+++ b/pkg/redis/proxy_test.go
@@ -1,0 +1,57 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package redis
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxy_StopConcurrent(t *testing.T) {
+	tests := []struct {
+		name    string
+		callers int
+	}{
+		{
+			name:    "stop is idempotent when called once",
+			callers: 1,
+		},
+		{
+			name:    "stop is idempotent under concurrent callers",
+			callers: 16,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewProxy("127.0.0.1:0", "127.0.0.1:0")
+
+			var wg sync.WaitGroup
+			wg.Add(tc.callers)
+			for i := 0; i < tc.callers; i++ {
+				go func() {
+					defer wg.Done()
+					p.Stop()
+				}()
+			}
+
+			assert.NotPanics(t, wg.Wait)
+		})
+	}
+}


### PR DESCRIPTION

The manager's redis proxy (`pkg/redis/proxy.go`) calls `Stop()` concurrently
from three places on the normal connection-close path, but `Stop()` was not safe
to call more than once. For every proxied connection, `handleConn` spawns the two
relay goroutines `copy` and `copyReader`; when the connection closes, each one's
`io.Copy` returns and calls `p.Stop()`, and manager shutdown
(`manager/manager.go`) calls `s.redisProxy.Stop()` as well.

The old `Stop()` guarded the close with a non-atomic `if p.done == nil`
check-then-act and then wrote `p.done = nil`, with no mutex on the struct:

```go
func (p *proxy) Stop() {
	if p.done == nil {
		return
	}
	close(p.done)
	p.done = nil
}
```

Two goroutines can both pass the nil check and both reach `close(p.done)`,
panicking with `close of closed channel` and crashing the whole manager process.
The `p.done = nil` write also races every concurrent read of `p.done` in the
`Serve`/`copy`/`copyReader` select statements, and once `p.done` is nil,
`Serve`'s `case <-p.done` turns into a receive on a nil channel that blocks
forever.

This change uses a `sync.Once` to close `p.done` exactly once and drops the
`p.done = nil` write:

```go
func (p *proxy) Stop() {
	p.closeOnce.Do(func() {
		close(p.done)
	})
}
```

`Stop()` is now idempotent and race-free, `p.done` stays non-nil so `Serve`
still observes shutdown, and no extra initialization is needed because the
zero-value `sync.Once` is ready to use.

A regression test (`pkg/redis/proxy_test.go`) calls `Stop()` concurrently from
many goroutines and asserts it does not panic; it fails under `-race` on the old
code and passes with this fix.

## Related Issue

Fixes #<ISSUE_NUMBER>

## Motivation and Context

Closing a proxied redis connection is the normal, frequent path, and it reliably
races two goroutines into `Stop()`. The unrecovered `close of closed channel`
panic takes down the entire manager process, and the accompanying data race is
undefined behavior. Making `Stop()` idempotent removes the crash and the race
with a minimal change.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
```
