### PR TITLE
fix: mirror seed peer progress into scheduler memory during download task stream reconciliation and use LoadOrStore for task creation to prevent race conditions and DAG fragmentation

### DIFF
--- a/scheduler/resource/standard/resource.go
+++ b/scheduler/resource/standard/resource.go
@@ -103,7 +103,7 @@ func New(cfg *config.Config, gc gc.GC, transportCredentials credentials.Transpor
 
 	// Initialize seed peer interface.
 	dialOptions := []grpc.DialOption{grpc.WithStatsHandler(otelgrpc.NewClientHandler()), grpc.WithTransportCredentials(transportCredentials)}
-	resource.seedPeer = newSeedPeer(peerManager, hostManager, resource.peerClientPool, dialOptions...)
+	resource.seedPeer = newSeedPeer(peerManager, hostManager, taskManager, resource.peerClientPool, int32(cfg.Scheduler.BackToSourceCount), dialOptions...)
 
 	return resource, nil
 }

--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -88,8 +88,14 @@ type seedPeer struct {
 	// hostManager is HostManager interface.
 	hostManager HostManager
 
+	// taskManager is TaskManager interface.
+	taskManager TaskManager
+
 	// clientPool is Pool interface.
 	clientPool dfdaemonclient.Pool
+
+	// backToSourceLimit is back-to-source limit of task.
+	backToSourceLimit int32
 
 	// dialOpts is the options for grpc dial.
 	dialOptions []grpc.DialOption
@@ -105,15 +111,17 @@ type seedPeer struct {
 }
 
 // New SeedPeer interface.
-func newSeedPeer(peerManager PeerManager, hostManager HostManager, clientPool dfdaemonclient.Pool, dialOptions ...grpc.DialOption) SeedPeer {
+func newSeedPeer(peerManager PeerManager, hostManager HostManager, taskManager TaskManager, clientPool dfdaemonclient.Pool, backToSourceLimit int32, dialOptions ...grpc.DialOption) SeedPeer {
 	return &seedPeer{
-		peerManager: peerManager,
-		hostManager: hostManager,
-		clientPool:  clientPool,
-		dialOptions: dialOptions,
-		hosts:       &sync.Map{},
-		hashring:    consistent.New(),
-		done:        make(chan struct{}),
+		peerManager:       peerManager,
+		hostManager:       hostManager,
+		taskManager:       taskManager,
+		clientPool:        clientPool,
+		backToSourceLimit: backToSourceLimit,
+		dialOptions:       dialOptions,
+		hosts:             &sync.Map{},
+		hashring:          consistent.New(),
+		done:              make(chan struct{}),
 	}
 }
 
@@ -141,17 +149,291 @@ func (s *seedPeer) TriggerDownloadTask(ctx context.Context, taskID string, req *
 		return err
 	}
 
-	// Wait for the download task to complete.
+	// Wait for the download task to complete. Meanwhile, mirror the seed peer
+	// progress into scheduler memory. This is important after scheduler restarts:
+	// the seed may still have a complete local task, but the scheduler has lost
+	// the in-memory task/peer DAG. The DownloadTask stream is the on-demand
+	// reconciliation point that makes the seed peer available as a parent again.
+	var peer *Peer
 	for {
-		_, err := stream.Recv()
+		resp, err := stream.Recv()
 		if err != nil {
 			if err == io.EOF {
+				if peer != nil {
+					if err := s.completeSeedPeerDownloadTask(ctx, peer); err != nil {
+						return err
+					}
+				}
+
 				return nil
+			}
+
+			if peer != nil && !peer.FSM.Is(PeerStateFailed) {
+				if err := peer.FSM.Event(ctx, PeerEventDownloadFailed); err != nil {
+					peer.Log.Errorf("seed peer download task failed, but set peer failed state failed: %s", err.Error())
+				}
 			}
 
 			return err
 		}
+
+		peer, err = s.handleDownloadTaskResponse(ctx, taskID, req.GetDownload(), resp, peer)
+		if err != nil {
+			return err
+		}
 	}
+}
+
+func (s *seedPeer) handleDownloadTaskResponse(ctx context.Context, taskID string, download *commonv2.Download, resp *dfdaemonv2.DownloadTaskResponse, peer *Peer) (*Peer, error) {
+	if resp == nil {
+		return peer, nil
+	}
+
+	if resp.GetTaskId() != "" && resp.GetTaskId() != taskID {
+		return nil, fmt.Errorf("seed peer download task response task id %s does not match %s", resp.GetTaskId(), taskID)
+	}
+
+	if peer == nil {
+		var err error
+		peer, err = s.initSeedPeerForDownloadTask(ctx, taskID, download, resp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := s.ensureSeedPeerDownloading(ctx, peer, download.GetNeedBackToSource()); err != nil {
+		return nil, err
+	}
+
+	switch r := resp.GetResponse().(type) {
+	case *dfdaemonv2.DownloadTaskResponse_DownloadTaskStartedResponse:
+		started := r.DownloadTaskStartedResponse
+		if started == nil {
+			return peer, nil
+		}
+
+		peer.Task.ContentLength.Store(int64(started.GetContentLength()))
+		if download.GetActualPieceCount() > 0 {
+			peer.Task.TotalPieceCount.Store(int32(download.GetActualPieceCount()))
+		} else {
+			if count := calculatePieceCount(started.GetContentLength(), peer.Task.PieceLength); count > 0 {
+				peer.Task.TotalPieceCount.Store(count)
+			}
+		}
+
+		// When the seed local task is already complete, dfdaemon may return all
+		// pieces in the started response and set is_finished. Store those pieces and
+		// mark the seed peer completed immediately, so later scheduling retries can
+		// select it as parent without waiting for another scheduler announce path.
+		if started.GetIsFinished() {
+			for _, piece := range started.GetPieces() {
+				if err := storeSeedPeerPiece(peer, piece); err != nil {
+					return nil, err
+				}
+			}
+
+			if err := s.completeSeedPeerDownloadTask(ctx, peer); err != nil {
+				return nil, err
+			}
+		}
+	case *dfdaemonv2.DownloadTaskResponse_DownloadPieceFinishedResponse:
+		finished := r.DownloadPieceFinishedResponse
+		if finished == nil {
+			return peer, nil
+		}
+
+		if err := storeSeedPeerPiece(peer, finished.GetPiece()); err != nil {
+			return nil, err
+		}
+	}
+
+	return peer, nil
+}
+
+func (s *seedPeer) initSeedPeerForDownloadTask(ctx context.Context, taskID string, download *commonv2.Download, resp *dfdaemonv2.DownloadTaskResponse) (*Peer, error) {
+	if download == nil {
+		download = &commonv2.Download{}
+	}
+
+	hostID := resp.GetHostId()
+	if hostID == "" {
+		return nil, fmt.Errorf("seed peer download task response host id is empty")
+	}
+
+	peerID := resp.GetPeerId()
+	if peerID == "" {
+		return nil, fmt.Errorf("seed peer download task response peer id is empty")
+	}
+
+	host, loaded := s.hostManager.Load(hostID)
+	if !loaded {
+		return nil, fmt.Errorf("can not find seed host id: %s", hostID)
+	}
+	host.UpdatedAt.Store(time.Now())
+
+	task, loaded := s.taskManager.Load(taskID)
+	if !loaded {
+		options := []TaskOption{WithPieceLength(download.GetActualPieceLength())}
+		if download.GetDigest() != "" {
+			d, err := digest.Parse(download.GetDigest())
+			if err != nil {
+				return nil, err
+			}
+
+			options = append(options, WithDigest(d))
+		}
+
+		task = NewTask(taskID, download.GetUrl(), download.GetTag(), download.GetApplication(), download.GetType(),
+			download.GetFilteredQueryParams(), download.GetRequestHeader(), s.backToSourceLimit, options...)
+		s.taskManager.Store(task)
+	} else {
+		task.URL = download.GetUrl()
+		task.FilteredQueryParams = download.GetFilteredQueryParams()
+		task.Header = download.GetRequestHeader()
+		if task.PieceLength == 0 && download.GetActualPieceLength() > 0 {
+			task.PieceLength = download.GetActualPieceLength()
+		}
+	}
+
+	if download.GetActualContentLength() > 0 || download.ActualContentLength != nil {
+		task.ContentLength.Store(int64(download.GetActualContentLength()))
+	}
+	if download.GetActualPieceCount() > 0 || download.ActualPieceCount != nil {
+		task.TotalPieceCount.Store(int32(download.GetActualPieceCount()))
+	}
+
+	if !task.FSM.Is(TaskStateRunning) && !task.FSM.Is(TaskStateSucceeded) {
+		if err := task.FSM.Event(ctx, TaskEventDownload); err != nil {
+			return nil, err
+		}
+	}
+
+	peer, loaded := s.peerManager.Load(peerID)
+	if loaded {
+		peer.UpdatedAt.Store(time.Now())
+		return peer, nil
+	}
+
+	options := []PeerOption{WithPriority(download.GetPriority())}
+	if download.GetRange() != nil {
+		options = append(options, WithRange(http.Range{Start: int64(download.GetRange().GetStart()), Length: int64(download.GetRange().GetLength())}))
+	}
+	if download.ConcurrentPieceCount != nil {
+		options = append(options, WithConcurrentPieceCount(download.GetConcurrentPieceCount()))
+	}
+
+	peer = NewPeer(peerID, task, host, options...)
+	s.peerManager.Store(peer)
+	peer.Log.Info("seed peer has been stored from download task response")
+
+	if err := peer.FSM.Event(ctx, PeerEventRegisterNormal); err != nil {
+		return nil, err
+	}
+
+	return peer, nil
+}
+
+func (s *seedPeer) ensureSeedPeerDownloading(ctx context.Context, peer *Peer, needBackToSource bool) error {
+	if !peer.Task.FSM.Is(TaskStateRunning) && !peer.Task.FSM.Is(TaskStateSucceeded) {
+		if err := peer.Task.FSM.Event(ctx, TaskEventDownload); err != nil {
+			return err
+		}
+	}
+
+	if !peer.FSM.Is(PeerStateReceivedNormal) && !peer.FSM.Is(PeerStateReceivedSmall) && !peer.FSM.Is(PeerStateReceivedTiny) && !peer.FSM.Is(PeerStateReceivedEmpty) {
+		return nil
+	}
+
+	if needBackToSource {
+		return peer.FSM.Event(ctx, PeerEventDownloadBackToSource)
+	}
+
+	return peer.FSM.Event(ctx, PeerEventDownload)
+}
+
+func (s *seedPeer) completeSeedPeerDownloadTask(ctx context.Context, peer *Peer) error {
+	if !peer.FSM.Is(PeerStateSucceeded) {
+		if err := peer.FSM.Event(ctx, PeerEventDownloadSucceeded); err != nil {
+			return err
+		}
+	}
+
+	if peer.Range == nil && !peer.Task.FSM.Is(TaskStateSucceeded) {
+		if !peer.Task.FSM.Is(TaskStateRunning) {
+			if err := peer.Task.FSM.Event(ctx, TaskEventDownload); err != nil {
+				return err
+			}
+		}
+
+		if err := peer.Task.FSM.Event(ctx, TaskEventDownloadSucceeded); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func storeSeedPeerPiece(peer *Peer, protoPiece *commonv2.Piece) error {
+	if protoPiece == nil {
+		return nil
+	}
+
+	cost := time.Duration(0)
+	if protoPiece.GetCost() != nil {
+		cost = protoPiece.GetCost().AsDuration()
+	}
+
+	createdAt := time.Now()
+	if protoPiece.GetCreatedAt() != nil {
+		createdAt = protoPiece.GetCreatedAt().AsTime()
+	} else if cost > 0 {
+		createdAt = createdAt.Add(-cost)
+	}
+
+	piece := &Piece{
+		Number:      int32(protoPiece.GetNumber()),
+		ParentID:    protoPiece.GetParentId(),
+		Offset:      protoPiece.GetOffset(),
+		Length:      protoPiece.GetLength(),
+		TrafficType: protoPiece.GetTrafficType(),
+		Cost:        cost,
+		CreatedAt:   createdAt,
+	}
+
+	if len(protoPiece.GetDigest()) > 0 {
+		d, err := digest.Parse(protoPiece.GetDigest())
+		if err != nil {
+			return err
+		}
+
+		piece.Digest = d
+	}
+
+	peer.FinishedPieces.Set(uint(piece.Number))
+	peer.AppendPieceCost(piece.Cost)
+	peer.PieceUpdatedAt.Store(time.Now())
+	peer.UpdatedAt.Store(time.Now())
+	peer.Host.UpdatedAt.Store(time.Now())
+	peer.Task.StorePiece(piece)
+	peer.Task.UpdatedAt.Store(time.Now())
+	if peer.Task.TotalPieceCount.Load() <= piece.Number {
+		peer.Task.TotalPieceCount.Store(piece.Number + 1)
+	}
+
+	metrics.DownloadPieceCount.WithLabelValues(piece.TrafficType.String(), peer.Task.Type.String(),
+		peer.Host.Type.Name()).Inc()
+	metrics.Traffic.WithLabelValues(piece.TrafficType.String(), peer.Task.Type.String(),
+		peer.Host.Type.Name()).Add(float64(piece.Length))
+
+	return nil
+}
+
+func calculatePieceCount(contentLength uint64, pieceLength uint64) int32 {
+	if pieceLength == 0 {
+		return 0
+	}
+
+	return int32((contentLength + pieceLength - 1) / pieceLength)
 }
 
 // TriggerTask triggers the seed peer to download task.

--- a/scheduler/resource/standard/seed_peer.go
+++ b/scheduler/resource/standard/seed_peer.go
@@ -283,10 +283,11 @@ func (s *seedPeer) initSeedPeerForDownloadTask(ctx context.Context, taskID strin
 			options = append(options, WithDigest(d))
 		}
 
-		task = NewTask(taskID, download.GetUrl(), download.GetTag(), download.GetApplication(), download.GetType(),
+		newTask := NewTask(taskID, download.GetUrl(), download.GetTag(), download.GetApplication(), download.GetType(),
 			download.GetFilteredQueryParams(), download.GetRequestHeader(), s.backToSourceLimit, options...)
-		s.taskManager.Store(task)
-	} else {
+		task, loaded = s.taskManager.LoadOrStore(newTask)
+	}
+	if loaded {
 		task.URL = download.GetUrl()
 		task.FilteredQueryParams = download.GetFilteredQueryParams()
 		task.Header = download.GetRequestHeader()

--- a/scheduler/resource/standard/seed_peer_test.go
+++ b/scheduler/resource/standard/seed_peer_test.go
@@ -19,6 +19,7 @@ package standard
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ import (
 	dfdaemonv2 "d7y.io/api/v2/pkg/apis/dfdaemon/v2"
 	schedulerv1 "d7y.io/api/v2/pkg/apis/scheduler/v1"
 	dfdaemonclientmocks "d7y.io/dragonfly/v2/pkg/rpc/dfdaemon/client/mocks"
+	"d7y.io/dragonfly/v2/pkg/types"
 )
 
 func TestSeedPeer_newSeedPeer(t *testing.T) {
@@ -49,10 +51,11 @@ func TestSeedPeer_newSeedPeer(t *testing.T) {
 			ctl := gomock.NewController(t)
 			defer ctl.Finish()
 			hostManager := NewMockHostManager(ctl)
+			taskManager := NewMockTaskManager(ctl)
 			peerManager := NewMockPeerManager(ctl)
 			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
 
-			tc.expect(t, newSeedPeer(peerManager, hostManager, clientPool))
+			tc.expect(t, newSeedPeer(peerManager, hostManager, taskManager, clientPool, mockTaskBackToSourceLimit))
 		})
 	}
 }
@@ -76,13 +79,93 @@ func TestSeedPeer_TriggerDownloadTask(t *testing.T) {
 			ctl := gomock.NewController(t)
 			defer ctl.Finish()
 			hostManager := NewMockHostManager(ctl)
+			taskManager := NewMockTaskManager(ctl)
 			peerManager := NewMockPeerManager(ctl)
 			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
 
-			seedPeer := newSeedPeer(peerManager, hostManager, clientPool)
+			seedPeer := newSeedPeer(peerManager, hostManager, taskManager, clientPool, mockTaskBackToSourceLimit)
 			tc.expect(t, seedPeer.TriggerDownloadTask(context.Background(), mockTaskID, &dfdaemonv2.DownloadTaskRequest{}))
 		})
 	}
+}
+
+func TestSeedPeer_handleDownloadTaskResponse_registersSeedPeer(t *testing.T) {
+	assert := assert.New(t)
+
+	hostManager := &hostManager{Map: &sync.Map{}, normals: &sync.Map{}, seeds: &sync.Map{}}
+	taskManager := &taskManager{Map: &sync.Map{}}
+	peerManager := &peerManager{Map: &sync.Map{}, mu: &sync.Mutex{}}
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+	clientPool := dfdaemonclientmocks.NewMockPool(ctl)
+	seedPeer := newSeedPeer(peerManager, hostManager, taskManager, clientPool, mockTaskBackToSourceLimit).(*seedPeer)
+
+	seedHost := NewHost("seed-host", "127.0.0.1", "seed", "seed", 4000, 8001, 65001, types.HostTypeSuperSeed)
+	hostManager.Store(seedHost)
+	task := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithPieceLength(mockTaskPieceLength))
+	taskManager.Store(task)
+
+	contentLength := uint64(4096)
+	pieceCount := uint64(2)
+	download := &commonv2.Download{
+		Url:                 mockTaskURL,
+		Type:                commonv2.TaskType_STANDARD,
+		Priority:            commonv2.Priority_LEVEL6,
+		FilteredQueryParams: mockTaskFilteredQueryParams,
+		RequestHeader:       mockTaskHeader,
+		NeedBackToSource:    true,
+		ActualPieceLength:   &mockTaskPieceLength,
+		ActualContentLength: &contentLength,
+		ActualPieceCount:    &pieceCount,
+	}
+
+	started := &dfdaemonv2.DownloadTaskResponse{
+		HostId: seedHost.ID,
+		TaskId: mockTaskID,
+		PeerId: "seed-peer",
+		Response: &dfdaemonv2.DownloadTaskResponse_DownloadTaskStartedResponse{
+			DownloadTaskStartedResponse: &dfdaemonv2.DownloadTaskStartedResponse{ContentLength: contentLength},
+		},
+	}
+	peer, err := seedPeer.handleDownloadTaskResponse(context.Background(), mockTaskID, download, started, nil)
+	assert.NoError(err)
+	assert.NotNil(peer)
+	assert.Equal("seed-peer", peer.ID)
+	assert.True(peer.FSM.Is(PeerStateBackToSource))
+	assert.Equal(int64(contentLength), task.ContentLength.Load())
+	assert.Equal(int32(pieceCount), task.TotalPieceCount.Load())
+
+	trafficType := commonv2.TrafficType_LOCAL_PEER
+	pieceResp := &dfdaemonv2.DownloadTaskResponse{
+		HostId: seedHost.ID,
+		TaskId: mockTaskID,
+		PeerId: "seed-peer",
+		Response: &dfdaemonv2.DownloadTaskResponse_DownloadPieceFinishedResponse{
+			DownloadPieceFinishedResponse: &dfdaemonv2.DownloadPieceFinishedResponse{Piece: &commonv2.Piece{
+				Number:      0,
+				Offset:      0,
+				Length:      mockTaskPieceLength,
+				TrafficType: &trafficType,
+			}},
+		},
+	}
+	peer, err = seedPeer.handleDownloadTaskResponse(context.Background(), mockTaskID, download, pieceResp, peer)
+	assert.NoError(err)
+	assert.True(peer.FinishedPieces.Test(0))
+	piece, loaded := task.LoadPiece(0)
+	assert.True(loaded)
+	assert.Equal(commonv2.TrafficType_LOCAL_PEER, piece.TrafficType)
+
+	assert.NoError(seedPeer.completeSeedPeerDownloadTask(context.Background(), peer))
+	assert.True(peer.FSM.Is(PeerStateSucceeded))
+	assert.True(task.FSM.Is(TaskStateSucceeded))
+
+	storedPeer, loaded := peerManager.Load("seed-peer")
+	assert.True(loaded)
+	assert.Equal(peer, storedPeer)
+	storedPeer, loaded = task.LoadPeer("seed-peer")
+	assert.True(loaded)
+	assert.Equal(peer, storedPeer)
 }
 
 func TestSeedPeer_TriggerTask(t *testing.T) {
@@ -104,10 +187,11 @@ func TestSeedPeer_TriggerTask(t *testing.T) {
 			ctl := gomock.NewController(t)
 			defer ctl.Finish()
 			hostManager := NewMockHostManager(ctl)
+			taskManager := NewMockTaskManager(ctl)
 			peerManager := NewMockPeerManager(ctl)
 			clientPool := dfdaemonclientmocks.NewMockPool(ctl)
 
-			seedPeer := newSeedPeer(peerManager, hostManager, clientPool)
+			seedPeer := newSeedPeer(peerManager, hostManager, taskManager, clientPool, mockTaskBackToSourceLimit)
 			mockTask := NewTask(mockTaskID, mockTaskURL, mockTaskTag, mockTaskApplication, commonv2.TaskType_STANDARD, mockTaskFilteredQueryParams, mockTaskHeader, mockTaskBackToSourceLimit, WithDigest(mockTaskDigest))
 			peer, result, err := seedPeer.TriggerTask(context.Background(), nil, mockTask)
 			tc.expect(t, peer, result, err)

--- a/scheduler/service/service_v1.go
+++ b/scheduler/service/service_v1.go
@@ -796,15 +796,19 @@ func (v *V1) storeTask(_ context.Context, req *schedulerv1.PeerTaskRequest, typ 
 		}
 
 		// Piece length is not supported in Protocol V1, use default value 0.
-		task := resource.NewTask(req.GetTaskId(), req.GetUrl(), req.UrlMeta.GetTag(), req.UrlMeta.GetApplication(),
+		newTask := resource.NewTask(req.GetTaskId(), req.GetUrl(), req.UrlMeta.GetTag(), req.UrlMeta.GetApplication(),
 			typ, filteredQueryParams, req.UrlMeta.GetHeader(), int32(v.config.Scheduler.BackToSourceCount), options...)
-		v.resource.TaskManager().Store(task)
-		task.Log.Info("create new task")
-		return task
+		task, loaded = v.resource.TaskManager().LoadOrStore(newTask)
+		if !loaded {
+			task.Log.Info("create new task")
+			return task
+		}
 	}
 
 	// Task is the pointer, if the task already exists, the next request will
-	// update the task's Url and UrlMeta in task manager.
+	// update the task's Url and UrlMeta in task manager. LoadOrStore prevents
+	// concurrent requests with the same task ID from replacing the canonical
+	// task instance and splitting peers into different DAGs.
 	task.URL = req.GetUrl()
 	task.FilteredQueryParams = filteredQueryParams
 	task.Header = req.UrlMeta.GetHeader()

--- a/scheduler/service/service_v1_test.go
+++ b/scheduler/service/service_v1_test.go
@@ -2686,7 +2686,9 @@ func TestServiceV1_storeTask(t *testing.T) {
 					mr.TaskManager().Return(taskManager).Times(1),
 					mt.Load(gomock.Eq(mockTaskID)).Return(nil, false).Times(1),
 					mr.TaskManager().Return(taskManager).Times(1),
-					mt.Store(gomock.Any()).Return().Times(1),
+					mt.LoadOrStore(gomock.Any()).DoAndReturn(func(task *resource.Task) (*resource.Task, bool) {
+						return task, false
+					}).Times(1),
 				)
 
 				task := svc.storeTask(context.Background(), &schedulerv1.PeerTaskRequest{

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1801,7 +1801,9 @@ func (v *V2) handleResource(_ context.Context, stream schedulerv2.Scheduler_Anno
 		return nil, nil, nil, status.Errorf(codes.NotFound, "host %s not found", hostID)
 	}
 
-	// Store new task or update task.
+	// Store new task or update task. Use LoadOrStore when creating a task to avoid
+	// concurrent requests with the same task ID replacing the canonical task
+	// instance and splitting peers into different DAGs.
 	task, loaded := v.resource.TaskManager().Load(taskID)
 	if !loaded {
 		options := []standard.TaskOption{
@@ -1817,12 +1819,13 @@ func (v *V2) handleResource(_ context.Context, stream schedulerv2.Scheduler_Anno
 			options = append(options, standard.WithDigest(d))
 		}
 
-		task = standard.NewTask(taskID, download.GetUrl(), download.GetTag(), download.GetApplication(), download.GetType(),
+		newTask := standard.NewTask(taskID, download.GetUrl(), download.GetTag(), download.GetApplication(), download.GetType(),
 			download.GetFilteredQueryParams(), download.GetRequestHeader(), int32(v.config.Scheduler.BackToSourceCount), options...)
-		task.ContentLength.Store(int64(download.GetActualContentLength()))
-		task.TotalPieceCount.Store(int32(download.GetActualPieceCount()))
-		v.resource.TaskManager().Store(task)
-	} else {
+		newTask.ContentLength.Store(int64(download.GetActualContentLength()))
+		newTask.TotalPieceCount.Store(int32(download.GetActualPieceCount()))
+		task, loaded = v.resource.TaskManager().LoadOrStore(newTask)
+	}
+	if loaded {
 		task.URL = download.GetUrl()
 		task.FilteredQueryParams = download.GetFilteredQueryParams()
 		task.Header = download.GetRequestHeader()

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -3312,7 +3312,9 @@ func TestServiceV2_handleResource(t *testing.T) {
 					mr.TaskManager().Return(taskManager).Times(1),
 					mt.Load(gomock.Eq(mockTask.ID)).Return(nil, false).Times(1),
 					mr.TaskManager().Return(taskManager).Times(1),
-					mt.Store(gomock.Any()).Return().Times(1),
+					mt.LoadOrStore(gomock.Any()).DoAndReturn(func(task *standard.Task) (*standard.Task, bool) {
+						return task, false
+					}).Times(1),
 					mr.PeerManager().Return(peerManager).Times(1),
 					mp.Load(gomock.Eq(mockPeer.ID)).Return(mockPeer, true).Times(1),
 				)


### PR DESCRIPTION
修复scheduler重启后，seed节点本地文件无法重新注册到scheduler上的问题

注：本补丁由Codex生成