### PR TITLE
Add fuzz targets for digest, http range, and dfnet packages

### DIFF
--- a/pkg/dfnet/fuzz.go
+++ b/pkg/dfnet/fuzz.go
@@ -1,0 +1,9 @@
+package dfnet
+
+func FuzzNetAddrJSON(data []byte) int {
+	var addr NetAddr
+	if err := addr.UnmarshalJSON(data); err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/digest/fuzz.go
+++ b/pkg/digest/fuzz.go
@@ -1,0 +1,15 @@
+package digest
+
+import (
+	"strings"
+)
+
+func FuzzParse(data []byte) int {
+	s := string(data)
+	s = strings.TrimSpace(s)
+	_, err := Parse(s)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/net/http/fuzz.go
+++ b/pkg/net/http/fuzz.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"strconv"
+	"strings"
+)
+
+func FuzzParseRange(data []byte) int {
+	s := string(data)
+	parts := strings.SplitN(s, "\n", 2)
+	if len(parts) < 2 {
+		return 0
+	}
+	rangeStr := parts[0]
+	sizeStr := strings.TrimSpace(parts[1])
+	size, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	_, _ = ParseRange(rangeStr, size)
+	_, _ = ParseURLMetaRange(rangeStr, size)
+	return 1
+}


### PR DESCRIPTION
Adds three Go fuzz targets to enable the OSS-Fuzz build of Dragonfly v2:
```
pkg/digest/fuzz.go — FuzzParse exercising digest.Parse
pkg/net/http/fuzz.go — FuzzParseRange exercising ParseRange and ParseURLMetaRange
pkg/dfnet/fuzz.go — FuzzNetAddrJSON exercising NetAddr.UnmarshalJSON
```

These Fuzz* entry points are required by OSS-Fuzz's compile_go_fuzzer, which locates the fuzzer function inside the target package.