### PR TITLE
feat(manager): support customizing root user password via environment…

### DIFF
--- a/manager/permission/rbac/rbac.go
+++ b/manager/permission/rbac/rbac.go
@@ -67,17 +67,18 @@ const (
 	// RootUserName is the name of the built-in root user.
 	RootUserName = "root"
 
-	// DragonflyRootPasswordEnvName is the environment variable name of the root user's
-	// password. When set, the password is reconciled with it on every start.
-	DragonflyRootPasswordEnvName = "DRAGONFLY_ROOT_PASSWORD"
+	// DragonflyInitialRootPasswordEnvName is the environment variable name of the root
+	// user's initial password. It is only used when seeding the root user for the first
+	// time; the password is managed in the database afterwards.
+	DragonflyInitialRootPasswordEnvName = "DRAGONFLY_INITIAL_ROOT_PASSWORD"
 
-	// DefaultRootPassword is the password of the root user when DragonflyRootPasswordEnvName
-	// is not set.
+	// DefaultRootPassword is the initial password of the root user when
+	// DragonflyInitialRootPasswordEnvName is not set.
 	DefaultRootPassword = "dragonfly"
 )
 
 // MinRootPasswordLength and MaxRootPasswordLength match the password binding of
-// types.SignInRequest, so that the seeded password can be used to sign in.
+// types.SignInRequest, so that the seeded password can always be used to sign in.
 const (
 	MinRootPasswordLength = 8
 	MaxRootPasswordLength = 20
@@ -87,50 +88,19 @@ var (
 	apiGroupRegexp = regexp.MustCompile(`^/api/v[0-9]+/([-_a-zA-Z]*)[/.*]*`)
 )
 
-// rootPassword returns the root user's password and whether it was set explicitly through
-// DragonflyRootPasswordEnvName, which allows reconciling it instead of only seeding it.
-func rootPassword() (string, bool, error) {
-	password := os.Getenv(DragonflyRootPasswordEnvName)
+// initialRootPassword returns the password to seed the root user with, which is
+// DragonflyInitialRootPasswordEnvName if set and DefaultRootPassword otherwise.
+func initialRootPassword() (string, error) {
+	password := os.Getenv(DragonflyInitialRootPasswordEnvName)
 	if password == "" {
-		return DefaultRootPassword, false, nil
+		return DefaultRootPassword, nil
 	}
 
 	if len(password) < MinRootPasswordLength || len(password) > MaxRootPasswordLength {
-		return "", false, fmt.Errorf("%s must be between %d and %d characters", DragonflyRootPasswordEnvName, MinRootPasswordLength, MaxRootPasswordLength)
+		return "", fmt.Errorf("%s must be between %d and %d characters", DragonflyInitialRootPasswordEnvName, MinRootPasswordLength, MaxRootPasswordLength)
 	}
 
-	return password, true, nil
-}
-
-// reconcileRootPassword updates the root user's password when it differs from the given one,
-// letting an operator rotate it by restarting the manager with a new DragonflyRootPasswordEnvName.
-func reconcileRootPassword(db *gorm.DB, password string) error {
-	rootUser := managermodels.User{}
-	if err := db.First(&rootUser, managermodels.User{Name: RootUserName}).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil
-		}
-
-		return err
-	}
-
-	if err := bcrypt.CompareHashAndPassword([]byte(rootUser.EncryptedPassword), []byte(password)); err == nil {
-		return nil
-	}
-
-	encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
-	if err != nil {
-		return err
-	}
-
-	if err := db.Model(&rootUser).Updates(managermodels.User{
-		EncryptedPassword: string(encryptedPasswordBytes),
-	}).Error; err != nil {
-		return err
-	}
-
-	logger.Infof("reset the root user's password from %s", DragonflyRootPasswordEnvName)
-	return nil
+	return password, nil
 }
 
 func NewEnforcer(gdb *gorm.DB) (*casbin.Enforcer, error) {
@@ -171,14 +141,14 @@ func InitRBAC(e *casbin.Enforcer, g *gin.Engine, db *gorm.DB) error {
 		return err
 	}
 
-	password, explicit, err := rootPassword()
-	if err != nil {
-		return err
-	}
-
 	if rootUserCount <= 0 {
-		if !explicit {
-			logger.Warnf("seed the root user with the default password, set %s to override it", DragonflyRootPasswordEnvName)
+		password, err := initialRootPassword()
+		if err != nil {
+			return err
+		}
+
+		if password == DefaultRootPassword {
+			logger.Warnf("seed the root user with the default password, set %s to override it", DragonflyInitialRootPasswordEnvName)
 		}
 
 		encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
@@ -199,17 +169,9 @@ func InitRBAC(e *casbin.Enforcer, g *gin.Engine, db *gorm.DB) error {
 		if _, err := e.AddRoleForUser(fmt.Sprint(rootUser.ID), RootRole); err != nil {
 			return err
 		}
-
-		return nil
 	}
 
-	// Leave the password of an existing root user alone unless it is managed explicitly, so that
-	// a password changed from the console is not reverted on the next start.
-	if !explicit {
-		return nil
-	}
-
-	return reconcileRootPassword(db, password)
+	return nil
 }
 
 type Permission struct {

--- a/manager/permission/rbac/rbac.go
+++ b/manager/permission/rbac/rbac.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 
 	"github.com/casbin/casbin/v2"
@@ -29,6 +30,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 
+	logger "d7y.io/dragonfly/v2/internal/dflog"
 	managermodels "d7y.io/dragonfly/v2/manager/models"
 	"d7y.io/dragonfly/v2/pkg/strings"
 )
@@ -61,9 +63,75 @@ const (
 	ReadAction = "read"
 )
 
+const (
+	// RootUserName is the name of the built-in root user.
+	RootUserName = "root"
+
+	// DragonflyRootPasswordEnvName is the environment variable name of the root user's
+	// password. When set, the password is reconciled with it on every start.
+	DragonflyRootPasswordEnvName = "DRAGONFLY_ROOT_PASSWORD"
+
+	// DefaultRootPassword is the password of the root user when DragonflyRootPasswordEnvName
+	// is not set.
+	DefaultRootPassword = "dragonfly"
+)
+
+// MinRootPasswordLength and MaxRootPasswordLength match the password binding of
+// types.SignInRequest, so that the seeded password can be used to sign in.
+const (
+	MinRootPasswordLength = 8
+	MaxRootPasswordLength = 20
+)
+
 var (
 	apiGroupRegexp = regexp.MustCompile(`^/api/v[0-9]+/([-_a-zA-Z]*)[/.*]*`)
 )
+
+// rootPassword returns the root user's password and whether it was set explicitly through
+// DragonflyRootPasswordEnvName, which allows reconciling it instead of only seeding it.
+func rootPassword() (string, bool, error) {
+	password := os.Getenv(DragonflyRootPasswordEnvName)
+	if password == "" {
+		return DefaultRootPassword, false, nil
+	}
+
+	if len(password) < MinRootPasswordLength || len(password) > MaxRootPasswordLength {
+		return "", false, fmt.Errorf("%s must be between %d and %d characters", DragonflyRootPasswordEnvName, MinRootPasswordLength, MaxRootPasswordLength)
+	}
+
+	return password, true, nil
+}
+
+// reconcileRootPassword updates the root user's password when it differs from the given one,
+// letting an operator rotate it by restarting the manager with a new DragonflyRootPasswordEnvName.
+func reconcileRootPassword(db *gorm.DB, password string) error {
+	rootUser := managermodels.User{}
+	if err := db.First(&rootUser, managermodels.User{Name: RootUserName}).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+
+		return err
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(rootUser.EncryptedPassword), []byte(password)); err == nil {
+		return nil
+	}
+
+	encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		return err
+	}
+
+	if err := db.Model(&rootUser).Updates(managermodels.User{
+		EncryptedPassword: string(encryptedPasswordBytes),
+	}).Error; err != nil {
+		return err
+	}
+
+	logger.Infof("reset the root user's password from %s", DragonflyRootPasswordEnvName)
+	return nil
+}
 
 func NewEnforcer(gdb *gorm.DB) (*casbin.Enforcer, error) {
 	adapter, err := gormadapter.NewAdapterByDBWithCustomTable(gdb, &managermodels.CasbinRule{})
@@ -103,15 +171,24 @@ func InitRBAC(e *casbin.Enforcer, g *gin.Engine, db *gorm.DB) error {
 		return err
 	}
 
+	password, explicit, err := rootPassword()
+	if err != nil {
+		return err
+	}
+
 	if rootUserCount <= 0 {
-		encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte("dragonfly"), bcrypt.MinCost)
+		if !explicit {
+			logger.Warnf("seed the root user with the default password, set %s to override it", DragonflyRootPasswordEnvName)
+		}
+
+		encryptedPasswordBytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
 		if err != nil {
 			return err
 		}
 
 		rootUser := managermodels.User{
 			EncryptedPassword: string(encryptedPasswordBytes),
-			Name:              "root",
+			Name:              RootUserName,
 			State:             managermodels.UserStateEnabled,
 		}
 
@@ -122,9 +199,17 @@ func InitRBAC(e *casbin.Enforcer, g *gin.Engine, db *gorm.DB) error {
 		if _, err := e.AddRoleForUser(fmt.Sprint(rootUser.ID), RootRole); err != nil {
 			return err
 		}
+
+		return nil
 	}
 
-	return nil
+	// Leave the password of an existing root user alone unless it is managed explicitly, so that
+	// a password changed from the console is not reverted on the next start.
+	if !explicit {
+		return nil
+	}
+
+	return reconcileRootPassword(db, password)
 }
 
 type Permission struct {

--- a/manager/permission/rbac/rbac_test.go
+++ b/manager/permission/rbac/rbac_test.go
@@ -24,83 +24,78 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRootPassword(t *testing.T) {
+func TestInitialRootPassword(t *testing.T) {
 	tests := []struct {
 		name   string
 		env    string
 		set    bool
-		expect func(t *testing.T, password string, explicit bool, err error)
+		expect func(t *testing.T, password string, err error)
 	}{
 		{
 			name: "environment variable is not set",
 			set:  false,
-			expect: func(t *testing.T, password string, explicit bool, err error) {
+			expect: func(t *testing.T, password string, err error) {
 				assert := assert.New(t)
 				assert.NoError(err)
 				assert.Equal(DefaultRootPassword, password)
-				assert.False(explicit)
 			},
 		},
 		{
 			name: "environment variable is empty",
 			env:  "",
 			set:  true,
-			expect: func(t *testing.T, password string, explicit bool, err error) {
+			expect: func(t *testing.T, password string, err error) {
 				assert := assert.New(t)
 				assert.NoError(err)
 				assert.Equal(DefaultRootPassword, password)
-				assert.False(explicit)
 			},
 		},
 		{
 			name: "environment variable is set",
 			env:  "dragonfly-root",
 			set:  true,
-			expect: func(t *testing.T, password string, explicit bool, err error) {
+			expect: func(t *testing.T, password string, err error) {
 				assert := assert.New(t)
 				assert.NoError(err)
 				assert.Equal("dragonfly-root", password)
-				assert.True(explicit)
 			},
 		},
 		{
 			name: "environment variable is too short",
 			env:  strings.Repeat("a", MinRootPasswordLength-1),
 			set:  true,
-			expect: func(t *testing.T, password string, explicit bool, err error) {
+			expect: func(t *testing.T, password string, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "DRAGONFLY_ROOT_PASSWORD must be between 8 and 20 characters")
+				assert.EqualError(err, "DRAGONFLY_INITIAL_ROOT_PASSWORD must be between 8 and 20 characters")
 			},
 		},
 		{
 			name: "environment variable is too long",
 			env:  strings.Repeat("a", MaxRootPasswordLength+1),
 			set:  true,
-			expect: func(t *testing.T, password string, explicit bool, err error) {
+			expect: func(t *testing.T, password string, err error) {
 				assert := assert.New(t)
-				assert.EqualError(err, "DRAGONFLY_ROOT_PASSWORD must be between 8 and 20 characters")
+				assert.EqualError(err, "DRAGONFLY_INITIAL_ROOT_PASSWORD must be between 8 and 20 characters")
 			},
 		},
 		{
 			name: "environment variable is of the minimum length",
 			env:  strings.Repeat("a", MinRootPasswordLength),
 			set:  true,
-			expect: func(t *testing.T, password string, explicit bool, err error) {
+			expect: func(t *testing.T, password string, err error) {
 				assert := assert.New(t)
 				assert.NoError(err)
 				assert.Len(password, MinRootPasswordLength)
-				assert.True(explicit)
 			},
 		},
 		{
 			name: "environment variable is of the maximum length",
 			env:  strings.Repeat("a", MaxRootPasswordLength),
 			set:  true,
-			expect: func(t *testing.T, password string, explicit bool, err error) {
+			expect: func(t *testing.T, password string, err error) {
 				assert := assert.New(t)
 				assert.NoError(err)
 				assert.Len(password, MaxRootPasswordLength)
-				assert.True(explicit)
 			},
 		},
 	}
@@ -108,13 +103,13 @@ func TestRootPassword(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.set {
-				t.Setenv(DragonflyRootPasswordEnvName, tc.env)
+				t.Setenv(DragonflyInitialRootPasswordEnvName, tc.env)
 			} else {
-				os.Unsetenv(DragonflyRootPasswordEnvName)
+				os.Unsetenv(DragonflyInitialRootPasswordEnvName)
 			}
 
-			password, explicit, err := rootPassword()
-			tc.expect(t, password, explicit, err)
+			password, err := initialRootPassword()
+			tc.expect(t, password, err)
 		})
 	}
 }

--- a/manager/permission/rbac/rbac_test.go
+++ b/manager/permission/rbac/rbac_test.go
@@ -17,10 +17,107 @@
 package rbac
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRootPassword(t *testing.T) {
+	tests := []struct {
+		name   string
+		env    string
+		set    bool
+		expect func(t *testing.T, password string, explicit bool, err error)
+	}{
+		{
+			name: "environment variable is not set",
+			set:  false,
+			expect: func(t *testing.T, password string, explicit bool, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(DefaultRootPassword, password)
+				assert.False(explicit)
+			},
+		},
+		{
+			name: "environment variable is empty",
+			env:  "",
+			set:  true,
+			expect: func(t *testing.T, password string, explicit bool, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal(DefaultRootPassword, password)
+				assert.False(explicit)
+			},
+		},
+		{
+			name: "environment variable is set",
+			env:  "dragonfly-root",
+			set:  true,
+			expect: func(t *testing.T, password string, explicit bool, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Equal("dragonfly-root", password)
+				assert.True(explicit)
+			},
+		},
+		{
+			name: "environment variable is too short",
+			env:  strings.Repeat("a", MinRootPasswordLength-1),
+			set:  true,
+			expect: func(t *testing.T, password string, explicit bool, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "DRAGONFLY_ROOT_PASSWORD must be between 8 and 20 characters")
+			},
+		},
+		{
+			name: "environment variable is too long",
+			env:  strings.Repeat("a", MaxRootPasswordLength+1),
+			set:  true,
+			expect: func(t *testing.T, password string, explicit bool, err error) {
+				assert := assert.New(t)
+				assert.EqualError(err, "DRAGONFLY_ROOT_PASSWORD must be between 8 and 20 characters")
+			},
+		},
+		{
+			name: "environment variable is of the minimum length",
+			env:  strings.Repeat("a", MinRootPasswordLength),
+			set:  true,
+			expect: func(t *testing.T, password string, explicit bool, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Len(password, MinRootPasswordLength)
+				assert.True(explicit)
+			},
+		},
+		{
+			name: "environment variable is of the maximum length",
+			env:  strings.Repeat("a", MaxRootPasswordLength),
+			set:  true,
+			expect: func(t *testing.T, password string, explicit bool, err error) {
+				assert := assert.New(t)
+				assert.NoError(err)
+				assert.Len(password, MaxRootPasswordLength)
+				assert.True(explicit)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(DragonflyRootPasswordEnvName, tc.env)
+			} else {
+				os.Unsetenv(DragonflyRootPasswordEnvName)
+			}
+
+			password, explicit, err := rootPassword()
+			tc.expect(t, password, explicit, err)
+		})
+	}
+}
 
 func TestGetApiGroupName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

The manager seeds the built-in REST API user `root` with the hardcoded
password `dragonfly` when it initializes an empty database. This change
reads the password from the `DRAGONFLY_ROOT_PASSWORD` environment
variable instead:

- When the variable is set and no root user exists, the root user is
  seeded with its value.
- When the variable is set and the root user already exists, its
  password is reconciled with the variable on every start, so an
  operator can rotate the password by restarting the manager with a new
  value. Passwords changed from the console are left alone when the
  variable is not set.
- The value must be 8 to 20 characters, matching the password binding
  of `types.SignInRequest`, so the seeded password can always sign in.
  An invalid value fails the manager start.
- When the variable is not set, the behavior is unchanged and a warning
  is logged if the root user is seeded with the default password.

## Related Issue

https://github.com/dragonflyoss/helm-charts/issues/505

The counterpart helm-charts change passes this variable to the manager
from a secret.

## Motivation and Context

If an operator exposes the manager service externally for GRPC access,
the REST API is exposed on the same service with the default
credentials. There isn't much of a point in having credentials in the
first place if almost everybody just uses the default.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.