### PR TITLE
feat(scheduler): skip scheduling for seed peer with small range requests

### DIFF
--- a/scheduler/config/constants.go
+++ b/scheduler/config/constants.go
@@ -170,3 +170,11 @@ const (
 	// DefaultLogRotateMaxBackups is the default number of old log files to keep.
 	DefaultLogRotateMaxBackups = 20
 )
+
+const (
+	// MinPieceLength is the minimum length of a piece.
+	MinPieceLength = 4 * 1024 * 1024
+
+	// MaxPieceLength is the maximum length of a piece.
+	MaxPieceLength = 64 * 1024 * 1024
+)

--- a/scheduler/service/service_v2.go
+++ b/scheduler/service/service_v2.go
@@ -1387,6 +1387,15 @@ func (v *V2) handleRegisterPeerRequest(ctx context.Context, stream schedulerv2.S
 	case download.GetNeedBackToSource():
 		peer.Log.Info("peer need back to source")
 		peer.NeedBackToSource.Store(true)
+	// If peer is seed peer and the range length is smaller than
+	// config.MinPieceLength, skip scheduling and let the seed peer
+	// download back-to-source directly to avoid the scheduling overhead of
+	// small range requests.
+	case host.Type != types.HostTypeNormal && download.GetRange() != nil &&
+		download.GetRange().GetLength() < config.MinPieceLength:
+		peer.Log.Infof("seed peer need back to source, because range length %d is smaller than %d",
+			download.GetRange().GetLength(), uint64(config.MinPieceLength))
+		peer.NeedBackToSource.Store(true)
 	// If task is pending, failed, leave, or succeeded and has no available peer,
 	// scheduler trigger seed peer download back-to-source.
 	case task.FSM.Is(standard.TaskStatePending) ||

--- a/scheduler/service/service_v2_test.go
+++ b/scheduler/service/service_v2_test.go
@@ -2005,6 +2005,44 @@ func TestServiceV2_handleRegisterPeerRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "size scope is SizeScope_NORMAL and seed peer with range length smaller than minRangeLengthForSeedPeerScheduling",
+			req: &schedulerv2.RegisterPeerRequest{
+				Download: &commonv2.Download{
+					Digest: &dgst,
+					Range: &commonv2.Range{
+						Start:  0,
+						Length: 1024,
+					},
+				},
+			},
+			run: func(t *testing.T, svc *V2, req *schedulerv2.RegisterPeerRequest, peer *standard.Peer, seedPeer *standard.Peer, seedPeerManager standard.SeedPeer, hostManager standard.HostManager, taskManager standard.TaskManager,
+				peerManager standard.PeerManager, stream schedulerv2.Scheduler_AnnouncePeerServer, mr *standard.MockResourceMockRecorder, mh *standard.MockHostManagerMockRecorder,
+				mt *standard.MockTaskManagerMockRecorder, mp *standard.MockPeerManagerMockRecorder, mc *standard.MockSeedPeerMockRecorder, ma *schedulerv2mocks.MockScheduler_AnnouncePeerServerMockRecorder, ms *schedulingmocks.MockSchedulingMockRecorder) {
+				gomock.InOrder(
+					mr.HostManager().Return(hostManager).Times(1),
+					mh.Load(gomock.Eq(peer.Host.ID)).Return(peer.Host, true).Times(1),
+					mr.TaskManager().Return(taskManager).Times(1),
+					mt.Load(gomock.Eq(peer.Task.ID)).Return(peer.Task, true).Times(1),
+					mr.PeerManager().Return(peerManager).Times(1),
+					mp.Load(gomock.Eq(peer.ID)).Return(peer, true).Times(1),
+					ms.ScheduleCandidateParents(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1),
+				)
+
+				peer.Host.Type = pkgtypes.HostTypeSuperSeed
+				peer.Task.ContentLength.Store(129)
+				peer.Task.TotalPieceCount.Store(2)
+				peer.Task.StorePeer(peer)
+				peer.Priority = commonv2.Priority_LEVEL6
+				peer.StoreAnnouncePeerStream(stream)
+
+				assert := assert.New(t)
+				assert.NoError(svc.handleRegisterPeerRequest(context.Background(), nil, peer.Host.ID, peer.Task.ID, peer.ID, req))
+				assert.Equal(peer.FSM.Current(), standard.PeerStateReceivedNormal)
+				assert.Equal(peer.NeedBackToSource.Load(), true)
+				assert.Equal(peer.Task.FSM.Current(), standard.TaskStateRunning)
+			},
+		},
+		{
 			name: "size scope is SizeScope_NORMAL",
 			req: &schedulerv2.RegisterPeerRequest{
 				Download: &commonv2.Download{


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add `MinPieceLength` (4MB) and `MaxPieceLength` (64MB) constants
- Skip scheduling for non-normal (seed) peers when range length is below `MinPieceLength`, marking them as back-to-source directly
- Reduces scheduling overhead for small range requests on seed peers
- Add test case covering seed peer with small range length scenario
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
