### PR TITLE
feat(scheduler): handle HitLocalCache in peer register & upgrade v2.2.32

### DIFF
--- a/build/images/manager/Dockerfile
+++ b/build/images/manager/Dockerfile
@@ -1,10 +1,11 @@
 ARG BASE_IMAGE=alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-FROM node:20-alpine@sha256:658d0f63e501824d6c23e06d4bb95c71e7d704537c9d9272f488ac03a370d448 AS console-builder
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS console-builder
 
 WORKDIR /build
 
 COPY ./manager/console/package.json /build
+COPY ./manager/console/yarn.lock /build
 
 RUN yarn install --frozen-lockfile --network-timeout 1000000
 

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.46.0
 	google.golang.org/api v0.288.0
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module d7y.io/dragonfly/v2
 go 1.25.5
 
 require (
-	d7y.io/api/v2 v2.2.30
+	d7y.io/api/v2 v2.2.32
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/appleboy/gin-jwt/v2 v2.10.3

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+d7y.io/api/v2 v2.2.32 h1:tGK/llLBoWdHVN8bwB1k7tXGw3FNUDv82XdhzAcXJWg=
+d7y.io/api/v2 v2.2.32/go.mod h1:8qiLrU0pd3yVZdjraORYLdVPD1was3AXp4dRyCo7N1Q=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
@@ -1291,8 +1293,8 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-d7y.io/api/v2 v2.2.30 h1:hUG7MmCbS/evGJvlBKClCehiolFufUv8DQcScwTaIFc=
-d7y.io/api/v2 v2.2.30/go.mod h1:q05190yfo1T5VR2/cK7RVQqIESPVA2VKRX4rS/7x9rc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -92,7 +92,7 @@ build-manager-console() {
     CONSOLE_ASSETS=$CONSOLE_DIR/dist/*
     MANAGER_ASSETS_DIR=$MANAGER_DIR/dist
     docker run --workdir=/build \
-        --rm -v ${CONSOLE_DIR}:/build node:20-alpine \
+        --rm -v ${CONSOLE_DIR}:/build node:24-alpine \
         sh -c "yarn install --network-timeout 1000000 && yarn build"
     cp -r $CONSOLE_ASSETS $MANAGER_ASSETS_DIR
 }

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1314,7 +1314,7 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 	// If the download hits the local cache of the peer completely, the peer only reports
 	// the metadata to the scheduler and no need to be scheduled or trigger the seed peer
 	// to download back-to-source.
-	if req.GetDownload().GetHitLocalCache() {
+	if req.GetDownload().GetMetadataOnly() {
 		// Handle task with peer register request.
 		if !peer.Task.FSM.Is(standard.TaskStateRunning) {
 			if err := peer.Task.FSM.Event(ctx, standard.TaskEventDownload); err != nil {
@@ -1342,10 +1342,10 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 			return status.Error(codes.Internal, err.Error())
 		}
 
-		peer.Log.Info("peer hits local cache, send HitLocalCacheResponse")
+		peer.Log.Info("peer hits local cache, send MetadataOnlyResponse")
 		if err := stream.Send(&schedulerv2.AnnouncePeerResponse{
-			Response: &schedulerv2.AnnouncePeerResponse_HitLocalCacheResponse{
-				HitLocalCacheResponse: &schedulerv2.HitLocalCacheResponse{},
+			Response: &schedulerv2.AnnouncePeerResponse_MetadataOnlyResponse{
+				MetadataOnlyResponse: &schedulerv2.MetadataOnlyResponse{},
 			},
 		}); err != nil {
 			peer.Log.Error(err)

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1313,9 +1313,7 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 
 	// If the download hits the local cache of the peer completely, the peer only reports
 	// the metadata to the scheduler and no need to be scheduled or trigger the seed peer
-	// to download back-to-source. Send the HitLocalCacheResponse to the peer directly,
-	// and the peer will report the download peer started and finished requests, so that
-	// the peer can be scheduled as a candidate parent for other peers.
+	// to download back-to-source.
 	if req.GetDownload().GetHitLocalCache() {
 		// Handle task with peer register request.
 		if !peer.Task.FSM.Is(standard.TaskStateRunning) {

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1311,6 +1311,56 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 	metrics.RegisterPeerCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
 		peer.Host.Type.Name()).Inc()
 
+	// If the download hits the local cache of the peer completely, the peer only reports
+	// the metadata to the scheduler and no need to be scheduled or trigger the seed peer
+	// to download back-to-source. Send the HitLocalCacheResponse to the peer directly,
+	// and the peer will report the download peer started and finished requests, so that
+	// the peer can be scheduled as a candidate parent for other peers.
+	if req.GetDownload().GetHitLocalCache() {
+		// Handle task with peer register request.
+		if !peer.Task.FSM.Is(standard.TaskStateRunning) {
+			if err := peer.Task.FSM.Event(ctx, standard.TaskEventDownload); err != nil {
+				// Collect RegisterPeerFailureCount metrics.
+				metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
+					peer.Host.Type.Name()).Inc()
+				return status.Error(codes.Internal, err.Error())
+			}
+		} else {
+			peer.Task.UpdatedAt.Store(time.Now())
+		}
+
+		stream, loaded := peer.LoadAnnouncePeerStream()
+		if !loaded {
+			// Collect RegisterPeerFailureCount metrics.
+			metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
+				peer.Host.Type.Name()).Inc()
+			return status.Error(codes.NotFound, "AnnouncePeerStream not found")
+		}
+
+		if err := peer.FSM.Event(ctx, standard.PeerEventRegisterNormal); err != nil {
+			// Collect RegisterPeerFailureCount metrics.
+			metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
+				peer.Host.Type.Name()).Inc()
+			return status.Error(codes.Internal, err.Error())
+		}
+
+		peer.Log.Info("peer hits local cache, send HitLocalCacheResponse")
+		if err := stream.Send(&schedulerv2.AnnouncePeerResponse{
+			Response: &schedulerv2.AnnouncePeerResponse_HitLocalCacheResponse{
+				HitLocalCacheResponse: &schedulerv2.HitLocalCacheResponse{},
+			},
+		}); err != nil {
+			peer.Log.Error(err)
+
+			// Collect RegisterPeerFailureCount metrics.
+			metrics.RegisterPeerFailureCount.WithLabelValues(priority.String(), peer.Task.Type.String(),
+				peer.Host.Type.Name()).Inc()
+			return status.Error(codes.Internal, err.Error())
+		}
+
+		return nil
+	}
+
 	// Provides an exponential delay with jitter to prevent thundering herd problems. When a host has many
 	// concurrent registration requests, later requests are delayed progressively to avoid overwhelming the
 	// source with simultaneous back-to-source tasks from a single host.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add early-return path for `HitLocalCache` flag in peer register
- Transition task/peer FSM states and send `HitLocalCacheResponse` directly without scheduling or triggering seed peer
- Bump `d7y.io/api/v2` dependency from v2.2.30 to v2.2.32
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4880
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
